### PR TITLE
Add institutional knowledge skills for git-ai contributors

### DIFF
--- a/skills/git-ai-add-agent/SKILL.md
+++ b/skills/git-ai-add-agent/SKILL.md
@@ -1,0 +1,352 @@
+---
+name: git-ai-add-agent
+description: "Add support for a new AI coding agent to git-ai. Use when you need to integrate a new agent (like a new IDE, coding assistant, or AI tool) so that git-ai can track its file edits and attribute them correctly."
+argument-hint: "[name of the new AI agent to add support for]"
+allowed-tools: ["Read", "Grep", "Glob", "Bash", "Edit", "Write"]
+---
+
+# Adding a New AI Agent Preset to git-ai
+
+This guide covers all the code changes needed to integrate a new AI coding agent.
+
+## Architecture Overview
+
+Each agent integration has two layers:
+1. **AgentCheckpointPreset** (`src/commands/checkpoint_agent/`) — parses the hook input JSON the agent sends and returns the edited file paths, transcript, and model info
+2. **HookInstaller** (`src/mdm/agents/`) — detects whether the agent is installed, reads/writes its config file to install/uninstall git-ai hooks
+
+## Step 1: Create the Preset
+
+Create `src/commands/checkpoint_agent/<agent>_preset.rs` (for complex agents) or add to `agent_presets.rs` (for simpler ones).
+
+### Understand the Agent's Hook Input Format
+
+Git-ai receives JSON via stdin when the agent fires its hook. The shape varies per agent. Study `src/commands/checkpoint_agent/amp_preset.rs` and `src/commands/checkpoint_agent/pi_preset.rs` for reference.
+
+**Common patterns:**
+
+```rust
+#[derive(Deserialize)]
+struct MyAgentHookInput {
+    hook_event_name: String,   // "PreToolUse" | "PostToolUse" (or agent-specific names)
+    session_id: String,
+    cwd: String,
+    tool_name: Option<String>,
+    tool_use_id: Option<String>,
+    tool_input: Option<serde_json::Value>,
+    // agent-specific fields...
+}
+```
+
+### Implement the Preset
+
+```rust
+pub struct MyAgentPreset;
+
+impl AgentCheckpointPreset for MyAgentPreset {
+    fn run(&self, flags: AgentCheckpointFlags) -> Result<AgentRunResult, GitAiError> {
+        let input: MyAgentHookInput = serde_json::from_str(
+            flags.hook_input.as_deref().unwrap_or("")
+        ).map_err(|e| GitAiError::PresetError(format!("Failed to parse hook input: {}", e)))?;
+
+        let is_pre_edit = input.hook_event_name == "PreToolUse";
+        let is_post_edit = input.hook_event_name == "PostToolUse";
+
+        // Extract file paths from the tool_input
+        let file_paths = extract_file_paths_from_tool_input(&input.tool_input);
+
+        if is_pre_edit {
+            // Check if this is a bash/shell tool (use bash_tool fast path)
+            if is_bash_tool(&input.tool_name) {
+                let strategy = prepare_agent_bash_pre_hook(
+                    &input.session_id,
+                    input.tool_use_id.as_deref(),
+                    SupportedAgent::MyAgent,
+                    &input.tool_name.as_deref().unwrap_or(""),
+                    &flags,
+                )?;
+                match strategy {
+                    BashPreHookStrategy::EmitHumanCheckpoint => {
+                        return Ok(AgentRunResult {
+                            agent_id: make_agent_id("my_agent", &input.session_id, ""),
+                            checkpoint_kind: CheckpointKind::Human,
+                            ..Default::default()
+                        });
+                    }
+                    BashPreHookStrategy::SkipCheckpoint => {
+                        return Err(GitAiError::PresetError("skip".to_string()));
+                    }
+                }
+            }
+
+            // File edit: pre-edit is always a Human (untracked) checkpoint
+            return Ok(AgentRunResult {
+                agent_id: make_agent_id("my_agent", &input.session_id, ""),
+                checkpoint_kind: CheckpointKind::Human,
+                will_edit_filepaths: Some(file_paths),
+                repo_working_dir: Some(input.cwd.clone()),
+                ..Default::default()
+            });
+        }
+
+        if is_post_edit {
+            // Load transcript and model from your agent's storage
+            let (transcript, model) = load_my_agent_transcript(&input.session_id)?;
+
+            return Ok(AgentRunResult {
+                agent_id: make_agent_id("my_agent", &input.session_id, &model),
+                checkpoint_kind: CheckpointKind::AiAgent,
+                edited_filepaths: Some(file_paths),
+                transcript: Some(transcript),
+                repo_working_dir: Some(input.cwd.clone()),
+                ..Default::default()
+            });
+        }
+
+        Err(GitAiError::PresetError(format!("Unknown event: {}", input.hook_event_name)))
+    }
+}
+
+fn make_agent_id(tool: &str, session_id: &str, model: &str) -> AgentId {
+    AgentId {
+        tool: tool.to_string(),
+        id: session_id.to_string(),
+        model: model.to_string(),
+    }
+}
+```
+
+### Bash Tool Handling
+
+If the agent has a bash/shell execution tool (most do), use the shared bash_tool path. Add your agent to `classify_tool` in `bash_tool.rs`:
+
+```rust
+// In src/commands/checkpoint_agent/bash_tool.rs classify_tool():
+SupportedAgent::MyAgent => {
+    if ["bash", "shell", "run_command"].contains(&tool_name_lower.as_str()) {
+        ToolClass::Bash
+    } else if ["edit_file", "write_file", "apply_patch"].contains(&tool_name_lower.as_str()) {
+        ToolClass::FileEdit
+    } else {
+        ToolClass::Skip
+    }
+}
+```
+
+And add to the `SupportedAgent` enum in `bash_tool.rs`.
+
+### Agent Metadata for Transcript Re-fetching
+
+Include `agent_metadata` with the transcript path so post-commit can re-fetch the transcript:
+
+```rust
+let mut agent_metadata = HashMap::new();
+agent_metadata.insert("transcript_path".to_string(), transcript_path.to_string_lossy().to_string());
+// Include test override path for test isolation:
+if let Ok(test_path) = std::env::var("GIT_AI_MY_AGENT_STORAGE_PATH") {
+    agent_metadata.insert("__test_storage_path".to_string(), test_path);
+}
+```
+
+### Transcript Loading
+
+Load the transcript lazily and return `PromptUpdateResult::Updated(transcript, model)`. Register a transcript updater in `src/authorship/prompt_utils.rs`:
+
+```rust
+"my_agent" => {
+    my_agent_preset::transcript_and_model_from_storage(
+        agent_metadata.get("transcript_path").map(String::as_str),
+        &agent_id.id,
+        agent_metadata.get("__test_storage_path").map(String::as_str),
+    )
+}
+```
+
+## Step 2: Register the Preset
+
+In `src/commands/checkpoint_agent/agent_presets.rs`, add to the preset lookup:
+
+```rust
+pub fn get_preset_for_agent(name: &str) -> Option<Box<dyn AgentCheckpointPreset>> {
+    match name {
+        // ... existing presets ...
+        "my_agent" | "my-agent" => Some(Box::new(MyAgentPreset)),
+        _ => None,
+    }
+}
+```
+
+Also add to `src/commands/checkpoint_agent/bash_tool.rs` `is_known_preset_for_bash_tool` if the agent uses bash tool detection.
+
+## Step 3: Create the MDM Installer
+
+Create `src/mdm/agents/my_agent.rs`:
+
+```rust
+use crate::mdm::hook_installer::{HookInstaller, HookInstallerParams, HookCheckResult};
+
+pub struct MyAgentInstaller;
+
+impl HookInstaller for MyAgentInstaller {
+    fn name(&self) -> &str { "My Agent" }
+    fn id(&self) -> &str { "my_agent" }
+    fn process_names(&self) -> Vec<&str> { vec!["my-agent", "myagent"] }
+
+    fn check_hooks(&self, params: &HookInstallerParams) -> Result<HookCheckResult, GitAiError> {
+        // Check if the agent is installed (binary, config dir, etc.)
+        let config_path = resolve_my_agent_config_path()?;
+
+        let tool_installed = config_path.exists() || binary_exists("my-agent");
+        if !tool_installed {
+            return Ok(HookCheckResult::not_installed());
+        }
+
+        // Check if git-ai hooks are already in the config
+        let hooks_installed = check_my_agent_hooks_installed(&config_path, params)?;
+        Ok(HookCheckResult { tool_installed, hooks_installed, hooks_up_to_date: hooks_installed })
+    }
+
+    fn install_hooks(&self, params: &HookInstallerParams) -> Result<Option<String>, GitAiError> {
+        // Write git-ai hook entries to the agent's config file
+        // Return Some(unified_diff_string) for user preview, or None on no-op
+        let binary_path = params.binary_path.display().to_string();
+        let pre_hook_cmd = format!("{} checkpoint my-agent --hook-input stdin", binary_path);
+        let post_hook_cmd = format!("{} checkpoint my-agent --hook-input stdin", binary_path);
+        // ... write to config file ...
+    }
+
+    fn uninstall_hooks(&self, params: &HookInstallerParams) -> Result<Option<String>, GitAiError> {
+        // Remove git-ai entries from the agent's config
+    }
+}
+```
+
+Register in `src/mdm/agents/mod.rs`:
+
+```rust
+pub fn get_all_installers() -> Vec<Box<dyn HookInstaller>> {
+    vec![
+        // ... existing installers ...
+        Box::new(my_agent::MyAgentInstaller),
+    ]
+}
+```
+
+And add the module declaration in `src/mdm/agents/mod.rs`:
+
+```rust
+pub mod my_agent;
+```
+
+## Step 4: Add Test Support
+
+### Integration Tests
+
+Create `tests/integration/my_agent.rs` with the standard pattern:
+
+```rust
+#[test]
+fn test_my_agent_basic_attribution() {
+    let repo = TestRepo::new();
+    let file_path = repo.path().join("test.rs");
+
+    // Simulate pre-edit (human) checkpoint
+    std::fs::write(&file_path, "fn old_code() {}\n").unwrap();
+    let hook_input_pre = serde_json::json!({
+        "hook_event_name": "PreToolUse",
+        "session_id": "session-123",
+        "cwd": repo.path().to_str().unwrap(),
+        "tool_name": "edit_file",
+        "tool_input": { "file_path": "test.rs" }
+    });
+    repo.git_ai_with_stdin(
+        &["checkpoint", "my-agent", "--hook-input", "stdin"],
+        hook_input_pre.to_string()
+    ).unwrap();
+
+    // Simulate post-edit (AI) checkpoint
+    std::fs::write(&file_path, "fn old_code() {}\nfn ai_code() {}\n").unwrap();
+    let hook_input_post = serde_json::json!({
+        "hook_event_name": "PostToolUse",
+        "session_id": "session-123",
+        "cwd": repo.path().to_str().unwrap(),
+        "tool_name": "edit_file",
+        "tool_input": { "file_path": "test.rs" }
+    });
+    repo.git_ai_with_stdin(
+        &["checkpoint", "my-agent", "--hook-input", "stdin"],
+        hook_input_post.to_string()
+    ).unwrap();
+
+    repo.stage_all_and_commit("test commit").unwrap();
+    let mut file = repo.filename("test.rs");
+    file.assert_committed_lines(lines![
+        "fn old_code() {}".unattributed_human(),
+        "fn ai_code() {}".ai(),
+    ]);
+}
+```
+
+Register in `tests/integration/main.rs`:
+```rust
+mod my_agent;
+```
+
+### Test Isolation for Storage Paths
+
+Use `GIT_AI_MY_AGENT_STORAGE_PATH` pattern so parallel tests don't conflict on real agent storage:
+
+```rust
+repo.patch_git_ai_config(|_patch| {});  // forces isolated HOME
+std::env::set_var("GIT_AI_MY_AGENT_STORAGE_PATH", temp_dir.path());
+```
+
+Or better, accept it in `agent_metadata` and pass it as `__test_storage_path`.
+
+## Step 5: Add to the Recognized Preset Names
+
+In `tests/integration/repos/test_repo.rs`, add to `is_known_checkpoint_preset`:
+
+```rust
+fn is_known_checkpoint_preset(name: &str) -> bool {
+    matches!(name,
+        // ... existing ...
+        | "my-agent" | "my_agent"
+    )
+}
+```
+
+This ensures `normalize_test_git_ai_checkpoint_args` correctly identifies your preset name and inserts `--` before file paths.
+
+## Naming Conventions
+
+| Field | Convention | Example |
+|---|---|---|
+| Preset name | kebab-case | `"my-agent"` |
+| `AgentId.tool` | snake_case | `"my_agent"` |
+| Installer `id()` | snake_case | `"my_agent"` |
+| Env var override | `GIT_AI_<AGENT>_STORAGE_PATH` | `GIT_AI_MY_AGENT_STORAGE_PATH` |
+| Test metadata key | `"__test_storage_path"` | standard key name |
+
+## Checklist
+
+- [ ] `src/commands/checkpoint_agent/<agent>_preset.rs` — preset implementation
+- [ ] Register in `agent_presets.rs` `get_preset_for_agent()`
+- [ ] Add to `bash_tool.rs` `SupportedAgent` enum and `classify_tool()` (if has bash/shell tool)
+- [ ] Register transcript updater in `prompt_utils.rs`
+- [ ] `src/mdm/agents/<agent>.rs` — hook installer
+- [ ] Register in `src/mdm/agents/mod.rs` `get_all_installers()`
+- [ ] `tests/integration/my_agent.rs` — integration tests
+- [ ] Register in `tests/integration/main.rs`
+- [ ] Add to `is_known_checkpoint_preset` in `test_repo.rs`
+- [ ] Run `task test TEST_FILTER=my_agent` to verify
+- [ ] Run `task lint && task fmt` before committing
+
+## Reference Implementations
+
+Study these before writing your own:
+- **Simple file-edit only**: `src/commands/checkpoint_agent/pi_preset.rs` (Pi has explicit semantic event names, a good clean example)
+- **With bash tool**: `src/commands/checkpoint_agent/amp_preset.rs` (AmpPreset has the full pre/post + bash flow)
+- **SQLite-backed transcript**: `src/commands/checkpoint_agent/opencode_preset.rs` (reads from SQLite with filesystem fallback)
+- **JS plugin installer**: `src/mdm/agents/amp.rs` (embeds a TypeScript plugin file at compile time)
+- **IDE settings installer**: `src/mdm/agents/cursor.rs` (checks binary, dotfiles, and IDE settings paths)

--- a/skills/git-ai-architecture/SKILL.md
+++ b/skills/git-ai-architecture/SKILL.md
@@ -1,0 +1,219 @@
+---
+name: git-ai-architecture
+description: "Understand or navigate the git-ai codebase architecture. Use when you need to know how the binary dispatch works, where to add new commands, how error handling works, how feature flags are managed, how the config singleton works, or how cross-platform concerns are handled."
+argument-hint: "[architectural question or area to understand]"
+allowed-tools: ["Read", "Grep", "Glob", "Bash"]
+---
+
+# git-ai Architecture
+
+## Binary Dispatch — How One Binary Does Two Jobs
+
+`src/main.rs` dispatches based on `argv[0]`:
+
+```
+argv[0] == "git-ai"  →  commands::git_ai_handlers::handle_git_ai()  (direct subcommands)
+argv[0] == "git"     →  commands::git_handlers::handle_git()          (transparent proxy)
+```
+
+In production, the binary is symlinked as `git` so it intercepts all git commands. In debug builds, setting `GIT_AI=git` forces proxy mode regardless of binary name — this is how integration tests invoke the binary as a git proxy without symlinking.
+
+```rust
+// debug-only shortcut in main.rs:
+#[cfg(debug_assertions)]
+if std::env::var("GIT_AI").as_deref() == Ok("git") {
+    commands::git_handlers::handle_git(&cli.args);
+    return;
+}
+```
+
+Clap is configured with `disable_help_flag = true`, `disable_version_flag = true`, `trailing_var_arg = true`, `allow_hyphen_values = true` — it does trivial argv collection because the binary cannot consume any flags meant for git.
+
+## Git Proxy Flow (handle_git)
+
+`src/commands/git_handlers.rs`
+
+1. Parse argv → `ParsedGitInvocation`
+2. Resolve git aliases via `resolve_alias_invocation` (handles cycles, shell aliases)
+3. `run_pre_command_hooks()` — wrapped in `std::panic::catch_unwind` per hook so panics never abort the user's git command
+4. `proxy_to_git()` — spawn the real git binary
+5. `run_post_command_hooks()` — also panic-caught
+
+A `CommandHooksContext` struct threads state from pre to post hooks (rebase original head, stash SHA, async join handles, stashed VirtualAttributions).
+
+**Read-only commands short-circuit entirely**: `command_classification::is_definitely_read_only_invocation` bypasses the wrapper for `blame`, `log`, `status`, `diff`, `stash list`, `worktree list`, etc. — critical for performance with IDE git panels (thousands of calls/session).
+
+**Daemon mode** (`feature_flags().async_mode`): wrapper becomes a pure git passthrough + daemon ping. Pre/post state is sent to the daemon which handles attribution asynchronously.
+
+## Direct Subcommands (handle_git_ai)
+
+`src/commands/git_ai_handlers.rs`
+
+A large `match args[0].as_str()` over two dozen subcommands: `checkpoint`, `stats`, `status`, `show`, `blame`, `diff`, `log`, `config`, `bg`/`d`/`daemon`, `install-hooks`, `ci`, `upgrade`, `login`/`logout`/`whoami`, `dashboard`, `share`, `sync-prompts`, `prompts`, `search`, `continue`, `fetch-notes`, etc.
+
+Notable patterns:
+- `InternalDatabase::warmup()` is called early for DB-heavy commands (`checkpoint`, `show-prompt`, `share`, `search`, `continue`)
+- `is_interactive_terminal()` gates observability event emission (only from real TTYs)
+- Debug-only commands are wrapped in `#[cfg(debug_assertions)]`
+- Version output: `cfg!(debug_assertions)` appends `(debug)` suffix
+
+## Error Type Design
+
+`src/error.rs` — hand-rolled (no `thiserror`):
+
+```rust
+pub enum GitAiError {
+    #[cfg(feature = "test-support")]
+    GitError(git2::Error),           // test-only: libgit2 errors
+    IoError(std::io::Error),
+    GitCliError {                    // structured: code + stderr + original args
+        code: Option<i32>,
+        stderr: String,
+        args: Vec<String>,
+    },
+    GixError(String),
+    JsonError(serde_json::Error),
+    Utf8Error(std::str::Utf8Error),
+    FromUtf8Error(std::string::FromUtf8Error),
+    PresetError(String),             // user-facing, no prefix in Display
+    SqliteError(rusqlite::Error),
+    Generic(String),
+}
+```
+
+Key design choices:
+- `GitCliError` is **structured** — always shows the invocation + exit code + stderr to the user
+- `git2::Error` is gated behind `#[cfg(feature = "test-support")]` — production never depends on libgit2
+- Manual `Clone` impl flattens non-Clone inner types into `Generic(format!(...))` preserving the message
+- `PresetError` displays bare (no prefix) because it's already prose-shaped for the user
+- `From<T>` impls for `io::Error`, `serde_json::Error`, `Utf8Error`, `FromUtf8Error`, `rusqlite::Error`
+
+## Feature Flag System
+
+`src/feature_flags.rs` — the `define_feature_flags!` macro generates three things:
+
+```rust
+define_feature_flags!(
+    rewrite_stash:    rewrite_stash,              debug = true,  release = true,
+    inter_commit_move: checkpoint_inter_commit_move, debug = false, release = false,
+    auth_keyring:     auth_keyring,               debug = false, release = false,
+    async_mode:       async_mode,                 debug = false, release = true,  // ← diverges!
+);
+```
+
+Two-name design: `$field` = Rust struct field; `$file_name` = JSON config key AND env var suffix (`GIT_AI_<FILE_NAME>`).
+
+**Precedence** (highest to lowest):
+1. Env vars (`GIT_AI_*` prefix, via `envy`)
+2. `~/.git-ai/config.json` file
+3. Compiled-in debug/release defaults
+
+`async_mode` is the canonical example of debug/release divergence: false in debug (tests run wrapper mode by default), true in release (daemon mode for production). Tests respect `GIT_AI_TEST_GIT_MODE` env var to override.
+
+## Config Singleton
+
+`Config::get()` — global `OnceLock` accessed everywhere, reads from `~/.git-ai/config.json`.
+
+Test isolation:
+- `GIT_AI_TEST_CONFIG_PATCH` env var carries a `ConfigPatch` JSON blob that overrides specific fields without writing to disk
+- `GIT_AI_TEST_DB_PATH` places SQLite outside `.git/` (as a sibling) to prevent WAL/SHM interference with git operations
+
+## Logging Conventions — Three Layers
+
+| Layer | API | When |
+|---|---|---|
+| User-facing debug | `debug_log!(...)` | User-visible `[git-ai]` prefixed stderr messages; active when `cfg!(debug_assertions)` or `GIT_AI_DEBUG=1`; silenced by `GIT_AI_DEBUG=0` |
+| Internal tracing | `tracing::debug!(...)` | Subsystem diagnostics (hook skip reasons, daemon plumbing) |
+| Observability telemetry | `observability::log_error(...)` / `log_message(...)` | Structured events to daemon or per-PID log files; gated by `is_interactive_terminal()` |
+
+Performance logging: `GIT_AI_DEBUG_PERFORMANCE=1` (human-readable) or `=2` (JSON) emits per-phase durations for `pre_command`, `git`, `post_command`.
+
+## Cross-Platform Patterns
+
+**Signal forwarding (Unix only)** — `git_handlers.rs`:
+
+```rust
+#[cfg(unix)]
+static CHILD_PGID: AtomicI32 = AtomicI32::new(0);
+
+#[cfg(unix)]
+extern "C" fn forward_signal_handler(sig: libc::c_int) {
+    let pgid = CHILD_PGID.load(Ordering::Relaxed);
+    if pgid > 0 { unsafe { let _ = libc::kill(-pgid, sig); } }
+}
+```
+
+Child is placed in its own process group (`setpgid(0, 0)` via `pre_exec`) so SIGTERM/SIGINT/SIGHUP/SIGQUIT forward to the whole group. Skip when stdin is a TTY (avoids SIGTTIN/SIGTTOU suspension).
+
+On exit, if child died by signal → re-raise the same signal after restoring `SIG_DFL` so callers see authentic signal-death exit status.
+
+**Windows specifics:**
+- `CREATE_NO_WINDOW` flag when stdin is not a TTY (no console popup)
+- NTSTATUS `0xC000013A` detection for Ctrl-C exit
+- `NUL` instead of `/dev/null` for null hooks path
+- Platform-gated deps: `named_pipe`, `winreg`
+
+**Import gating:**
+```rust
+#[cfg(unix)] use std::os::unix::process::CommandExt;
+#[cfg(windows)] use std::os::windows::process::CommandExt;
+```
+
+## Rust Edition / Version Details
+
+- `edition = "2024"`, `rust-toolchain = "1.93.0"`
+- Stable let-chains (`if let Some(x) = foo && condition { ... }`) used throughout
+- `unsafe { std::env::set_var/remove_var }` — required in edition 2024
+- `OnceLock` for global singletons
+- `test-support` Cargo feature gates `git2` dep and exposes internal functions for testing:
+
+```rust
+#[cfg(feature = "test-support")] pub fn internal_fn() { ... }
+#[cfg(not(feature = "test-support"))] fn internal_fn() { ... }
+```
+
+## Library vs Binary
+
+`src/lib.rs` exports all modules as `pub mod` (api, auth, authorship, ci, commands, config, daemon, error, feature_flags, git, http, mdm, metrics, observability, repo_url, utils). Everything is reachable from integration tests in `tests/`. Finer-grained visibility uses `pub(crate)`.
+
+One integration test target:
+```toml
+[[test]]
+name = "integration"
+path = "tests/integration/main.rs"
+harness = true
+```
+
+## Panic Isolation Around Hooks
+
+Every hook call in `run_pre_command_hooks` and `run_post_command_hooks` is wrapped:
+
+```rust
+let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+    // hook call
+}));
+if let Err(panic_payload) = result {
+    // extract message, log to observability, never abort the user's git command
+}
+```
+
+## File Navigation Guide
+
+| What you're looking for | Where to look |
+|---|---|
+| Binary entry point, dispatch | `src/main.rs` |
+| Git proxy hooks dispatch | `src/commands/git_handlers.rs` |
+| Direct subcommand dispatch | `src/commands/git_ai_handlers.rs` |
+| Error types | `src/error.rs` |
+| Feature flags macro | `src/feature_flags.rs` |
+| Config struct | `src/config.rs` (or `src/commands/config.rs`) |
+| Hook implementations | `src/commands/hooks/` |
+| Attribution engine | `src/authorship/` |
+| Checkpoint command | `src/commands/checkpoint.rs` |
+| Agent presets | `src/commands/checkpoint_agent/` |
+| Git subprocess execution | `src/git/repository.rs` |
+| Working log storage | `src/authorship/working_log.rs` |
+| Rebase/rewrite authorship | `src/authorship/rebase_authorship.rs` |
+| CI integration | `src/ci/` + `src/commands/ci_handlers.rs` |
+| MDM agent detection | `src/mdm/agents/` |
+| Test harness | `tests/integration/repos/` |

--- a/skills/git-ai-attribution/SKILL.md
+++ b/skills/git-ai-attribution/SKILL.md
@@ -1,0 +1,212 @@
+---
+name: git-ai-attribution
+description: "Understand or modify the git-ai attribution system. Use when working on the checkpoint pipeline, working log storage, authorship note format, line attribution logic, stats calculation, move detection, or the pre/post-commit hooks."
+argument-hint: "[what you want to understand or change about the attribution system]"
+allowed-tools: ["Read", "Grep", "Glob", "Bash", "Edit", "Write"]
+---
+
+# git-ai Attribution System
+
+## The Big Picture: Three-Stage Pipeline
+
+```
+[1] Checkpoint fires (pre or post AI edit)
+       ↓
+[2] Working log entry appended to .git/ai/working_logs/<HEAD_sha>/
+       ↓
+[3] git commit → post-commit hook → AuthorshipLog written to refs/notes/ai
+```
+
+## Stage 1: Checkpoints
+
+### Checkpoint Types
+
+| Kind | `to_str()` | Who fires it | Attribution result |
+|---|---|---|---|
+| `Human` (legacy) | `"human"` | AI agent presets *before* they edit a file | "Untracked" — the sentinel `"human"` author_id is dropped in the final note; shows as `unknown_additions` in stats |
+| `KnownHuman` | `"known_human"` | IDE/editor extensions on real keystrokes | Author hash `h_<14 hex>` routed to `metadata.humans` |
+| `AiAgent` | `"ai_agent"` | AI agent presets *after* they edit a file | Hash `<16 hex>` of `SHA256("{tool}:{agent_id}")` routed to `metadata.prompts` |
+| `AiTab` | `"ai_tab"` | Tab-completion AI | Same hashing as `AiAgent` |
+
+**The AI pre/post duality:** AI agent presets fire a `Human` (untracked) checkpoint *before* editing to baseline the file state, then fire an `AiAgent` checkpoint *after* editing. The diff between the two is the AI's contribution.
+
+### Checkpoint Command
+
+```
+git-ai checkpoint <preset> [<file>...]
+```
+
+`<preset>` is matched to `AgentCheckpointPreset` implementations in `src/commands/checkpoint_agent/agent_presets.rs`. Test-only presets: `mock_ai`, `mock_known_human`, `human` (bare/legacy).
+
+The checkpoint command in `src/commands/checkpoint.rs`:
+1. Resolves the working directory and touched file paths
+2. Loads prior checkpoints from the working log to get previous file states
+3. Per file: SHA256-hashes current content, loads prior attributions, runs `AttributionTracker::update_attributions_for_checkpoint`
+4. Builds a `Checkpoint` struct and appends it to the JSONL working log
+
+## Stage 2: Working Log
+
+Storage: `.git/ai/working_logs/<base_commit_sha>/` (keyed by HEAD at checkpoint time)
+
+```
+Checkpoint                              (working_log.rs)
+ ├─ kind: CheckpointKind
+ ├─ entries: Vec<WorkingLogEntry>
+ │   ├─ file: String                   (POSIX-normalized path)
+ │   ├─ blob_sha: String               (SHA256 of file content)
+ │   ├─ attributions: Vec<Attribution>       (char-level)
+ │   └─ line_attributions: Vec<LineAttribution>  (line-level)
+ ├─ agent_id: Option<AgentId { tool, id, model }>
+ ├─ transcript: Option<AiTranscript>
+ └─ line_stats: CheckpointLineStats
+```
+
+**INITIAL bucket:** `.git/ai/working_logs/<sha>/INITIAL/` carries uncommitted AI-attributed lines forward across commits, so partial staging doesn't lose attribution when the user commits in multiple batches.
+
+## Stage 3: AuthorshipLog (refs/notes/ai)
+
+### Schema Version: `authorship/3.0.0`
+
+```
+AuthorshipLog
+ ├─ attestations: Vec<FileAttestation>
+ │   ├─ file_path: String
+ │   └─ entries: Vec<AttestationEntry>
+ │        ├─ hash: String           ("h_" prefix → human; otherwise → AI prompt hash)
+ │        └─ line_ranges: Vec<LineRange>
+ └─ metadata: AuthorshipMetadata
+     ├─ schema_version: "authorship/3.0.0"
+     ├─ base_commit_sha: String
+     ├─ prompts: BTreeMap<hash, PromptRecord>
+     │    └─ PromptRecord { agent_id, messages, total_additions/deletions, accepted_lines, ... }
+     └─ humans: BTreeMap<"h_"+hash, HumanRecord>
+```
+
+### Wire Format
+
+The note is a hybrid text+JSON document:
+```
+src/file.rs
+  abc123def4567890 1,2,19-222
+  h_31dce776f88375 5
+"path with space.rs"
+  fedcba9876543210 400-405
+---
+{ ...AuthorshipMetadata as pretty-printed JSON... }
+```
+
+`---` divides attestation section from metadata JSON. Quoted paths cannot contain literal quotes. Line ranges sort ascending.
+
+### Hash Conventions
+
+- AI prompt hash: first 16 hex chars of `SHA256("{tool}:{agent_id}")`
+- Human hash: `"h_"` + first 14 hex chars of `SHA256(git_committer_identity)` → always 16 chars total
+- The `h_` prefix is load-bearing — routes entries to `metadata.humans` instead of `metadata.prompts`
+
+### Git Notes Namespace
+
+All authorship data lives under `refs/notes/ai` — NOT the default `refs/notes/commits`.
+
+```bash
+git notes --ref=ai list                    # list all notes
+git log --notes=ai                         # show notes in git log
+git notes --ref=ai show <commit_sha>       # show one note
+```
+
+## AttributionTracker — The Core Engine
+
+`src/authorship/attribution_tracker.rs`
+
+`update_attributions_for_checkpoint(old_content, new_content, old_attrs, author, ts, is_ai)` runs a 5-phase pipeline:
+
+1. **Diff**: line-level via `imara_diff`, descend into changed hunks. Fast path for huge hunks (≥256KB); tokenized diff for sub-line precision otherwise. AI checkpoints always force Delete+Insert (never Equal) so coincidental token matches can't inherit prior human attribution.
+
+2. **Catalog**: scan diff ops into `Vec<Deletion>` + `Vec<Insertion>` with byte offsets.
+
+3. **Move detection** (skipped for AI checkpoints): finds moved code blocks ≥3 lines, preserves original authorship through moves.
+
+4. **Transform**: `Equal` → carry forward; `Delete`+move → reattach; `Insert`(AI) → `current_author`; `Insert`(non-AI) → inherit from context or last attribution.
+
+5. **Merge**: sort, dedup, coalesce contiguous same-author runs.
+
+## Move Detection
+
+`src/authorship/move_detection.rs`
+
+Algorithm: group consecutive lines, build content hash lookup, greedily extend matches ≥ threshold (default: 3 lines). Whitespace-normalized matching. **Always skipped for AI checkpoints** — AI rewrites should attribute new bytes to AI, not preserve through-moves.
+
+## VirtualAttributions — The Pivot Type
+
+`src/authorship/virtual_attribution.rs`
+
+In-memory holder of per-file line attributions before they become a persisted note. Constructors:
+
+| Constructor | Source | Use case |
+|---|---|---|
+| `from_just_working_log` | Working log checkpoints (live worktree) | Normal post-commit |
+| `new_for_base_commit` | git blame on a commit + notes | Historical range stats |
+| `from_working_log_snapshot` | Frozen final-state map | Daemon mode (avoids TOCTOU) |
+| `from_working_log_for_commit` | Blame + working log merged | Amend/squash |
+
+`to_authorship_log_and_initial_working_log` is the central conversion — called in post-commit to produce the final `AuthorshipLog` from the VirtualAttributions.
+
+## Pre-commit and Post-commit Hooks
+
+`src/authorship/pre_commit.rs` — minimal:
+- Detects if an AI agent's bash tool is active (`bash_tool::checkpoint_context_from_active_bash`)
+- If active: fires `AiAgent` checkpoint on staged files
+- Otherwise: fires `Human` (untracked) checkpoint
+
+`src/authorship/post_commit.rs` — the heavy lifter:
+1. Refresh prompt transcripts (`update_prompts_to_latest`)
+2. Batch-upsert `PromptDbRecord` rows to SQLite
+3. Build `VirtualAttributions::from_just_working_log`
+4. Run `to_authorship_log_and_initial_working_log` → final `AuthorshipLog`
+5. Apply `PromptStorageMode` (Local / Notes / Default→CAS)
+6. Serialize and `notes_add(repo, commit_sha, ...)` → `refs/notes/ai`
+7. Skip stats if too expensive (>1000 hunks, >6000 lines, >200 files, or merge commit)
+8. Write new INITIAL attributions; delete parent's working log directory
+9. Emit `committed` telemetry metric
+
+## Stats Calculation
+
+`src/authorship/stats.rs`
+
+`CommitStats` fields: `human_additions`, `unknown_additions`, `ai_additions`, `ai_accepted`, `total_ai_additions/deletions`, `time_waiting_for_ai`, `tool_model_breakdown`.
+
+Pipeline: git diff stats → per-file, intersect attestation line ranges with diff added-lines using binary-search overlap → bucket by `h_` prefix. `time_waiting_for_ai` sums User→Assistant message timestamp deltas in the transcript.
+
+## Coordinate Space Discipline
+
+**Working log line numbers = workdir coordinates** (lines in the file as it exists on disk)
+**AuthorshipLog line numbers = commit coordinates** (lines in the file as committed)
+
+Conversion in `to_authorship_log_and_initial_working_log`: count unstaged lines below each candidate line and subtract. This is why post-commit must compute both `committed_hunks` (from `git diff parent..commit`) and `unstaged_hunks` (from `git diff commit..worktree`) before converting coordinates.
+
+## Key Invariants
+
+- **Force-split for AI**: AI checkpoints emit Delete+Insert (never Equal), so coincidental token matches can't inherit prior human attribution.
+- **Move detection is non-AI only**: AI rewrites attribute new bytes to AI; moves are only useful for human edits.
+- **INITIAL bucket continuity**: uncommitted AI-attributed lines carry forward across commits via the INITIAL directory so partial staging loses nothing.
+- **`h_` prefix partitions the hash space**: one 16-char hash space serves both AI and human attribution without collision.
+- **NFC normalization** at every path comparison boundary (working-log paths may be NFD from git on macOS).
+- **POSIX normalization** (`normalize_to_posix`) at every checkpoint entry boundary.
+
+## Relevant Files
+
+| File | Purpose |
+|---|---|
+| `src/commands/checkpoint.rs` | Checkpoint command entry point |
+| `src/commands/checkpoint_agent/agent_presets.rs` | Per-agent preset implementations |
+| `src/authorship/working_log.rs` | Working log storage, Checkpoint/Attribution types |
+| `src/authorship/attribution_tracker.rs` | Core diff-and-attribute engine |
+| `src/authorship/virtual_attribution.rs` | In-memory attribution pivot |
+| `src/authorship/authorship_log.rs` | AuthorshipLog type |
+| `src/authorship/authorship_log_serialization.rs` | Wire format, hash generation, schema version |
+| `src/authorship/pre_commit.rs` | Pre-commit hook |
+| `src/authorship/post_commit.rs` | Post-commit hook (attribution finalization) |
+| `src/authorship/stats.rs` | CommitStats calculation |
+| `src/authorship/move_detection.rs` | Move detection algorithm |
+| `src/authorship/range_authorship.rs` | Commit-range attribution stats |
+| `src/authorship/prompt_utils.rs` | Prompt lookup and transcript refresh |
+| `src/git/refs.rs` | `notes_add`, `get_authorship`, `grep_ai_notes` |

--- a/skills/git-ai-hooks/SKILL.md
+++ b/skills/git-ai-hooks/SKILL.md
@@ -1,0 +1,251 @@
+---
+name: git-ai-hooks
+description: "Understand or modify the git-ai hook system. Use when working on how git-ai intercepts git commands (commit, rebase, cherry-pick, stash, reset, checkout, push, fetch, etc.), how attribution is preserved through history-rewriting operations, how the rewrite log works, or how the signal forwarding and subprocess execution work."
+argument-hint: "[hook or operation you want to understand or modify]"
+allowed-tools: ["Read", "Grep", "Glob", "Bash", "Edit", "Write"]
+---
+
+# git-ai Hook Architecture
+
+## Overview
+
+When git-ai acts as a transparent git proxy (symlinked as `git`), it intercepts every git command and runs pre/post hooks around the real git invocation. This lets it track attribution through all history-rewriting operations.
+
+```
+git <command> args
+    → git-ai binary (via symlink)
+        → run_pre_command_hooks()  [panic-isolated]
+        → proxy_to_git()           [real git]
+        → run_post_command_hooks() [panic-isolated]
+```
+
+Every hook is wrapped in `std::panic::catch_unwind(AssertUnwindSafe(...))` — a panicking hook logs to observability and is silently swallowed. It never blocks the user's git command.
+
+## Hook Modules
+
+All hooks live in `src/commands/hooks/`. Each implements a pre/post pair around a git subcommand.
+
+### `commit_hooks.rs`
+
+**Pre**: Captures HEAD before commit (`require_pre_command_head()`), runs `pre_commit::pre_commit` (materializes virtual attributions for staged files). Skips on dry-run or bare repo.
+
+**Post**: Skips on dry-run / pre-hook failure / failed exit. Detects `--amend` (emits `RewriteLogEvent::CommitAmend`) vs normal commit (`Commit`). Calls `Repository::handle_rewrite_log_event` → `rewrite_authorship_if_needed`. Suppresses output on `--porcelain/--quiet/-q/--no-status`.
+
+### `rebase_hooks.rs`
+
+**Pre**: Probes `.git/rebase-merge`/`.git/rebase-apply`. Detects if a rebase is already in progress (no double-start). Resolves `original_head` (positional branch arg) and `onto` (`--onto` flag or `@{upstream}`). Writes `RebaseStart` event with `is_interactive`.
+
+**Post**: Bails if rebase still in progress (conflict pause → user runs `rebase --continue`). On failure writes `RebaseAbort`. On success calls `process_completed_rebase` → `build_rebase_commit_mappings` → emits `RebaseComplete` → triggers `rewrite_authorship_after_rebase_v2`.
+
+**Commit mapping** (`build_rebase_commit_mappings`):
+1. `merge_base(original_head, new_head)` to find split point
+2. Walk `original_head..base` for original commits (git rev-list --ancestry-path)
+3. Walk `new_head` first-parent for new commits, count-capped at original count
+
+### `cherry_pick_hooks.rs`
+
+**Pre**: Probes `CHERRY_PICK_HEAD`/`sequencer/`. Parses commit refs/ranges from CLI (handling `-m`, ranges via `git rev-list --reverse`, keywords `continue/abort/skip`). Writes `CherryPickStart`.
+
+**Post**: Builds new-commit list via `walk_commits_to_base(repo, new_head, original_head)`. Emits `CherryPickComplete { source_commits, new_commits }` → `rewrite_authorship_after_cherry_pick`.
+
+### `reset_hooks.rs`
+
+**Pre**: Takes a `Human` checkpoint (captures working-tree state before reset), stores `pre_command_base_commit`, resolves tree-ish to SHA *before* reset runs (critical: `HEAD~1` resolves differently after reset).
+
+**Post**: Branches on `--hard` / `--soft|--mixed|--merge` and presence of pathspecs:
+- Hard reset: deletes working log for old HEAD
+- Soft/mixed: `reconstruct_working_log_after_reset` rebuilds attributions when resetting backward; `apply_wrapper_plumbing_rewrite_if_possible` for non-ancestor resets (Graphite-style)
+- Pathspec resets: merge non-pathspec checkpoints from old log with freshly-reconstructed pathspec-only log
+- Appends `Reset` event
+
+### `stash_hooks.rs`
+
+**Pre**: For `pop`/`apply`/`branch` → resolve and store stash SHA *before* git deletes it. For create paths → run `Human` checkpoint.
+
+**Post**:
+- `push/save`: build `VirtualAttributions`, serialize as `AuthorshipLog`, save under `refs/notes/ai-stash` keyed by stash SHA
+- `pop/apply/branch`: read stash note, convert attestations back to `LineAttribution` records, seed new working log via `write_initial_attributions_with_contents`
+- Tolerates exit code 1 when `git status --porcelain=v2` shows unmerged entries
+
+### `merge_hooks.rs`
+
+**Post**: Only acts on `--squash` + success + non-dry-run. Captures source branch HEAD, base branch HEAD, and staged file blob OIDs → stores `MergeSquashEvent` so a later `git commit` can replay AI authorship from the squashed range.
+
+### `checkout_hooks.rs` / `switch_hooks.rs`
+
+**Pre**: Stores pre-command HEAD. On `--merge/-m`, captures `VirtualAttributions::from_just_working_log` into `stashed_va`.
+
+**Post** (5 cases):
+- Pathspec checkout: remove attributions for those paths
+- HEAD unchanged: no-op
+- `-f/--force`: delete working log
+- `--merge`: restore stashed VA via `restore_stashed_va` (re-resolves line numbers in new working tree); skip if conflict markers present (byte offsets would be wrong)
+- Otherwise: rename working log from old to new HEAD
+
+`switch` mirrors checkout but adds `--discard-changes` to the force-flag set.
+
+### `fetch_hooks.rs`
+
+**Pre** (fetch): Spawns a background thread that calls `fetch_authorship_notes` in parallel with the main fetch. Returns `JoinHandle` for the post-hook to join.
+
+**Pre** (pull): Layered on fetch pre-hook. For `pull --rebase`, writes a *speculative* `RebaseStart` (so `rebase --continue` after a conflict has a recoverable original head). For `pull --rebase --autostash` with dirty tree, captures `VirtualAttributions` into `stashed_va`.
+
+**Post** (pull): Joins fetch thread. Restores stashed VA when HEAD moved. Calls `rename_working_log` for fast-forward pulls (detected from reflog: `pull: Fast-forward`). Runs `process_completed_pull_rebase`. Cancels speculative `RebaseStart` with `RebaseAbort` when no conflict occurred.
+
+### `push_hooks.rs`
+
+**Pre**: Spawns background thread for `push_authorship_notes` to resolved remote. Skips on `--dry-run`, `-d/--delete`, `--mirror`.
+
+**Post**: Joins push thread (regardless of main push success).
+
+### `clone_hooks.rs`
+
+**Post**: Extracts target dir, opens new repo, checks `Config::is_allowed_repository`, fetches `refs/notes/ai*` from origin via `sync_authorship::fetch_authorship_notes`.
+
+### `update_ref_hooks.rs`
+
+**Pre**: Parses non-stdin, non-deletion `update-ref <name> <new> [<old>]`. Captures old target SHA and whether the ref is HEAD or matches the current branch.
+
+**Post**: If ref moved forward → rename working log when it's the checked-out branch. For non-ancestor rewrites (Graphite restack) → `apply_wrapper_plumbing_rewrite_if_possible` synthesizes a `RebaseCompleteEvent`.
+
+## CommandHooksContext — Shared State
+
+Pre-hooks store state here; post-hooks consume it. Key fields:
+
+```rust
+struct CommandHooksContext {
+    pre_commit_hook_result: Option<bool>,
+    rebase_original_head: Option<String>,
+    rebase_onto: Option<String>,
+    fetch_authorship_handle: Option<JoinHandle<()>>,
+    push_authorship_handle: Option<JoinHandle<()>>,
+    stash_sha: Option<String>,
+    stashed_va: Option<VirtualAttributions>,
+}
+```
+
+## Rewrite Log
+
+`src/git/rewrite_log.rs` — `.git/ai/rewrite_log` (JSONL, **newest-first**)
+
+Records every history-rewriting operation so daemon mode and cross-process recovery can replay state:
+
+```
+RewriteLogEvent variants:
+  Commit { base_commit, commit_sha }
+  CommitAmend { original_commit, amended_commit_sha }
+  MergeSquash { source_branch, source_head, base_branch, base_head, staged_file_blobs }
+  RebaseStart { original_head, is_interactive, onto_head }
+  RebaseComplete { original_head, new_head, is_interactive, original_commits, new_commits }
+  RebaseAbort { original_head }
+  CherryPickStart/Complete/Abort (parallel structure)
+  Reset { kind: Hard|Soft|Mixed, new_head_sha, old_head_sha, ... }
+  Stash { operation: Create|Apply|Pop|Drop|... }
+  AuthorshipLogsSynced { synced, origin, timestamp }
+```
+
+**Format**: `#[serde(untagged)]` — each variant identified by its top-level key name. Malformed lines silently skipped. Maximum 200 events.
+
+**Append logic**: reads existing → parse → prepend new event → deduplicate → truncate to 200 → rewrite whole file.
+
+**Recovery pattern**: walk events newest-first, short-circuit on terminal events (e.g. `RebaseComplete` or `RebaseAbort` found before the first `RebaseStart` → `has_active_rebase_start_event = false`).
+
+## Rebase Authorship Rewrite Algorithm
+
+`src/authorship/rebase_authorship.rs` — entry: `rewrite_authorship_if_needed`
+
+### Fast Path (no-op rebase)
+
+If rebased commits' tracked file contents match the originals: just rewrite each note's `base_commit_sha` field. No blame needed.
+
+### Slow Path (`rewrite_authorship_after_rebase_v2`)
+
+1. Single combined `git diff-tree -p --stdin` call for both sides (new commits + original commits) — one subprocess for all diffs
+2. Partition into `new_commit_deltas` and `original_hunks_by_commit`
+3. Reconstruct attribution baseline at `original_head` (from cached notes, or blame fallback)
+4. For each `(original, new)` commit pair in topological order:
+   - Apply new commit's hunks to running line-attribution map
+   - Transfer original commit's attribution where hunks match; diff-based transfer otherwise
+5. Write fresh `AuthorshipLog` notes for each new commit
+6. `migrate_working_log_after_rebase(original_head, new_head)` — rename or merge the working log directory
+
+### Working Log Keying Through Rewrites
+
+| Operation | Working log change |
+|---|---|
+| Plain commit | Consume `<parent>/`, write INITIAL to `<new_commit>/` |
+| Amend | Rename `<orig>/` → `<amended>/` |
+| Rebase | Rename `<original_head>/` → `<new_head>/`, or merge INITIAL when both exist |
+| `reset --hard` | Delete `<old_head>/` |
+| `reset --soft/--mixed` | `reconstruct_working_log_after_reset` → write INITIAL to `<target>/` |
+| Stash push | Serialize working log to note under `refs/notes/ai-stash`, clear from INITIAL |
+| Stash pop | Read stash note, write INITIAL to `<HEAD>/` |
+| Checkout (force/branch) | Rename working log directory |
+
+**Invariant**: `<base_commit>` in the working log path always matches current HEAD by end of a successful hook cycle.
+
+## Git Subprocess Execution
+
+`src/git/repository.rs`
+
+```rust
+repo.exec_git(args)                   // errors on non-zero exit
+repo.exec_git_allow_nonzero(args)     // returns Output; caller checks status
+repo.exec_git_stdin(args, data)       // pipes data to stdin on separate thread (avoids deadlock)
+repo.exec_git_stdin_with_env(args, env, data)
+```
+
+Cross-cutting behaviors in every variant:
+- Injects `-c core.hooksPath=/dev/null` when `should_disable_internal_git_hooks()` is true (prevents recursion when git-ai calls git internally)
+- Removes `GIT_EXTERNAL_DIFF` and `GIT_DIFF_OPTS` to prevent user diff drivers from corrupting parsed output
+- On Windows: `CREATE_NO_WINDOW` when stdin is not a TTY
+
+**Stdin deadlock prevention**: `exec_git_stdin` spawns a separate thread to write stdin while the main thread calls `wait_with_output()`. `BrokenPipe` from the writer is tolerated.
+
+## Command Classification
+
+`src/git/command_classification.rs`
+
+`is_definitely_read_only_invocation(command, subcommand)` — returns true for `blame`, `log`, `status`, `diff`, `diff-index`, `rev-list`, `grep`, `stash list`, `stash show`, `worktree list`, etc. Anything not listed is treated as mutating.
+
+Read-only invocations bypass the entire wrapper hook chain and suppress trace2 events — critical for IDE git panels (Zed, VS Code) that call git thousands of times per session.
+
+## Signal Forwarding (Unix)
+
+Child processes are placed in their own process group (`setpgid(0, 0)` via `pre_exec`). SIGTERM/SIGINT/SIGHUP/SIGQUIT are forwarded to the entire group (`kill(-pgid, sig)`).
+
+Skip when stdin is a TTY — child must inherit the foreground terminal pgrp for interactive flows, otherwise SIGTTIN/SIGTTOU would suspend it.
+
+On exit: if child died by signal → re-raise that signal after restoring `SIG_DFL` so the wrapper's exit status matches the child's.
+
+## Adding or Modifying a Hook
+
+1. Hook file: `src/commands/hooks/<subcommand>_hooks.rs`
+2. Register pre/post functions in `src/commands/hooks/mod.rs`
+3. Wire into dispatch in `src/commands/git_handlers.rs` `run_pre_command_hooks` / `run_post_command_hooks`
+4. If state must flow pre→post: add a field to `CommandHooksContext`
+5. If state must survive across processes (daemon mode): add a `RewriteLogEvent` variant and write it in the pre-hook; read it back in post-hook recovery paths
+6. If the hook rewrites history: update `migrate_working_log_after_rebase` or add a new working-log migration path
+
+## Relevant Files
+
+| File | Purpose |
+|---|---|
+| `src/commands/git_handlers.rs` | Dispatcher, proxy_to_git, signal forwarding, CommandHooksContext |
+| `src/commands/hooks/mod.rs` | Hook module exports |
+| `src/commands/hooks/commit_hooks.rs` | Commit pre/post |
+| `src/commands/hooks/rebase_hooks.rs` | Rebase pre/post, commit mapping |
+| `src/commands/hooks/cherry_pick_hooks.rs` | Cherry-pick pre/post |
+| `src/commands/hooks/reset_hooks.rs` | Reset pre/post, working log reconstruction |
+| `src/commands/hooks/stash_hooks.rs` | Stash pre/post, stash note serialize/restore |
+| `src/commands/hooks/merge_hooks.rs` | Squash merge event recording |
+| `src/commands/hooks/checkout_hooks.rs` | Checkout pre/post, stashed VA restore |
+| `src/commands/hooks/fetch_hooks.rs` | Fetch/pull pre/post, background note sync |
+| `src/commands/hooks/push_hooks.rs` | Push pre/post, background note push |
+| `src/commands/hooks/clone_hooks.rs` | Clone post, fetch initial notes |
+| `src/commands/hooks/update_ref_hooks.rs` | update-ref pre/post |
+| `src/authorship/rebase_authorship.rs` | Rebase/cherry-pick authorship rewrite (267KB) |
+| `src/git/rewrite_log.rs` | RewriteLogEvent schema, JSONL append |
+| `src/git/repository.rs` | exec_git*, find_repository |
+| `src/git/repo_state.rs` | CLI-free worktree/HEAD/reflog parsing |
+| `src/git/command_classification.rs` | Read-only command allowlist |

--- a/skills/git-ai-test/SKILL.md
+++ b/skills/git-ai-test/SKILL.md
@@ -1,0 +1,293 @@
+---
+name: git-ai-test
+description: "Write, fix, or understand integration tests for the git-ai codebase. Use when asked to add tests, diagnose test failures, understand testing patterns, or figure out how to test a specific attribution/checkpoint/rebase scenario."
+argument-hint: "[what you want to test or understand about the test infrastructure]"
+allowed-tools: ["Read", "Grep", "Glob", "Bash", "Edit", "Write"]
+---
+
+# git-ai Test Infrastructure
+
+The git-ai test suite uses **real git repositories** and **real subprocess invocations** of the compiled binary. There are no mocks of the git layer or the attribution engine.
+
+## Key Principle: Assert After Every Commit
+
+After every `commit` in every test, assert line-level attribution immediately. Never batch assertions at the end.
+
+```rust
+repo.stage_all_and_commit("Initial commit").unwrap();
+file.assert_committed_lines(lines!["line 1".human(), "AI line".ai()]);
+```
+
+## TestRepo — The Test Harness
+
+`tests/integration/repos/test_repo.rs`
+
+```rust
+let repo = TestRepo::new();                    // default mode (wrapper/daemon/wrapper-daemon per env)
+let repo = TestRepo::new_dedicated_daemon();   // dedicated daemon process
+let repo = TestRepo::new_worktree();           // linked worktree (returns worktree-side repo)
+let (mirror, upstream) = TestRepo::new_with_remote(); // cloned pair
+```
+
+### Subprocess Methods
+
+```rust
+repo.git(&["add", "."]).unwrap();
+repo.git(&["checkout", "-b", "feature"]).unwrap();
+repo.git_ai(&["checkpoint", "mock_ai", "file.rs"]).unwrap();
+repo.git_og(&["commit", "--author=...", "-m", "msg"]).unwrap(); // bypass git-ai hooks
+repo.stage_all_and_commit("msg").unwrap();                       // returns NewCommit
+repo.commit("msg").unwrap();                                     // requires manual staging
+```
+
+`git_og` uses `core.hooksPath=/dev/null` — use it when you need to set custom author/committer identity or create commits that should not trigger git-ai hooks.
+
+### Key Accessors
+
+```rust
+repo.path()                  // &PathBuf to repo root
+repo.current_branch()        // → "main"
+repo.filename("foo.rs")      // → TestFile<'_>
+repo.read_file("foo.rs")     // → Option<String>
+repo.read_authorship_note(sha) // → Option<String> raw note text
+repo.current_working_logs()  // → PersistedWorkingLog
+repo.stats()                 // → CommitStats (parsed JSON from git-ai stats)
+repo.patch_git_ai_config(|patch| { patch.ignore_prompts = Some(true); });
+```
+
+### Config Patching (Parallel-Safe)
+
+Use `patch_git_ai_config` rather than env vars — it's per-test and avoids needing `#[serial_test::serial]`:
+
+```rust
+repo.patch_git_ai_config(|patch| {
+    patch.exclude_prompts_in_repositories = Some(vec![]);
+    patch.feature_flags = Some(serde_json::json!({"async_mode": false}));
+});
+```
+
+## TestFile — The File Fluent API
+
+`tests/integration/repos/test_file.rs`
+
+```rust
+let mut file = repo.filename("example.rs");
+file.set_contents(lines!["line 1", "AI line".ai()]);
+repo.stage_all_and_commit("Initial commit").unwrap();
+file.assert_lines_and_blame(lines!["line 1".human(), "AI line".ai()]);
+```
+
+### lines! Macro and Attribution Types
+
+```rust
+lines![
+    "plain string",                  // → .human() by default
+    "Human edit".human(),            // tracked human (mock_known_human checkpoint)
+    "AI wrote this".ai(),            // AI attribution (mock_ai checkpoint)
+    "Untracked change".unattributed_human(),  // no checkpoint fired ("legacy human")
+]
+```
+
+`AuthorType` values and their checkpoint equivalents:
+| Trait method | Checkpoint preset | Meaning |
+|---|---|---|
+| `.ai()` | `mock_ai` | AI-attributed line |
+| `.human()` | `mock_known_human` | Explicitly-known human edit |
+| `.unattributed_human()` | `human` (bare) | Untracked — no checkpoint fired |
+
+### Assertion Methods
+
+```rust
+// After a commit where working tree is clean:
+file.assert_lines_and_blame(expected_lines);
+
+// After a commit where uncommitted edits still exist in working tree:
+file.assert_committed_lines(expected_lines);
+
+// Snapshot test (uses insta):
+file.assert_blame_snapshot();
+```
+
+## Two Paths for Writing File Content
+
+### Path 1: `set_contents` (High-Level)
+
+Use for most tests. The helper does a two-pass write: stub with placeholders → human checkpoint → real content → AI checkpoint → `git add -A`.
+
+```rust
+file.set_contents(lines!["human line", "AI line".ai()]);
+repo.stage_all_and_commit("commit").unwrap();
+file.assert_lines_and_blame(lines!["human line".human(), "AI line".ai()]);
+```
+
+**Do NOT use `set_contents` when:**
+- You're testing checkpoint internals, ordering, or edge cases
+- You need to test partial staging
+- You need to replicate the exact pre/post checkpoint flow of a real agent
+- The two-pass placeholder artifact would contaminate the test
+
+### Path 2: `fs::write` + Explicit Checkpoints (Low-Level)
+
+Use when checkpoint order and identity matter. This mirrors how real AI agents work: pre-edit (`human`) snapshot → AI edits → post-edit (`mock_ai`) snapshot.
+
+```rust
+use std::fs;
+
+let file_path = repo.path().join("example.rs");
+
+// Commit 1: completely untracked (no checkpoint at all)
+fs::write(&file_path, "Untracked line\n").unwrap();
+repo.stage_all_and_commit("Initial commit").unwrap();
+let mut file = repo.filename("example.rs");
+file.assert_committed_lines(lines!["Untracked line".unattributed_human()]);
+
+// Commit 2: explicit known-human checkpoint
+fs::write(&file_path, "Untracked line\nHuman line\n").unwrap();
+repo.git_ai(&["checkpoint", "mock_known_human", "example.rs"]).unwrap();
+repo.git(&["add", "."]).unwrap();
+repo.commit("Second commit").unwrap();
+file.assert_committed_lines(lines![
+    "Untracked line".unattributed_human(),
+    "Human line".human(),
+]);
+
+// Commit 3: AI agent pre/post checkpoint pair
+// Step A: pre-edit snapshot (mimics AI agent preset firing before it edits)
+fs::write(&file_path, "Untracked line\nHuman line\nPre-existing line\n").unwrap();
+repo.git_ai(&["checkpoint", "human", "example.rs"]).unwrap();  // "legacy" untracked pre-snapshot
+// Step B: AI edits the file
+fs::write(&file_path, "Untracked line\nHuman line\nPre-existing line\nAI Line\n").unwrap();
+// Step C: post-edit AI checkpoint
+repo.git_ai(&["checkpoint", "mock_ai", "example.rs"]).unwrap();
+repo.stage_all_and_commit("Third commit").unwrap();
+file.assert_committed_lines(lines![
+    "Untracked line".unattributed_human(),
+    "Human line".human(),
+    "Pre-existing line".unattributed_human(),
+    "AI Line".ai(),
+]);
+```
+
+**Valid checkpoint preset names:** `claude`, `codex`, `continue-cli`, `cursor`, `gemini`, `github-copilot`, `amp`, `windsurf`, `opencode`, `pi`, `ai_tab`, `firebender`, `mock_ai`, `mock_known_human`, `known_human`, `droid`, `agent-v1`.
+
+**Scoped vs unscoped checkpoints:**
+```rust
+repo.git_ai(&["checkpoint", "mock_ai", "file.rs"]).unwrap();  // scoped to one file
+repo.git_ai(&["checkpoint", "mock_ai"]).unwrap();              // unscoped: all dirty files
+```
+
+## Test Variant Macros
+
+At the end of most test files, add macro calls to double coverage via worktree-backed repos:
+
+```rust
+crate::reuse_tests_in_worktree!(
+    test_basic_attribution,
+    test_ai_line_persists,
+);
+```
+
+For tests that exercise repo-discovery or path handling, use `subdir_test_variants!` to generate 4 variants (plain, worktree, `-C flag`, `-C flag + worktree`):
+
+```rust
+crate::subdir_test_variants! {
+    fn test_something_from_subdir() {
+        let repo = TestRepo::new();
+        // ... test body ...
+    }
+}
+```
+
+## Test Isolation
+
+Every `TestRepo` gets isolated:
+- Random temp directory
+- Isolated `HOME` and `~/.gitconfig`
+- Per-test SQLite DB path (`GIT_AI_TEST_DB_PATH`) as a sibling of the repo dir
+- `GIT_AI_TEST_CONFIG_PATCH` env var for config overrides
+
+Use `#[serial_test::serial]` only when a test must mutate process-global env vars that other tests could race on. Avoid it by using `patch_git_ai_config` instead.
+
+Use `#[ignore]` for:
+- Benchmarks (run with `task test EXTRA_TEST_BINARY_ARGS="--ignored"`)
+- Network-dependent tests
+- Tests known-broken with a TODO explaining when to fix
+
+## Testing Rebase / Cherry-Pick / Stash Attribution
+
+### Rebase
+
+```rust
+let repo = TestRepo::new();
+let mut file = repo.filename("foo.rs");
+file.set_contents(lines!["base"]);
+repo.stage_all_and_commit("Initial").unwrap();
+let main = repo.current_branch();
+
+repo.git(&["checkout", "-b", "feature"]).unwrap();
+let mut f = repo.filename("feature.rs");
+f.set_contents(lines!["AI line".ai()]);
+repo.stage_all_and_commit("AI feature").unwrap();
+
+repo.git(&["checkout", &main]).unwrap();
+// advance main...
+repo.git(&["checkout", "feature"]).unwrap();
+repo.git(&["rebase", &main]).unwrap();
+
+// Assert attribution survives rebase
+f.assert_lines_and_blame(lines!["AI line".ai()]);
+```
+
+### Stash
+
+```rust
+let mut file = repo.filename("work.rs");
+file.set_contents(lines!["AI work".ai()]);
+repo.git_ai(&["checkpoint", "mock_ai"]).unwrap(); // unscoped
+repo.git(&["stash"]).unwrap();
+// working tree is clean
+repo.git(&["stash", "pop"]).unwrap();
+let commit = repo.stage_all_and_commit("apply stash").unwrap();
+file.assert_lines_and_blame(lines!["AI work".ai()]);
+assert!(!commit.authorship_log.metadata.prompts.is_empty());
+```
+
+### Cherry-pick
+
+```rust
+repo.git(&["checkout", "-b", "other"]).unwrap();
+// make commits, get sha
+repo.git(&["checkout", &main]).unwrap();
+repo.git(&["cherry-pick", &feature_sha]).unwrap();
+// assert attribution transferred to new commit
+```
+
+## Verifying the Authorship Log Directly
+
+When blame isn't enough, read the raw note:
+
+```rust
+let commit = repo.stage_all_and_commit("msg").unwrap();
+let log = &commit.authorship_log;
+assert!(!log.metadata.prompts.is_empty());
+assert_eq!(log.attestations.len(), 1);
+assert!(log.attestations[0].entries.iter().any(|e| !e.hash.starts_with("h_")));
+```
+
+## Running Tests
+
+```bash
+task test                                    # full suite
+task test TEST_FILTER=test_basic_attribution # specific test
+task test NO_CAPTURE=true                    # with stdout
+task test EXTRA_TEST_BINARY_ARGS="--ignored" # include ignored (benchmarks)
+```
+
+## What Makes a Good Attribution Test
+
+1. **Assert line-level after every commit** — use `assert_lines_and_blame` or `assert_committed_lines`
+2. **Choose the right writing path** — `set_contents` for simple scenarios, `fs::write` + explicit checkpoints for checkpoint-internals tests
+3. **Verify the authorship log, not just blame** — check `commit.authorship_log.metadata.prompts` and `attestations`
+4. **Add `reuse_tests_in_worktree!`** at the bottom of the file for free worktree coverage
+5. **Use `patch_git_ai_config`** rather than env vars to stay parallel-safe
+6. **Keep `#[serial_test::serial]` out** unless truly needed (process-global env mutation)


### PR DESCRIPTION
Five skills encoding the codebase's patterns, idioms, and conventions
so future contributors have actionable reference when working in the repo:

- git-ai-test: TestRepo/TestFile API, lines! macro, two-path strategy
  (set_contents vs fs::write + explicit checkpoints), test isolation,
  reuse_tests_in_worktree! / subdir_test_variants! macros, and what
  makes a good attribution test

- git-ai-architecture: binary dispatch (argv[0] routing, GIT_AI=git),
  GitAiError design, feature flag macro (debug/release defaults,
  env precedence), config OnceLock, three logging layers,
  cross-platform signal/process patterns, file navigation guide

- git-ai-attribution: checkpoint types and semantics, working log
  storage layout, AuthorshipLog schema v3.0.0 wire format, hash
  conventions (h_ prefix), AttributionTracker 5-phase diff algorithm,
  VirtualAttributions constructors, coordinate space discipline,
  pre/post-commit hook logic, and key system invariants

- git-ai-hooks: all 12 hook modules with pre/post responsibilities,
  CommandHooksContext, rewrite log schema, rebase authorship rewrite
  algorithm (fast/slow paths), working log keying through all rewrite
  operations, read-only command classification, signal forwarding

- git-ai-add-agent: end-to-end checklist for adding a new AI agent
  preset (AgentCheckpointPreset, bash tool classification, transcript
  loading, HookInstaller MDM layer, test integration, naming
  conventions, reference implementations to study)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>