### PR TITLE
Add otel metrics export

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -54,6 +54,35 @@ pub struct NotesBackendConfig {
     pub backend_url: Option<String>,
 }
 
+/// Configuration for exporting metrics to an OpenTelemetry (OTLP/HTTP) backend.
+///
+/// Metrics export is enabled whenever a metrics endpoint can be resolved (either an
+/// explicit `metrics_endpoint`, or a base `endpoint` to which `/v1/metrics` is appended).
+/// Field/env nomenclature follows the OpenTelemetry specification.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct OtelConfig {
+    /// Base OTLP endpoint (`OTEL_EXPORTER_OTLP_ENDPOINT`). `/v1/metrics` is appended for the
+    /// metrics signal per the OTLP spec.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub endpoint: Option<String>,
+    /// Full metrics-signal endpoint (`OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`). Used verbatim,
+    /// with no path appended. Takes precedence over `endpoint` when set.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metrics_endpoint: Option<String>,
+    /// Headers attached to every OTLP request (`OTEL_EXPORTER_OTLP_HEADERS`), e.g. auth tokens.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub headers: Option<HashMap<String, String>>,
+    /// Value for the `service.name` resource attribute (`OTEL_SERVICE_NAME`). Defaults to `git-ai`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub service_name: Option<String>,
+    /// Additional OTLP Resource attributes (`OTEL_RESOURCE_ATTRIBUTES`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resource_attributes: Option<HashMap<String, String>>,
+}
+
+/// Default OTLP `service.name` resource attribute when none is configured.
+pub const DEFAULT_OTEL_SERVICE_NAME: &str = "git-ai";
+
 /// Optional git-ai author override for authorship metadata.
 ///
 /// Any unset field falls back to the effective Git committer identity.
@@ -181,6 +210,8 @@ pub struct Config {
     codex_hooks_format: CodexHooksFormat,
     notes_backend: NotesBackendConfig,
     transcript_streaming_lookback_days: Option<u32>,
+    #[serde(serialize_with = "serialize_masked_otel")]
+    otel: OtelConfig,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default, Serialize)]
@@ -262,6 +293,8 @@ pub struct FileConfig {
     pub notes_backend: Option<NotesBackendConfig>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub transcript_streaming_lookback_days: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub otel: Option<OtelConfig>,
 }
 
 static CONFIG: OnceLock<Config> = OnceLock::new();
@@ -321,6 +354,8 @@ pub struct ConfigPatch {
     pub notes_backend: Option<NotesBackendConfig>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub transcript_streaming_lookback_days: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub otel: Option<OtelConfig>,
 }
 
 impl Config {
@@ -627,6 +662,55 @@ impl Config {
         self.transcript_streaming_lookback_days
     }
 
+    /// Returns the OTLP exporter config.
+    pub fn otel(&self) -> &OtelConfig {
+        &self.otel
+    }
+
+    /// Resolve the full OTLP metrics-signal endpoint, or `None` when export is disabled.
+    ///
+    /// Precedence: an explicit `metrics_endpoint` is used verbatim; otherwise the base
+    /// `endpoint` has `/v1/metrics` appended (unless it already ends with that path), per
+    /// the OTLP specification.
+    pub fn otel_metrics_endpoint(&self) -> Option<String> {
+        if let Some(metrics_endpoint) = self
+            .otel
+            .metrics_endpoint
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+        {
+            return Some(metrics_endpoint.to_string());
+        }
+        let base = self
+            .otel
+            .endpoint
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())?;
+        let trimmed = base.trim_end_matches('/');
+        if trimmed.ends_with("/v1/metrics") {
+            Some(trimmed.to_string())
+        } else {
+            Some(format!("{}/v1/metrics", trimmed))
+        }
+    }
+
+    /// Returns true when an OTLP metrics endpoint is configured.
+    pub fn otel_metrics_enabled(&self) -> bool {
+        self.otel_metrics_endpoint().is_some()
+    }
+
+    /// Returns the configured OTLP `service.name`, falling back to the default.
+    pub fn otel_service_name(&self) -> &str {
+        self.otel
+            .service_name
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .unwrap_or(DEFAULT_OTEL_SERVICE_NAME)
+    }
+
     /// Returns true if quiet mode is enabled (suppresses chart output after commits)
     pub fn is_quiet(&self) -> bool {
         self.quiet
@@ -881,6 +965,57 @@ where
         }
     });
     masked.serialize(serializer)
+}
+
+/// Serialize an `OtelConfig` for display, masking header values (which may carry auth tokens).
+/// Only used for the runtime `Config` view; the on-disk `FileConfig` serializes headers verbatim.
+fn serialize_masked_otel<S>(otel: &OtelConfig, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let mut masked = otel.clone();
+    if let Some(headers) = masked.headers.as_mut() {
+        for value in headers.values_mut() {
+            *value = "****".to_string();
+        }
+    }
+    masked.serialize(serializer)
+}
+
+/// Parse an OTel-style comma-separated `key=value` list (used for headers and resource
+/// attributes). Whitespace around keys/values is trimmed; malformed entries are skipped.
+fn parse_otel_kv_list(raw: &str) -> HashMap<String, String> {
+    let mut map = HashMap::new();
+    for entry in raw.split(',') {
+        let entry = entry.trim();
+        if entry.is_empty() {
+            continue;
+        }
+        if let Some((key, value)) = entry.split_once('=') {
+            let key = key.trim();
+            if !key.is_empty() {
+                map.insert(key.to_string(), value.trim().to_string());
+            }
+        }
+    }
+    map
+}
+
+/// Merge a file-config `key=value` map with an env-var override (`OTEL_*` comma-separated list).
+/// Env entries win on key conflicts. Returns `None` when both sources are empty.
+fn merge_otel_kv(
+    file_map: Option<HashMap<String, String>>,
+    env_var: &str,
+) -> Option<HashMap<String, String>> {
+    let mut merged = file_map.unwrap_or_default();
+    if let Ok(raw) = env::var(env_var) {
+        merged.extend(parse_otel_kv_list(&raw));
+    }
+    if merged.is_empty() {
+        None
+    } else {
+        Some(merged)
+    }
 }
 
 fn normalize_optional_string(value: Option<String>) -> Option<String> {
@@ -1139,6 +1274,24 @@ fn build_config() -> Config {
             .or_else(|| file_backend.as_ref().and_then(|b| b.backend_url.clone())),
     };
 
+    // Resolve OTLP exporter config: standard OTEL_* env vars override file config.
+    let file_otel = file_cfg
+        .as_ref()
+        .and_then(|c| c.otel.clone())
+        .unwrap_or_default();
+    let otel_env_nonempty = |var: &str| env::var(var).ok().filter(|s| !s.trim().is_empty());
+    let otel = OtelConfig {
+        endpoint: otel_env_nonempty("OTEL_EXPORTER_OTLP_ENDPOINT").or(file_otel.endpoint),
+        metrics_endpoint: otel_env_nonempty("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT")
+            .or(file_otel.metrics_endpoint),
+        headers: merge_otel_kv(file_otel.headers, "OTEL_EXPORTER_OTLP_HEADERS"),
+        service_name: otel_env_nonempty("OTEL_SERVICE_NAME").or(file_otel.service_name),
+        resource_attributes: merge_otel_kv(
+            file_otel.resource_attributes,
+            "OTEL_RESOURCE_ATTRIBUTES",
+        ),
+    };
+
     // Transcript streaming lookback: env > file > default (7 days). 0 means unlimited (None).
     let transcript_streaming_lookback_days = env::var("GIT_AI_TRANSCRIPT_STREAMING_LOOKBACK_DAYS")
         .ok()
@@ -1177,6 +1330,7 @@ fn build_config() -> Config {
             codex_hooks_format,
             notes_backend,
             transcript_streaming_lookback_days,
+            otel,
         };
         apply_test_config_patch(&mut config);
         config
@@ -1207,6 +1361,7 @@ fn build_config() -> Config {
         codex_hooks_format,
         notes_backend,
         transcript_streaming_lookback_days,
+        otel,
     }
 }
 
@@ -1653,6 +1808,9 @@ fn apply_test_config_patch(config: &mut Config) {
         if let Some(days) = patch.transcript_streaming_lookback_days {
             config.transcript_streaming_lookback_days = if days == 0 { None } else { Some(days) };
         }
+        if let Some(otel) = patch.otel {
+            config.otel = otel;
+        }
     }
 }
 
@@ -1694,7 +1852,72 @@ mod tests {
             codex_hooks_format: CodexHooksFormat::ConfigToml,
             notes_backend: NotesBackendConfig::default(),
             transcript_streaming_lookback_days: Some(7),
+            otel: OtelConfig::default(),
         }
+    }
+
+    #[test]
+    fn test_parse_otel_kv_list_splits_and_trims() {
+        let parsed =
+            parse_otel_kv_list(" Authorization=Bearer abc , x-honeycomb-team=secret , ,bad=,=skip");
+        assert_eq!(
+            parsed.get("Authorization").map(String::as_str),
+            Some("Bearer abc")
+        );
+        assert_eq!(
+            parsed.get("x-honeycomb-team").map(String::as_str),
+            Some("secret")
+        );
+        // Empty entries, bare `=`, and `=value` (empty key) are skipped, but `bad=` (empty value) is kept.
+        assert_eq!(parsed.get("bad").map(String::as_str), Some(""));
+        assert!(!parsed.contains_key(""));
+    }
+
+    #[test]
+    fn test_otel_metrics_endpoint_appends_v1_metrics_to_base() {
+        let mut config = create_test_config(vec![], vec![]);
+        config.otel.endpoint = Some("https://otel.example.com:4318/".to_string());
+        assert_eq!(
+            config.otel_metrics_endpoint().as_deref(),
+            Some("https://otel.example.com:4318/v1/metrics")
+        );
+    }
+
+    #[test]
+    fn test_otel_metrics_endpoint_preserves_explicit_signal_endpoint() {
+        let mut config = create_test_config(vec![], vec![]);
+        config.otel.endpoint = Some("https://base.example.com".to_string());
+        config.otel.metrics_endpoint = Some("https://metrics.example.com/custom".to_string());
+        // The signal-specific endpoint is used verbatim and wins over base + /v1/metrics.
+        assert_eq!(
+            config.otel_metrics_endpoint().as_deref(),
+            Some("https://metrics.example.com/custom")
+        );
+    }
+
+    #[test]
+    fn test_otel_metrics_disabled_by_default() {
+        let config = create_test_config(vec![], vec![]);
+        assert!(!config.otel_metrics_enabled());
+        assert!(config.otel_metrics_endpoint().is_none());
+        assert_eq!(config.otel_service_name(), DEFAULT_OTEL_SERVICE_NAME);
+    }
+
+    #[test]
+    fn test_serialize_masked_otel_redacts_header_values() {
+        let mut config = create_test_config(vec![], vec![]);
+        let mut headers = HashMap::new();
+        headers.insert(
+            "Authorization".to_string(),
+            "Bearer super-secret".to_string(),
+        );
+        config.otel.headers = Some(headers);
+        let json = config.to_printable_json_pretty().expect("serialize");
+        assert!(
+            json.contains("\"****\""),
+            "expected masked header value in: {json}"
+        );
+        assert!(!json.contains("super-secret"), "raw secret leaked: {json}");
     }
 
     #[test]
@@ -1936,6 +2159,7 @@ mod tests {
             codex_hooks_format: CodexHooksFormat::ConfigToml,
             notes_backend: NotesBackendConfig::default(),
             transcript_streaming_lookback_days: Some(7),
+            otel: OtelConfig::default(),
         }
     }
 
@@ -2081,6 +2305,7 @@ mod tests {
             codex_hooks_format: CodexHooksFormat::ConfigToml,
             notes_backend: NotesBackendConfig::default(),
             transcript_streaming_lookback_days: Some(7),
+            otel: OtelConfig::default(),
         }
     }
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -54,6 +54,7 @@ pub mod domain;
 pub mod family_actor;
 pub mod git_backend;
 pub mod global_actor;
+pub mod otel_exporter;
 pub mod reducer;
 pub mod ref_cursor;
 pub mod sentry_layer;

--- a/src/daemon/otel_exporter.rs
+++ b/src/daemon/otel_exporter.rs
@@ -1,0 +1,469 @@
+//! OpenTelemetry (OTLP/HTTP) metrics exporter.
+//!
+//! Translates git-ai's internal [`MetricEvent`]s into the OTLP metrics data model and POSTs
+//! them as OTLP/HTTP JSON to a user-configured backend (OTel Collector, Grafana, Honeycomb,
+//! Datadog, …). Enabled whenever [`Config::otel_metrics_endpoint`] resolves to `Some`.
+//!
+//! Export is best-effort and fire-and-forget: failures are logged and dropped (no SQLite
+//! buffering, unlike the first-party metrics API) so a misconfigured backend can't grow an
+//! unbounded backlog.
+//!
+//! All six event kinds are exported via a universal `gitai.events` counter; events that carry
+//! meaningful numeric values additionally emit named counters (e.g. `gitai.commit.ai_additions`).
+
+use std::collections::BTreeMap;
+
+use serde_json::{Value, json};
+
+use crate::config::Config;
+use crate::metrics::events::{checkpoint_pos, install_hooks_pos};
+use crate::metrics::types::SparseArray;
+use crate::metrics::{
+    CheckpointValues, CommittedValues, EventAttributes, InstallHooksValues, MetricEvent, PosEncoded,
+};
+
+const SCOPE_NAME: &str = "git-ai";
+
+/// Flush a batch of metric events to the configured OTLP backend.
+///
+/// No-op when OTLP export is disabled or the batch produces no metrics.
+pub fn flush_otel_metrics(config: &Config, events: &[MetricEvent]) {
+    let endpoint = match config.otel_metrics_endpoint() {
+        Some(endpoint) => endpoint,
+        None => return,
+    };
+
+    let document = match build_otlp_metrics_document(config, events) {
+        Some(document) => document,
+        None => return,
+    };
+
+    let body = match serde_json::to_string(&document) {
+        Ok(body) => body,
+        Err(e) => {
+            tracing::warn!(%e, "otel: failed to serialize OTLP metrics document");
+            return;
+        }
+    };
+
+    let agent = crate::http::build_agent(Some(30));
+    let mut request = agent
+        .post(&endpoint)
+        .set("Content-Type", "application/json");
+    if let Some(headers) = config.otel().headers.as_ref() {
+        for (key, value) in headers {
+            request = request.set(key, value);
+        }
+    }
+
+    match crate::http::send_with_body(request, &body) {
+        Ok(resp) if (200..300).contains(&resp.status_code) => {
+            tracing::debug!(status = resp.status_code, "otel: exported metrics");
+        }
+        Ok(resp) => {
+            tracing::warn!(
+                status = resp.status_code,
+                "otel: backend rejected metrics export"
+            );
+        }
+        Err(e) => {
+            tracing::warn!(%e, "otel: failed to POST metrics to backend");
+        }
+    }
+}
+
+/// Build the OTLP/HTTP JSON metrics document for a batch of events.
+///
+/// Returns `None` when the batch is empty (no request should be sent).
+pub fn build_otlp_metrics_document(config: &Config, events: &[MetricEvent]) -> Option<Value> {
+    if events.is_empty() {
+        return None;
+    }
+
+    // Group data points by metric name (BTreeMap keeps output deterministic for snapshots).
+    let mut metric_points: BTreeMap<&'static str, Vec<Value>> = BTreeMap::new();
+
+    for event in events {
+        let common = common_attributes(&event.attrs);
+        let time_unix_nano = (event.timestamp as u64).saturating_mul(1_000_000_000);
+
+        let (extra_counter_attrs, numeric_metrics) = event_specific(event);
+
+        // Universal per-event counter.
+        let mut counter_attrs = common.clone();
+        counter_attrs.push(attribute(
+            "event.name",
+            any_string(event_name(event.event_id)),
+        ));
+        counter_attrs.extend(extra_counter_attrs.iter().cloned());
+        metric_points
+            .entry("gitai.events")
+            .or_default()
+            .push(data_point(time_unix_nano, 1, counter_attrs));
+
+        // Event-specific numeric metrics.
+        for metric in numeric_metrics {
+            let mut attrs = common.clone();
+            attrs.extend(extra_counter_attrs.iter().cloned());
+            attrs.extend(metric.attrs);
+            metric_points
+                .entry(metric.name)
+                .or_default()
+                .push(data_point(time_unix_nano, metric.value, attrs));
+        }
+    }
+
+    let metrics: Vec<Value> = metric_points
+        .into_iter()
+        .map(|(name, data_points)| sum_metric(name, data_points))
+        .collect();
+
+    Some(json!({
+        "resourceMetrics": [{
+            "resource": { "attributes": resource_attributes(config) },
+            "scopeMetrics": [{
+                "scope": {
+                    "name": SCOPE_NAME,
+                    "version": env!("CARGO_PKG_VERSION"),
+                },
+                "metrics": metrics,
+            }],
+        }],
+    }))
+}
+
+/// A named numeric metric extracted from an event's values.
+struct NumericMetric {
+    name: &'static str,
+    value: i64,
+    attrs: Vec<Value>,
+}
+
+/// Extract event-specific counter attributes and numeric metrics for a single event.
+fn event_specific(event: &MetricEvent) -> (Vec<Value>, Vec<NumericMetric>) {
+    match event.event_id {
+        x if x == crate::metrics::types::MetricEventId::Committed as u16 => {
+            let v = <CommittedValues as PosEncoded>::from_sparse(&event.values);
+            let mut metrics = Vec::new();
+            push_u32(
+                &mut metrics,
+                "gitai.commit.human_additions",
+                v.human_additions,
+            );
+            push_u32(
+                &mut metrics,
+                "gitai.commit.diff_added_lines",
+                v.git_diff_added_lines,
+            );
+            push_u32(
+                &mut metrics,
+                "gitai.commit.diff_deleted_lines",
+                v.git_diff_deleted_lines,
+            );
+            // Parallel arrays: index 0 is the aggregate ("all") across tools/models.
+            if let Some(Some(values)) = v.ai_additions.as_ref()
+                && let Some(total) = values.first()
+            {
+                metrics.push(NumericMetric {
+                    name: "gitai.commit.ai_additions",
+                    value: *total as i64,
+                    attrs: Vec::new(),
+                });
+            }
+            if let Some(Some(values)) = v.ai_accepted.as_ref()
+                && let Some(total) = values.first()
+            {
+                metrics.push(NumericMetric {
+                    name: "gitai.commit.ai_accepted",
+                    value: *total as i64,
+                    attrs: Vec::new(),
+                });
+            }
+            (Vec::new(), metrics)
+        }
+        x if x == crate::metrics::types::MetricEventId::Checkpoint as u16 => {
+            let v = <CheckpointValues as PosEncoded>::from_sparse(&event.values);
+            let mut extra = Vec::new();
+            if let Some(kind) = sparse_string(&event.values, checkpoint_pos::KIND) {
+                extra.push(attribute("checkpoint.kind", any_string(&kind)));
+            }
+            if let Some(edit_kind) = sparse_string(&event.values, checkpoint_pos::EDIT_KIND) {
+                extra.push(attribute("checkpoint.edit_kind", any_string(&edit_kind)));
+            }
+            let mut metrics = Vec::new();
+            push_u32(&mut metrics, "gitai.checkpoint.lines_added", v.lines_added);
+            push_u32(
+                &mut metrics,
+                "gitai.checkpoint.lines_deleted",
+                v.lines_deleted,
+            );
+            push_u32(
+                &mut metrics,
+                "gitai.checkpoint.lines_added_sloc",
+                v.lines_added_sloc,
+            );
+            push_u32(
+                &mut metrics,
+                "gitai.checkpoint.lines_deleted_sloc",
+                v.lines_deleted_sloc,
+            );
+            (extra, metrics)
+        }
+        x if x == crate::metrics::types::MetricEventId::InstallHooks as u16 => {
+            let _ = <InstallHooksValues as PosEncoded>::from_sparse(&event.values);
+            let mut extra = Vec::new();
+            if let Some(tool_id) = sparse_string(&event.values, install_hooks_pos::TOOL_ID) {
+                extra.push(attribute("install.tool_id", any_string(&tool_id)));
+            }
+            if let Some(status) = sparse_string(&event.values, install_hooks_pos::STATUS) {
+                extra.push(attribute("install.status", any_string(&status)));
+            }
+            (extra, Vec::new())
+        }
+        // Committed extracts numeric scalars from named positions; the constants below keep the
+        // mapping legible at the call site above.
+        _ => (Vec::new(), Vec::new()),
+    }
+}
+
+/// Convert the shared [`EventAttributes`] into OTLP key/value attributes (present fields only).
+fn common_attributes(attrs: &SparseArray) -> Vec<Value> {
+    let decoded = EventAttributes::from_sparse(attrs);
+    let mut out = Vec::new();
+
+    push_string_attr(&mut out, "gitai.version", &decoded.git_ai_version);
+    push_string_attr(&mut out, "gitai.repo_url", &decoded.repo_url);
+    push_string_attr(&mut out, "gitai.author", &decoded.author);
+    push_string_attr(&mut out, "gitai.commit_sha", &decoded.commit_sha);
+    push_string_attr(&mut out, "gitai.base_commit_sha", &decoded.base_commit_sha);
+    push_string_attr(&mut out, "gitai.branch", &decoded.branch);
+    push_string_attr(&mut out, "gitai.tool", &decoded.tool);
+    push_string_attr(&mut out, "gitai.model", &decoded.model);
+    push_string_attr(&mut out, "gitai.session_id", &decoded.session_id);
+    push_string_attr(&mut out, "gitai.trace_id", &decoded.trace_id);
+    push_string_attr(
+        &mut out,
+        "gitai.parent_session_id",
+        &decoded.parent_session_id,
+    );
+    push_string_attr(
+        &mut out,
+        "gitai.external_session_id",
+        &decoded.external_session_id,
+    );
+    push_string_attr(
+        &mut out,
+        "gitai.external_parent_session_id",
+        &decoded.external_parent_session_id,
+    );
+
+    // custom_attributes is a JSON object string; flatten its scalar entries (sorted for stability).
+    if let Some(Some(raw)) = decoded.custom_attributes.as_ref()
+        && let Ok(serde_json::Value::Object(map)) = serde_json::from_str::<Value>(raw)
+    {
+        for (key, value) in map {
+            if let Some(any) = scalar_any_value(&value) {
+                out.push(attribute(&format!("gitai.custom.{key}"), any));
+            }
+        }
+    }
+
+    out
+}
+
+/// Build the OTLP Resource attributes (service identity + host + user-configured attributes).
+fn resource_attributes(config: &Config) -> Vec<Value> {
+    let mut out = vec![
+        attribute("service.name", any_string(config.otel_service_name())),
+        attribute("service.version", any_string(env!("CARGO_PKG_VERSION"))),
+        attribute("os.type", any_string(std::env::consts::OS)),
+        attribute("host.arch", any_string(std::env::consts::ARCH)),
+    ];
+    if let Some(extra) = config.otel().resource_attributes.as_ref() {
+        // Sorted for deterministic output.
+        for (key, value) in extra.iter().collect::<BTreeMap<_, _>>() {
+            out.push(attribute(key, any_string(value)));
+        }
+    }
+    out
+}
+
+fn event_name(event_id: u16) -> &'static str {
+    use crate::metrics::types::MetricEventId::*;
+    if event_id == Committed as u16 {
+        "committed"
+    } else if event_id == AgentUsage as u16 {
+        "agent_usage"
+    } else if event_id == InstallHooks as u16 {
+        "install_hooks"
+    } else if event_id == Checkpoint as u16 {
+        "checkpoint"
+    } else if event_id == SessionEvent as u16 {
+        "session_event"
+    } else if event_id == OtelTrace as u16 {
+        "otel_trace"
+    } else {
+        "unknown"
+    }
+}
+
+// --- OTLP JSON helpers -----------------------------------------------------
+
+fn sum_metric(name: &str, data_points: Vec<Value>) -> Value {
+    json!({
+        "name": name,
+        "unit": "1",
+        "sum": {
+            // 1 = AGGREGATION_TEMPORALITY_DELTA
+            "aggregationTemporality": 1,
+            "isMonotonic": true,
+            "dataPoints": data_points,
+        },
+    })
+}
+
+fn data_point(time_unix_nano: u64, value: i64, attributes: Vec<Value>) -> Value {
+    json!({
+        "timeUnixNano": time_unix_nano.to_string(),
+        // OTLP/JSON encodes 64-bit integers as strings.
+        "asInt": value.to_string(),
+        "attributes": attributes,
+    })
+}
+
+fn attribute(key: &str, value: Value) -> Value {
+    json!({ "key": key, "value": value })
+}
+
+fn any_string(value: &str) -> Value {
+    json!({ "stringValue": value })
+}
+
+fn any_int(value: i64) -> Value {
+    json!({ "intValue": value.to_string() })
+}
+
+fn scalar_any_value(value: &Value) -> Option<Value> {
+    match value {
+        Value::String(s) => Some(any_string(s)),
+        Value::Bool(b) => Some(json!({ "boolValue": b })),
+        Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                Some(any_int(i))
+            } else {
+                n.as_f64().map(|f| json!({ "doubleValue": f }))
+            }
+        }
+        _ => None,
+    }
+}
+
+fn push_string_attr(out: &mut Vec<Value>, key: &str, field: &Option<Option<String>>) {
+    if let Some(Some(value)) = field {
+        out.push(attribute(key, any_string(value)));
+    }
+}
+
+fn push_u32(out: &mut Vec<NumericMetric>, name: &'static str, field: Option<Option<u32>>) {
+    if let Some(Some(value)) = field {
+        out.push(NumericMetric {
+            name,
+            value: value as i64,
+            attrs: Vec::new(),
+        });
+    }
+}
+
+fn sparse_string(arr: &SparseArray, pos: usize) -> Option<String> {
+    match arr.get(&pos.to_string()) {
+        Some(Value::String(s)) => Some(s.clone()),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::metrics::MetricEvent;
+
+    fn committed_event() -> MetricEvent {
+        let values = CommittedValues::new()
+            .human_additions(5)
+            .git_diff_added_lines(20)
+            .git_diff_deleted_lines(3)
+            .tool_model_pairs(vec!["all".to_string(), "claude-code::sonnet".to_string()])
+            .ai_additions(vec![15, 15])
+            .ai_accepted(vec![12, 12]);
+        let attrs = EventAttributes::with_version("9.9.9-test")
+            .repo_url("https://github.com/acme/widgets")
+            .author("dev@example.com")
+            .commit_sha("abc123")
+            .branch("main")
+            .tool("claude-code")
+            .model("sonnet")
+            .session_id("sess-1");
+        MetricEvent::with_timestamp(1_700_000_000, &values, attrs.to_sparse())
+    }
+
+    #[test]
+    fn empty_batch_produces_no_document() {
+        let config = Config::get();
+        assert!(build_otlp_metrics_document(config, &[]).is_none());
+    }
+
+    #[test]
+    fn committed_event_maps_to_otlp_metrics() {
+        let config = Config::get();
+        let doc = build_otlp_metrics_document(config, &[committed_event()])
+            .expect("document should be built");
+
+        let metrics = doc["resourceMetrics"][0]["scopeMetrics"][0]["metrics"]
+            .as_array()
+            .expect("metrics array");
+        let names: Vec<&str> = metrics.iter().filter_map(|m| m["name"].as_str()).collect();
+
+        assert!(names.contains(&"gitai.events"));
+        assert!(names.contains(&"gitai.commit.human_additions"));
+        assert!(names.contains(&"gitai.commit.ai_additions"));
+        assert!(names.contains(&"gitai.commit.ai_accepted"));
+
+        // The universal counter carries the event.name and decoded attributes.
+        let counter = metrics
+            .iter()
+            .find(|m| m["name"] == "gitai.events")
+            .expect("gitai.events present");
+        let dp = &counter["sum"]["dataPoints"][0];
+        assert_eq!(dp["asInt"], "1");
+        assert_eq!(dp["timeUnixNano"], "1700000000000000000");
+        let attr_keys: Vec<&str> = dp["attributes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|a| a["key"].as_str())
+            .collect();
+        assert!(attr_keys.contains(&"event.name"));
+        assert!(attr_keys.contains(&"gitai.tool"));
+
+        // ai_additions takes the aggregate (index 0) of the parallel array.
+        let ai = metrics
+            .iter()
+            .find(|m| m["name"] == "gitai.commit.ai_additions")
+            .unwrap();
+        assert_eq!(ai["sum"]["dataPoints"][0]["asInt"], "15");
+    }
+
+    #[test]
+    fn resource_carries_service_identity() {
+        let config = Config::get();
+        let doc =
+            build_otlp_metrics_document(config, &[committed_event()]).expect("document built");
+        let resource_attrs = doc["resourceMetrics"][0]["resource"]["attributes"]
+            .as_array()
+            .unwrap();
+        let service_name = resource_attrs
+            .iter()
+            .find(|a| a["key"] == "service.name")
+            .expect("service.name present");
+        assert_eq!(service_name["value"]["stringValue"], "git-ai");
+    }
+}

--- a/src/daemon/telemetry_worker.rs
+++ b/src/daemon/telemetry_worker.rs
@@ -290,6 +290,10 @@ fn flush_telemetry_batch(batch: TelemetryBuffer) {
     // Flush metrics (always processed — uploaded or stored in SQLite)
     if !batch.metrics.is_empty() {
         flush_metrics(&batch.metrics);
+        // Best-effort: additionally export to a user-configured OTLP backend when enabled.
+        if config.otel_metrics_enabled() {
+            crate::daemon::otel_exporter::flush_otel_metrics(config, &batch.metrics);
+        }
     }
 
     // Flush Sentry events (errors, performance, messages)


### PR DESCRIPTION
Allows sending existing metrics to an OTel collector, configured by the config.json file.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/1585" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->