### PR TITLE
Add AI review workflow

### DIFF
--- a/scripts/ai
+++ b/scripts/ai
@@ -4,6 +4,7 @@
 import argparse
 import json
 import os
+import shlex
 import shutil
 import subprocess
 import sys
@@ -31,33 +32,41 @@ def get_repo_root():
     ).stdout.strip()
 
 
+def build_harness_command(harness, resume_session=False, prompt=None):
+    """Build the command for launching an AI harness."""
+    if harness == "codex":
+        if resume_session:
+            command = ["codex", "resume", "--dangerously-bypass-approvals-and-sandbox"]
+        else:
+            command = ["codex", "--dangerously-bypass-approvals-and-sandbox"]
+
+    elif harness == "claude":
+        command = ["claude", "--dangerously-skip-permissions"]
+        if resume_session:
+            command.append("--resume")
+
+    else:
+        raise ValueError(f"Unknown harness '{harness}'")
+
+    if prompt:
+        command.append(prompt)
+
+    return command
+
+
 def open_worktree(worktree_dir, branch_name, harness=DEFAULT_HARNESS, resume_session=False, prompt=None):
     """Open the selected AI harness in the specified worktree."""
     set_tmux_window_name(branch_name)
     print(f"Launching {harness} in {worktree_dir}...")
     os.chdir(worktree_dir)
 
-    if harness == "codex":
-        if resume_session:
-            codex_args = ["codex", "resume", "--dangerously-bypass-approvals-and-sandbox"]
-            if prompt:
-                codex_args.append(prompt)
-        else:
-            codex_args = ["codex", "--dangerously-bypass-approvals-and-sandbox"]
-            if prompt:
-                codex_args.append(prompt)
-        os.execvp("codex", codex_args)
+    try:
+        command = build_harness_command(harness, resume_session, prompt)
+    except ValueError as error:
+        print(f"Error: {error}", file=sys.stderr)
+        sys.exit(1)
 
-    if harness == "claude":
-        claude_args = ["claude", "--dangerously-skip-permissions"]
-        if resume_session:
-            claude_args.append("--resume")
-        if prompt:
-            claude_args.append(prompt)
-        os.execvp("claude", claude_args)
-
-    print(f"Error: Unknown harness '{harness}'", file=sys.stderr)
-    sys.exit(1)
+    os.execvp(command[0], command)
 
 
 def check_local_branch_exists(branch):
@@ -216,9 +225,8 @@ def cmd_resume(args):
     open_worktree(worktree_dir, branch, harness=args.harness, resume_session=True)
 
 
-def cmd_pr(args):
-    """Check out a PR into a worktree and launch Claude."""
-    pr_number = args.pr_number
+def checkout_pr_worktree(pr_number):
+    """Check out a PR into a worktree and return its path and branch."""
     repo_root = get_repo_root()
 
     # 1. Fetch PR metadata
@@ -237,8 +245,7 @@ def cmd_pr(args):
     # 3. Check if worktree already exists
     if os.path.exists(worktree_dir):
         print(f"Using existing worktree for PR #{pr_number}")
-        open_worktree(worktree_dir, branch_name, harness=args.harness, resume_session=False)
-        return
+        return worktree_dir, branch_name
 
     # 4. Checkout PR using gh CLI (handles fetching)
     print(f"Checking out PR #{pr_number}...")
@@ -269,8 +276,71 @@ def cmd_pr(args):
     print(f"Creating worktree at {worktree_dir}...")
     run(["git", "worktree", "add", worktree_dir, branch_name])
 
-    # 7. Launch the selected harness without resume
+    return worktree_dir, branch_name
+
+
+def cmd_pr(args):
+    """Check out a PR into a worktree and launch an AI harness."""
+    worktree_dir, branch_name = checkout_pr_worktree(args.pr_number)
+
     open_worktree(worktree_dir, branch_name, harness=args.harness, resume_session=False)
+
+
+def build_review_prompt(pr_number, additional_prompt=None):
+    """Build the slash command used to review a PR."""
+    prompt = f"/review PR#{pr_number}"
+    if additional_prompt is not None:
+        prompt += f" {additional_prompt}"
+    return prompt
+
+
+def open_heavy_review(worktree_dir, branch_name, prompt, reviewer_count):
+    """Open equal numbers of Codex and Claude reviewers in tiled tmux panes."""
+    if not os.environ.get("TMUX"):
+        print("Error: --heavy must be run inside tmux", file=sys.stderr)
+        sys.exit(1)
+
+    set_tmux_window_name(branch_name)
+    os.chdir(worktree_dir)
+
+    harnesses = list(HARNESS_CHOICES) * reviewer_count
+    print(
+        f"Launching {reviewer_count} Codex and {reviewer_count} Claude "
+        f"reviewers in {worktree_dir}..."
+    )
+
+    for harness in harnesses[1:]:
+        command = build_harness_command(harness, prompt=prompt)
+        run([
+            "tmux",
+            "split-window",
+            "-d",
+            "-c",
+            worktree_dir,
+            shlex.join(command),
+        ])
+
+    run(["tmux", "select-layout", "tiled"])
+
+    command = build_harness_command(harnesses[0], prompt=prompt)
+    os.execvp(command[0], command)
+
+
+def cmd_review(args):
+    """Check out a PR and launch one or more agents with a review prompt."""
+    worktree_dir, branch_name = checkout_pr_worktree(args.pr_number)
+    prompt = build_review_prompt(args.pr_number, args.additional_prompt)
+
+    if args.heavy is not None:
+        open_heavy_review(worktree_dir, branch_name, prompt, args.heavy)
+        return
+
+    open_worktree(
+        worktree_dir,
+        branch_name,
+        harness=args.harness,
+        prompt=prompt,
+    )
 
 
 def cmd_new(args):
@@ -335,6 +405,31 @@ def build_parser():
     p_pr.add_argument("pr_number", type=int, help="PR number to check out")
     add_harness_argument(p_pr)
     p_pr.set_defaults(func=cmd_pr)
+
+    p_review = subparsers.add_parser(
+        "review",
+        help="Check out a PR and launch an AI harness with /review",
+    )
+    p_review.add_argument("pr_number", type=int, help="PR number to review")
+    p_review.add_argument(
+        "additional_prompt",
+        nargs="?",
+        help="Optional additional review prompt (quote it to preserve whitespace)",
+    )
+    p_review.add_argument(
+        "--heavy",
+        nargs="?",
+        const=2,
+        type=int,
+        choices=range(1, 4),
+        metavar="N",
+        help=(
+            "Launch N Codex and N Claude reviewers in tiled tmux panes "
+            "(default: 2 of each)"
+        ),
+    )
+    add_harness_argument(p_review)
+    p_review.set_defaults(func=cmd_review)
 
     return parser
 

--- a/tests/test_ai_script.py
+++ b/tests/test_ai_script.py
@@ -1,0 +1,256 @@
+import importlib.machinery
+import importlib.util
+import io
+import os
+import shlex
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+
+SCRIPT_PATH = Path(__file__).parents[1] / "scripts" / "ai"
+LOADER = importlib.machinery.SourceFileLoader("ai_script", str(SCRIPT_PATH))
+SPEC = importlib.util.spec_from_loader(LOADER.name, LOADER)
+ai_script = importlib.util.module_from_spec(SPEC)
+LOADER.exec_module(ai_script)
+
+
+class ReviewParserTests(unittest.TestCase):
+    def test_review_accepts_pr_number_and_preserves_additional_prompt(self):
+        additional_prompt = "  focus on async safety\nand keep this spacing  "
+
+        args = ai_script.build_parser().parse_args(
+            ["review", "123", additional_prompt, "--harness", "claude"]
+        )
+
+        self.assertEqual(args.pr_number, 123)
+        self.assertEqual(args.additional_prompt, additional_prompt)
+        self.assertEqual(args.harness, "claude")
+        self.assertIsNone(args.heavy)
+
+    def test_bare_heavy_defaults_to_two_reviewers_per_harness(self):
+        args = ai_script.build_parser().parse_args(["review", "123", "--heavy"])
+
+        self.assertEqual(args.heavy, 2)
+
+    def test_heavy_accepts_one_to_three_reviewers_per_harness(self):
+        parser = ai_script.build_parser()
+
+        for reviewer_count in (1, 2, 3):
+            with self.subTest(reviewer_count=reviewer_count):
+                args = parser.parse_args(
+                    ["review", "123", "--heavy", str(reviewer_count)]
+                )
+                self.assertEqual(args.heavy, reviewer_count)
+
+    def test_heavy_rejects_counts_outside_one_to_three(self):
+        parser = ai_script.build_parser()
+
+        for reviewer_count in (0, 4):
+            with self.subTest(reviewer_count=reviewer_count):
+                with self.assertRaises(SystemExit):
+                    with redirect_stderr(io.StringIO()):
+                        parser.parse_args(
+                            ["review", "123", "--heavy", str(reviewer_count)]
+                        )
+
+
+class ReviewCommandTests(unittest.TestCase):
+    def test_harness_commands_preserve_existing_launch_arguments(self):
+        self.assertEqual(
+            ai_script.build_harness_command(
+                "codex",
+                resume_session=True,
+                prompt="continue",
+            ),
+            [
+                "codex",
+                "resume",
+                "--dangerously-bypass-approvals-and-sandbox",
+                "continue",
+            ],
+        )
+        self.assertEqual(
+            ai_script.build_harness_command(
+                "claude",
+                resume_session=True,
+                prompt="continue",
+            ),
+            [
+                "claude",
+                "--dangerously-skip-permissions",
+                "--resume",
+                "continue",
+            ],
+        )
+
+    def test_review_builds_exact_agent_prompt(self):
+        self.assertEqual(ai_script.build_review_prompt(123), "/review PR#123")
+        self.assertEqual(
+            ai_script.build_review_prompt(123, "  inspect races\ncarefully  "),
+            "/review PR#123   inspect races\ncarefully  ",
+        )
+
+    @mock.patch.object(ai_script, "open_worktree")
+    @mock.patch.object(
+        ai_script,
+        "checkout_pr_worktree",
+        return_value=("/repo/.worktrees/topic", "topic"),
+    )
+    def test_review_reuses_pr_checkout_and_opens_selected_harness(
+        self, checkout_pr_worktree, open_worktree
+    ):
+        args = SimpleNamespace(
+            pr_number=123,
+            additional_prompt="focus on tests",
+            harness="claude",
+            heavy=None,
+        )
+
+        ai_script.cmd_review(args)
+
+        checkout_pr_worktree.assert_called_once_with(123)
+        open_worktree.assert_called_once_with(
+            "/repo/.worktrees/topic",
+            "topic",
+            harness="claude",
+            prompt="/review PR#123 focus on tests",
+        )
+
+    @mock.patch.object(ai_script, "open_heavy_review")
+    @mock.patch.object(
+        ai_script,
+        "checkout_pr_worktree",
+        return_value=("/repo/.worktrees/pr-123", "contributor-topic"),
+    )
+    def test_heavy_review_dispatches_requested_count_for_each_harness(
+        self, checkout_pr_worktree, open_heavy_review
+    ):
+        args = SimpleNamespace(
+            pr_number=123,
+            additional_prompt=None,
+            harness="codex",
+            heavy=3,
+        )
+
+        ai_script.cmd_review(args)
+
+        checkout_pr_worktree.assert_called_once_with(123)
+        open_heavy_review.assert_called_once_with(
+            "/repo/.worktrees/pr-123",
+            "contributor-topic",
+            "/review PR#123",
+            3,
+        )
+
+    @mock.patch.object(ai_script, "open_worktree")
+    @mock.patch.object(
+        ai_script,
+        "checkout_pr_worktree",
+        return_value=("/repo/.worktrees/topic", "topic"),
+    )
+    def test_pr_command_still_uses_shared_checkout(
+        self, checkout_pr_worktree, open_worktree
+    ):
+        ai_script.cmd_pr(SimpleNamespace(pr_number=123, harness="codex"))
+
+        checkout_pr_worktree.assert_called_once_with(123)
+        open_worktree.assert_called_once_with(
+            "/repo/.worktrees/topic",
+            "topic",
+            harness="codex",
+            resume_session=False,
+        )
+
+
+class HeavyReviewTests(unittest.TestCase):
+    @mock.patch.object(ai_script.os, "execvp")
+    @mock.patch.object(ai_script.os, "chdir")
+    @mock.patch.object(ai_script, "set_tmux_window_name")
+    @mock.patch.object(ai_script, "run")
+    def test_launches_requested_codex_and_claude_reviewers_in_tiled_panes(
+        self, run, set_tmux_window_name, chdir, execvp
+    ):
+        for reviewer_count in (1, 2, 3):
+            with self.subTest(reviewer_count=reviewer_count):
+                run.reset_mock()
+                set_tmux_window_name.reset_mock()
+                chdir.reset_mock()
+                execvp.reset_mock()
+
+                with mock.patch.dict(
+                    os.environ, {"TMUX": "/tmp/tmux.sock"}, clear=False
+                ):
+                    with redirect_stdout(io.StringIO()):
+                        ai_script.open_heavy_review(
+                            "/repo/.worktrees/topic",
+                            "topic",
+                            "/review PR#123 preserve whitespace",
+                            reviewer_count,
+                        )
+
+                set_tmux_window_name.assert_called_once_with("topic")
+                chdir.assert_called_once_with("/repo/.worktrees/topic")
+
+                split_calls = [
+                    call.args[0]
+                    for call in run.call_args_list
+                    if call.args[0][0:2] == ["tmux", "split-window"]
+                ]
+                expected_split_harnesses = (
+                    ["codex", "claude"] * reviewer_count
+                )[1:]
+                self.assertEqual(
+                    len(split_calls),
+                    reviewer_count * 2 - 1,
+                )
+                split_harnesses = [
+                    shlex.split(call[-1])[0] for call in split_calls
+                ]
+                self.assertEqual(
+                    split_harnesses,
+                    expected_split_harnesses,
+                )
+                for call in split_calls:
+                    self.assertEqual(
+                        call[3:5],
+                        ["-c", "/repo/.worktrees/topic"],
+                    )
+                    self.assertEqual(
+                        shlex.split(call[-1])[-1],
+                        "/review PR#123 preserve whitespace",
+                    )
+
+                run.assert_has_calls(
+                    [mock.call(["tmux", "select-layout", "tiled"])]
+                )
+                execvp.assert_called_once_with(
+                    "codex",
+                    [
+                        "codex",
+                        "--dangerously-bypass-approvals-and-sandbox",
+                        "/review PR#123 preserve whitespace",
+                    ],
+                )
+
+    @mock.patch.object(ai_script.os, "execvp")
+    @mock.patch.object(ai_script, "run")
+    def test_heavy_review_requires_current_tmux_window(self, run, execvp):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            with redirect_stderr(io.StringIO()):
+                with self.assertRaises(SystemExit):
+                    ai_script.open_heavy_review(
+                        "/repo/.worktrees/topic",
+                        "topic",
+                        "/review PR#123",
+                        2,
+                    )
+
+        run.assert_not_called()
+        execvp.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add `./ai review <pr-number> [additional-prompt]` on top of the existing PR worktree checkout flow
- invoke the selected harness with `/review PR#<number>` while preserving an optional prompt verbatim
- add `--heavy [N]` for tiled tmux review sessions with N Codex and N Claude agents; bare `--heavy` defaults to two of each and N is limited to 1-3
- add focused unit coverage for parsing, prompts, shared checkout dispatch, harness arguments, tmux pane counts, and whitespace preservation

## Validation

- `python3 -m unittest discover -s tests -p "test_*.py"`
- `task fmt`
- `task lint`
- `task test`
- live detached tmux smoke test confirming four panes start in the target worktree
