### PR TITLE
Add `--period` flag to `usage` command

### DIFF
--- a/src/commands/usage.rs
+++ b/src/commands/usage.rs
@@ -15,16 +15,48 @@ struct UsageJsonOutput<'a> {
     repos: &'a [RepoActivitySummary],
 }
 
+const DEFAULT_PERIOD: &str = "30d";
+
+/// Map a `--period` token to its window length in days, display label, and bucket granularity.
+fn resolve_period(token: &str) -> Result<(u64, String, BucketGranularity), String> {
+    match token {
+        "1d" => Ok((1, "last 24 hours".to_string(), BucketGranularity::Daily)),
+        "3d" => Ok((3, "last 3 days".to_string(), BucketGranularity::Daily)),
+        "7d" => Ok((7, "last 7 days".to_string(), BucketGranularity::Daily)),
+        "30d" => Ok((30, "last 30 days".to_string(), BucketGranularity::Weekly)),
+        other => Err(format!(
+            "Invalid --period value: {}. Expected one of 1d, 3d, 7d, 30d.",
+            other
+        )),
+    }
+}
+
 pub fn handle_usage(args: &[String]) {
     let mut json = false;
+    let mut period = DEFAULT_PERIOD.to_string();
 
     let mut i = 0;
     while i < args.len() {
-        match args[i].as_str() {
+        let arg = args[i].as_str();
+        match arg {
             "--json" => json = true,
             "--help" | "-h" => {
                 print_help();
                 return;
+            }
+            "--period" => {
+                i += 1;
+                match args.get(i) {
+                    Some(value) => period = value.clone(),
+                    None => {
+                        eprintln!("Missing value for --period.");
+                        eprintln!("Run 'git-ai usage --help' for usage.");
+                        std::process::exit(1);
+                    }
+                }
+            }
+            _ if arg.starts_with("--period=") => {
+                period = arg["--period=".len()..].to_string();
             }
             other => {
                 eprintln!("Unknown argument: {}", other);
@@ -35,14 +67,20 @@ pub fn handle_usage(args: &[String]) {
         i += 1;
     }
 
+    let (days, period_label, granularity) = match resolve_period(&period) {
+        Ok(resolved) => resolved,
+        Err(e) => {
+            eprintln!("{}", e);
+            eprintln!("Run 'git-ai usage --help' for usage.");
+            std::process::exit(1);
+        }
+    };
+
     // Best-effort refresh of the models.dev pricing cache (at most daily)
     // before stats — and therefore cost estimates — are computed.
     crate::metrics::model_pricing::refresh_cache_if_stale();
 
-    // Fixed 30-day window.
-    let since_ts = days_ago(30);
-    let period_label = "last 30 days".to_string();
-    let granularity = BucketGranularity::Weekly;
+    let since_ts = days_ago(days);
 
     // Fetch events once and derive both views from the same snapshot so the
     // per-repo breakdown totals are always consistent with the headline stats.
@@ -107,10 +145,11 @@ fn print_help() {
     eprintln!("Usage: git-ai usage [options]");
     eprintln!();
     eprintln!("Options:");
+    eprintln!("  --period <1d|3d|7d|30d>           Time window (default: 30d)");
     eprintln!("  --json                            Output as JSON");
     eprintln!("  --help                            Show this help");
     eprintln!();
-    eprintln!("Shows activity over the last 30 days from locally recorded metric events.");
+    eprintln!("Shows activity over the selected window from locally recorded metric events.");
     eprintln!("Metric rows older than approximately 365 days are pruned locally.");
 }
 
@@ -508,4 +547,46 @@ fn format_num_u64(n: u64) -> String {
         result.push(c);
     }
     result.chars().rev().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_period_defaults_to_thirty_day_weekly_window() {
+        let resolved = resolve_period(DEFAULT_PERIOD).unwrap();
+
+        assert_eq!(
+            resolved,
+            (30, "last 30 days".to_string(), BucketGranularity::Weekly)
+        );
+    }
+
+    #[test]
+    fn resolve_period_maps_short_windows_to_daily_granularity() {
+        let resolved: Vec<_> = ["1d", "3d", "7d"]
+            .iter()
+            .map(|t| resolve_period(t).unwrap())
+            .collect();
+
+        assert_eq!(
+            resolved,
+            vec![
+                (1, "last 24 hours".to_string(), BucketGranularity::Daily),
+                (3, "last 3 days".to_string(), BucketGranularity::Daily),
+                (7, "last 7 days".to_string(), BucketGranularity::Daily),
+            ]
+        );
+    }
+
+    #[test]
+    fn resolve_period_rejects_unknown_token() {
+        let result = resolve_period("90d");
+
+        assert_eq!(
+            result,
+            Err("Invalid --period value: 90d. Expected one of 1d, 3d, 7d, 30d.".to_string())
+        );
+    }
 }

--- a/src/commands/usage.rs
+++ b/src/commands/usage.rs
@@ -15,16 +15,48 @@ struct UsageJsonOutput<'a> {
     repos: &'a [RepoActivitySummary],
 }
 
+const DEFAULT_PERIOD: &str = "30d";
+
+/// Map a `--period` token to its window length in days, display label, and bucket granularity.
+fn resolve_period(token: &str) -> Result<(u64, String, BucketGranularity), String> {
+    match token {
+        "1d" => Ok((1, "last 24 hours".to_string(), BucketGranularity::Daily)),
+        "3d" => Ok((3, "last 3 days".to_string(), BucketGranularity::Daily)),
+        "7d" => Ok((7, "last 7 days".to_string(), BucketGranularity::Daily)),
+        "30d" => Ok((30, "last 30 days".to_string(), BucketGranularity::Weekly)),
+        other => Err(format!(
+            "Invalid --period value: {}. Expected one of 1d, 3d, 7d, 30d.",
+            other
+        )),
+    }
+}
+
 pub fn handle_usage(args: &[String]) {
     let mut json = false;
+    let mut period = DEFAULT_PERIOD.to_string();
 
     let mut i = 0;
     while i < args.len() {
-        match args[i].as_str() {
+        let arg = args[i].as_str();
+        match arg {
             "--json" => json = true,
             "--help" | "-h" => {
                 print_help();
                 return;
+            }
+            "--period" => {
+                i += 1;
+                match args.get(i) {
+                    Some(value) => period = value.clone(),
+                    None => {
+                        eprintln!("Missing value for --period.");
+                        eprintln!("Run 'git-ai usage --help' for usage.");
+                        std::process::exit(1);
+                    }
+                }
+            }
+            _ if arg.starts_with("--period=") => {
+                period = arg["--period=".len()..].to_string();
             }
             other => {
                 eprintln!("Unknown argument: {}", other);
@@ -35,10 +67,15 @@ pub fn handle_usage(args: &[String]) {
         i += 1;
     }
 
-    // Fixed 30-day window.
-    let since_ts = days_ago(30);
-    let period_label = "last 30 days".to_string();
-    let granularity = BucketGranularity::Weekly;
+    let (days, period_label, granularity) = match resolve_period(&period) {
+        Ok(resolved) => resolved,
+        Err(e) => {
+            eprintln!("{}", e);
+            eprintln!("Run 'git-ai usage --help' for usage.");
+            std::process::exit(1);
+        }
+    };
+    let since_ts = days_ago(days);
 
     // Fetch events once and derive both views from the same snapshot so the
     // per-repo breakdown totals are always consistent with the headline stats.
@@ -103,10 +140,11 @@ fn print_help() {
     eprintln!("Usage: git-ai usage [options]");
     eprintln!();
     eprintln!("Options:");
+    eprintln!("  --period <1d|3d|7d|30d>           Time window (default: 30d)");
     eprintln!("  --json                            Output as JSON");
     eprintln!("  --help                            Show this help");
     eprintln!();
-    eprintln!("Shows activity over the last 30 days from locally recorded metric events.");
+    eprintln!("Shows activity over the selected window from locally recorded metric events.");
     eprintln!("Metric rows older than approximately 365 days are pruned locally.");
 }
 
@@ -504,4 +542,46 @@ fn format_num_u64(n: u64) -> String {
         result.push(c);
     }
     result.chars().rev().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_period_defaults_to_thirty_day_weekly_window() {
+        let resolved = resolve_period(DEFAULT_PERIOD).unwrap();
+
+        assert_eq!(
+            resolved,
+            (30, "last 30 days".to_string(), BucketGranularity::Weekly)
+        );
+    }
+
+    #[test]
+    fn resolve_period_maps_short_windows_to_daily_granularity() {
+        let resolved: Vec<_> = ["1d", "3d", "7d"]
+            .iter()
+            .map(|t| resolve_period(t).unwrap())
+            .collect();
+
+        assert_eq!(
+            resolved,
+            vec![
+                (1, "last 24 hours".to_string(), BucketGranularity::Daily),
+                (3, "last 3 days".to_string(), BucketGranularity::Daily),
+                (7, "last 7 days".to_string(), BucketGranularity::Daily),
+            ]
+        );
+    }
+
+    #[test]
+    fn resolve_period_rejects_unknown_token() {
+        let result = resolve_period("90d");
+
+        assert_eq!(
+            result,
+            Err("Invalid --period value: 90d. Expected one of 1d, 3d, 7d, 30d.".to_string())
+        );
+    }
 }

--- a/tests/integration/commit_metric_metadata.rs
+++ b/tests/integration/commit_metric_metadata.rs
@@ -1,5 +1,6 @@
 use crate::repos::test_file::ExpectedLineExt;
 use crate::repos::test_repo::TestRepo;
+use crate::test_utils::isolated_metrics_db_path;
 use git_ai::metrics::MetricEvent;
 use git_ai::metrics::attrs::attr_pos;
 use git_ai::metrics::db::MetricsDatabase;
@@ -9,12 +10,6 @@ use serde_json::json;
 use std::fs;
 use std::path::Path;
 use std::time::{Duration, Instant};
-
-fn isolated_metrics_db_path() -> (tempfile::TempDir, String) {
-    let dir = tempfile::tempdir().expect("failed to create isolated metrics db dir");
-    let path = dir.path().join("metrics.db");
-    (dir, path.to_string_lossy().to_string())
-}
 
 fn codex_checkpoint(
     repo: &TestRepo,

--- a/tests/integration/e2e_user_scenarios.rs
+++ b/tests/integration/e2e_user_scenarios.rs
@@ -1,13 +1,8 @@
 use crate::repos::test_file::ExpectedLineExt;
 use crate::repos::test_repo::TestRepo;
+use crate::test_utils::extract_json_object;
 use git_ai::authorship::stats::CommitStats;
 use std::fs;
-
-fn extract_json_object(output: &str) -> String {
-    let start = output.find('{').unwrap_or(0);
-    let end = output.rfind('}').unwrap_or(output.len().saturating_sub(1));
-    output[start..=end].to_string()
-}
 
 fn commit_stats(repo: &TestRepo, args: &[&str]) -> CommitStats {
     let raw = repo.git_ai(args).expect("git-ai stats should succeed");

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -147,6 +147,7 @@ mod superuser_guard;
 mod sweep_e2e;
 mod test_utils_unit;
 mod tls_native_certs;
+mod usage_period;
 mod utf8_filenames;
 mod virtual_attribution_unit;
 mod windsurf;

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -146,6 +146,7 @@ mod superuser_guard;
 mod sweep_e2e;
 mod test_utils_unit;
 mod tls_native_certs;
+mod usage_period;
 mod utf8_filenames;
 mod virtual_attribution_unit;
 mod windsurf;

--- a/tests/integration/non_utf8_files.rs
+++ b/tests/integration/non_utf8_files.rs
@@ -1,13 +1,8 @@
 use crate::repos::test_file::ExpectedLineExt;
 use crate::repos::test_repo::TestRepo;
+use crate::test_utils::extract_json_object;
 use git_ai::authorship::stats::CommitStats;
 use std::fs;
-
-fn extract_json_object(output: &str) -> String {
-    let start = output.find('{').unwrap_or(0);
-    let end = output.rfind('}').unwrap_or(output.len().saturating_sub(1));
-    output[start..=end].to_string()
-}
 
 fn gbk_hello_world() -> Vec<u8> {
     // "你好世界" in GBK encoding (4 characters, 8 bytes)

--- a/tests/integration/session_event_attribution.rs
+++ b/tests/integration/session_event_attribution.rs
@@ -1,5 +1,6 @@
 use crate::repos::test_file::ExpectedLineExt;
 use crate::repos::test_repo::TestRepo;
+use crate::test_utils::isolated_metrics_db_path;
 use git_ai::authorship::authorship_log::LineRange;
 use git_ai::authorship::authorship_log_serialization::{AuthorshipLog, generate_session_id};
 use git_ai::authorship::working_log::AgentId;
@@ -11,12 +12,6 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 use std::time::UNIX_EPOCH;
-
-fn isolated_metrics_db_path() -> (tempfile::TempDir, String) {
-    let dir = tempfile::tempdir().expect("failed to create isolated metrics db dir");
-    let path = dir.path().join("metrics.db");
-    (dir, path.to_string_lossy().to_string())
-}
 
 fn file_mtime_secs(path: &Path) -> u32 {
     fs::metadata(path)

--- a/tests/integration/stats.rs
+++ b/tests/integration/stats.rs
@@ -1,5 +1,6 @@
 use crate::repos::test_file::ExpectedLineExt;
 use crate::repos::test_repo::TestRepo;
+use crate::test_utils::extract_json_object;
 use git_ai::authorship::stats::CommitStats;
 use insta::assert_debug_snapshot;
 use std::fs;
@@ -11,12 +12,6 @@ use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
 
 /// Extract the first complete JSON object from mixed stdout/stderr output.
-fn extract_json_object(output: &str) -> String {
-    let start = output.find('{').unwrap_or(0);
-    let end = output.rfind('}').unwrap_or(output.len().saturating_sub(1));
-    output[start..=end].to_string()
-}
-
 fn stats_from_args(repo: &TestRepo, args: &[&str]) -> CommitStats {
     let raw = repo.git_ai(args).expect("git-ai stats should succeed");
     let json = extract_json_object(&raw);

--- a/tests/integration/status_ignore.rs
+++ b/tests/integration/status_ignore.rs
@@ -1,4 +1,5 @@
 use crate::repos::test_repo::TestRepo;
+use crate::test_utils::extract_json_object;
 use git_ai::authorship::stats::CommitStats;
 use serde::Deserialize;
 use std::fs;
@@ -9,12 +10,6 @@ use std::os::unix::fs::PermissionsExt;
 struct StatusOutput {
     stats: CommitStats,
     checkpoints: Vec<serde_json::Value>,
-}
-
-fn extract_json_object(output: &str) -> String {
-    let start = output.find('{').unwrap_or(0);
-    let end = output.rfind('}').unwrap_or(output.len().saturating_sub(1));
-    output[start..=end].to_string()
 }
 
 fn status_from_args(repo: &TestRepo, args: &[&str]) -> StatusOutput {

--- a/tests/integration/status_unit.rs
+++ b/tests/integration/status_unit.rs
@@ -1,4 +1,5 @@
 use crate::repos::test_repo::{DaemonTestScope, TestRepo};
+use crate::test_utils::extract_json_object;
 use git_ai::authorship::stats::CommitStats;
 use serde::Deserialize;
 use std::fs;
@@ -8,12 +9,6 @@ use std::fs;
 struct StatusOutput {
     stats: CommitStats,
     checkpoints: Vec<serde_json::Value>,
-}
-
-fn extract_json_object(output: &str) -> String {
-    let start = output.find('{').unwrap_or(0);
-    let end = output.rfind('}').unwrap_or(output.len().saturating_sub(1));
-    output[start..=end].to_string()
 }
 
 fn status_json(repo: &TestRepo) -> StatusOutput {

--- a/tests/integration/test_utils.rs
+++ b/tests/integration/test_utils.rs
@@ -31,3 +31,21 @@ pub fn load_fixture(filename: &str) -> String {
     std::fs::read_to_string(fixture_path(filename))
         .unwrap_or_else(|_| panic!("Failed to read fixture: {}", filename))
 }
+
+/// Extract the outermost JSON object from command output, ignoring any leading or
+/// trailing non-JSON lines (for example daemon log noise on stderr).
+pub fn extract_json_object(output: &str) -> String {
+    let start = output.find('{').unwrap_or(0);
+    let end = output.rfind('}').unwrap_or(output.len().saturating_sub(1));
+    output[start..=end].to_string()
+}
+
+/// Create a temporary directory holding an isolated metrics database.
+///
+/// The returned `TempDir` must be kept alive for the lifetime of the test, since
+/// dropping it deletes the database on disk.
+pub fn isolated_metrics_db_path() -> (tempfile::TempDir, String) {
+    let dir = tempfile::tempdir().expect("failed to create isolated metrics db dir");
+    let path = dir.path().join("metrics.db");
+    (dir, path.to_string_lossy().to_string())
+}

--- a/tests/integration/usage_period.rs
+++ b/tests/integration/usage_period.rs
@@ -1,0 +1,133 @@
+use crate::repos::test_file::ExpectedLineExt;
+use crate::repos::test_repo::TestRepo;
+use crate::test_utils::{extract_json_object, isolated_metrics_db_path};
+use chrono::NaiveDate;
+use serde_json::Value;
+use std::time::{Duration, Instant};
+
+fn seed_ai_commit(repo: &TestRepo) {
+    let mut file = repo.filename("app.rs");
+    file.set_contents(crate::lines!["fn main() {}", "let answer = 42;".ai()]);
+    repo.stage_all_and_commit("AI commit")
+        .expect("AI commit should succeed");
+    file.assert_committed_lines(crate::lines![
+        "fn main() {}".human(),
+        "let answer = 42;".ai()
+    ]);
+}
+
+/// Run `git-ai usage` with the metrics DB pointed at the daemon's isolated path,
+/// retrying until the just-committed activity is persisted or the deadline passes.
+fn usage_json(repo: &TestRepo, metrics_db_path: &str, extra_args: &[&str]) -> Value {
+    let mut args = vec!["usage"];
+    args.extend_from_slice(extra_args);
+    args.push("--json");
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        repo.sync_daemon_force();
+        let result =
+            repo.git_ai_with_env(&args, &[("GIT_AI_TEST_METRICS_DB_PATH", metrics_db_path)]);
+        if let Ok(output) = &result {
+            let json = extract_json_object(output);
+            if let Ok(value) = serde_json::from_str::<Value>(&json) {
+                return value;
+            }
+        }
+
+        if Instant::now() >= deadline {
+            panic!("usage {args:?} did not return activity data: {result:?}");
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+}
+
+/// The window spans `calendar_start` to `calendar_end` as local dates. A fixed
+/// `days * 86400` second subtraction lands on the same wall-clock time N days back,
+/// so the span is N days except within an hour of midnight on a DST-transition day,
+/// where it can shift by one. Callers assert a `[N - 1, N]` range to tolerate that.
+fn window_span_days(value: &Value) -> i64 {
+    let parse = |key: &str| {
+        let text = value[key].as_str().expect("date field should be a string");
+        NaiveDate::parse_from_str(text, "%Y-%m-%d").expect("date field should parse")
+    };
+    (parse("calendar_end") - parse("calendar_start")).num_days()
+}
+
+fn assert_window(value: &Value, expected_label: &str, expected_days: i64) {
+    assert_eq!(value["period_label"].as_str().unwrap(), expected_label);
+    let span = window_span_days(value);
+    assert!(
+        (expected_days - 1..=expected_days).contains(&span),
+        "expected a {expected_days}-day window (tolerating one DST day), got span {span}"
+    );
+}
+
+#[test]
+fn usage_period_valid_tokens_report_their_label_and_window() {
+    let (_metrics_db_dir, metrics_db_path) = isolated_metrics_db_path();
+    let repo =
+        TestRepo::new_with_daemon_env(&[("GIT_AI_TEST_METRICS_DB_PATH", metrics_db_path.as_str())]);
+    seed_ai_commit(&repo);
+    let cases = [
+        ("1d", "last 24 hours", 1),
+        ("3d", "last 3 days", 3),
+        ("7d", "last 7 days", 7),
+        ("30d", "last 30 days", 30),
+    ];
+
+    for (token, expected_label, expected_days) in cases {
+        let value = usage_json(&repo, &metrics_db_path, &["--period", token]);
+        assert_window(&value, expected_label, expected_days);
+    }
+}
+
+#[test]
+fn usage_period_accepts_the_equals_form() {
+    let (_metrics_db_dir, metrics_db_path) = isolated_metrics_db_path();
+    let repo =
+        TestRepo::new_with_daemon_env(&[("GIT_AI_TEST_METRICS_DB_PATH", metrics_db_path.as_str())]);
+    seed_ai_commit(&repo);
+
+    let value = usage_json(&repo, &metrics_db_path, &["--period=3d"]);
+
+    assert_window(&value, "last 3 days", 3);
+}
+
+#[test]
+fn usage_without_period_defaults_to_thirty_day_window() {
+    let (_metrics_db_dir, metrics_db_path) = isolated_metrics_db_path();
+    let repo =
+        TestRepo::new_with_daemon_env(&[("GIT_AI_TEST_METRICS_DB_PATH", metrics_db_path.as_str())]);
+    seed_ai_commit(&repo);
+
+    let value = usage_json(&repo, &metrics_db_path, &[]);
+
+    assert_window(&value, "last 30 days", 30);
+}
+
+#[test]
+fn usage_period_invalid_token_exits_nonzero_with_message() {
+    let repo = TestRepo::new();
+
+    let result = repo.git_ai(&["usage", "--period", "90d"]);
+
+    let err = result.expect_err("an invalid --period value should exit non-zero");
+    assert!(
+        err.contains("Invalid --period value: 90d. Expected one of 1d, 3d, 7d, 30d."),
+        "unexpected error output: {err}"
+    );
+}
+
+#[test]
+fn usage_period_missing_value_exits_nonzero_with_message() {
+    let repo = TestRepo::new();
+
+    let result = repo.git_ai(&["usage", "--period"]);
+
+    let err = result.expect_err("a missing --period value should exit non-zero");
+    assert!(
+        err.contains("Missing value for --period."),
+        "unexpected error output: {err}"
+    );
+}

--- a/tests/integration/utf8_filenames.rs
+++ b/tests/integration/utf8_filenames.rs
@@ -1,5 +1,6 @@
 use crate::repos::test_file::ExpectedLineExt;
 use crate::repos::test_repo::TestRepo;
+use crate::test_utils::extract_json_object;
 /// Tests for UTF-8 filename handling with Chinese characters and emojis.
 ///
 /// This tests verifies that files with non-ASCII characters in their filenames
@@ -11,12 +12,6 @@ use crate::repos::test_repo::TestRepo;
 use git_ai::authorship::stats::CommitStats;
 
 /// Extract the first complete JSON object from mixed stdout/stderr output.
-fn extract_json_object(output: &str) -> String {
-    let start = output.find('{').unwrap_or(0);
-    let end = output.rfind('}').unwrap_or(output.len().saturating_sub(1));
-    output[start..=end].to_string()
-}
-
 #[test]
 fn test_chinese_filename_ai_attribution() {
     let repo = TestRepo::new();


### PR DESCRIPTION
#### The `--period` flag was not implemented for `git ai usage`, but appeared in the `git ai -h` help text:

<img width="660" height="85" alt="image" src="https://github.com/user-attachments/assets/f65fa5fc-fec2-4fec-b4d6-de266e6e0571" />

#### Now it is implemented for `git ai usage`:

<img width="854" height="275" alt="image" src="https://github.com/user-attachments/assets/addf90cf-bd17-4f15-81d9-aed1897edeed" />

#### Integration Test Utility Functions

I also deduplicated some copy/pasted integration test utility functions.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/2167" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
