### PR TITLE
Add metrics reingestion database reset

### DIFF
--- a/src/metrics/db.rs
+++ b/src/metrics/db.rs
@@ -2899,15 +2899,16 @@ mod tests {
         let reset = db.reingest_metrics(Some(from_ts), Some(to_ts)).unwrap();
 
         assert_eq!(reset, 3);
-        let rows: Vec<(
-            i64,
-            Option<i64>,
-            i64,
-            Option<String>,
-            Option<i64>,
-            i64,
-            Option<i64>,
-        )> = db
+        struct DeliveryState {
+            id: i64,
+            delivered_ts: Option<i64>,
+            attempts: i64,
+            last_sync_error: Option<String>,
+            last_sync_at: Option<i64>,
+            next_retry_at: i64,
+            processing_started_at: Option<i64>,
+        }
+        let rows: Vec<DeliveryState> = db
             .conn
             .prepare(
                 "SELECT id, delivered_ts, attempts, last_sync_error, last_sync_at, \
@@ -2916,15 +2917,15 @@ mod tests {
             )
             .unwrap()
             .query_map([], |row| {
-                Ok((
-                    row.get(0)?,
-                    row.get(1)?,
-                    row.get(2)?,
-                    row.get(3)?,
-                    row.get(4)?,
-                    row.get(5)?,
-                    row.get(6)?,
-                ))
+                Ok(DeliveryState {
+                    id: row.get(0)?,
+                    delivered_ts: row.get(1)?,
+                    attempts: row.get(2)?,
+                    last_sync_error: row.get(3)?,
+                    last_sync_at: row.get(4)?,
+                    next_retry_at: row.get(5)?,
+                    processing_started_at: row.get(6)?,
+                })
             })
             .unwrap()
             .collect::<Result<_, _>>()
@@ -2933,19 +2934,19 @@ mod tests {
         for (index, row) in rows.iter().enumerate() {
             let in_range = matches!(index, 1..=3);
             if in_range {
-                assert_eq!(row.1, None, "row {} should be pending", row.0);
-                assert_eq!(row.2, 0);
-                assert_eq!(row.3, None);
-                assert_eq!(row.4, None);
-                assert_eq!(row.5, 0);
-                assert_eq!(row.6, None);
+                assert_eq!(row.delivered_ts, None, "row {} should be pending", row.id);
+                assert_eq!(row.attempts, 0);
+                assert_eq!(row.last_sync_error, None);
+                assert_eq!(row.last_sync_at, None);
+                assert_eq!(row.next_retry_at, 0);
+                assert_eq!(row.processing_started_at, None);
             } else {
-                assert_eq!(row.1, Some(now as i64), "row {} changed", row.0);
-                assert_eq!(row.2, 6);
-                assert_eq!(row.3.as_deref(), Some("stopped"));
-                assert_eq!(row.4, Some(now as i64));
-                assert_eq!(row.5, now as i64);
-                assert_eq!(row.6, Some(now as i64));
+                assert_eq!(row.delivered_ts, Some(now as i64), "row {} changed", row.id);
+                assert_eq!(row.attempts, 6);
+                assert_eq!(row.last_sync_error.as_deref(), Some("stopped"));
+                assert_eq!(row.last_sync_at, Some(now as i64));
+                assert_eq!(row.next_retry_at, now as i64);
+                assert_eq!(row.processing_started_at, Some(now as i64));
             }
         }
     }

--- a/src/metrics/db.rs
+++ b/src/metrics/db.rs
@@ -2979,11 +2979,12 @@ mod tests {
     fn test_reingest_all_resets_rows_without_event_metadata() {
         let (mut db, _temp_dir) = create_test_db();
         let now = unix_now();
-        let ids = db.insert_events_with_delivered_ts(
-            &[event_json(seconds_ago(100)), "not-json".to_string()],
-            Some(now),
-        )
-        .unwrap();
+        let ids = db
+            .insert_events_with_delivered_ts(
+                &[event_json(seconds_ago(100)), "not-json".to_string()],
+                Some(now),
+            )
+            .unwrap();
         db.conn
             .execute(
                 "UPDATE metrics SET processing_started_at = ?1 WHERE id = ?2",

--- a/src/metrics/db.rs
+++ b/src/metrics/db.rs
@@ -775,44 +775,35 @@ impl MetricsDatabase {
                 // Legacy rows predate cached event metadata. Reuse the existing
                 // bounded-batch backfill before applying an event-time filter so
                 // valid historical events are not silently missed.
-                self.backfill_event_metadata()?;
-                self.conn
-                    .execute(
-                        r#"
-                        UPDATE metrics
-                        SET delivered_ts = NULL,
-                            attempts = 0,
-                            last_sync_error = NULL,
-                            last_sync_at = NULL,
-                            next_retry_at = 0,
-                            processing_started_at = NULL
-                        WHERE event_ts >= ?1
-                          AND event_ts < ?2
-                          AND event_kind IS NOT NULL
-                        "#,
-                        params![i64::from(from_ts), i64::from(to_ts)],
-                    )
-                    .map_err(Into::into)
+                if !self.event_metadata_backfill_completed()? {
+                    self.backfill_event_metadata()?;
+                }
             }
-            (None, None) => self
-                .conn
-                .execute(
-                    r#"
-                    UPDATE metrics
-                    SET delivered_ts = NULL,
-                        attempts = 0,
-                        last_sync_error = NULL,
-                        last_sync_at = NULL,
-                        next_retry_at = 0,
-                        processing_started_at = NULL
-                    "#,
-                    [],
-                )
-                .map_err(Into::into),
+            (None, None) => {}
             _ => Err(GitAiError::Generic(
                 "metrics reingestion requires no bounds or an ordered from/to pair".to_string(),
-            )),
-        }
+            ))?,
+        };
+
+        self.conn
+            .execute(
+                r#"
+                UPDATE metrics
+                SET delivered_ts = NULL,
+                    attempts = 0,
+                    last_sync_error = NULL,
+                    last_sync_at = NULL,
+                    next_retry_at = 0,
+                    processing_started_at = NULL
+                WHERE processing_started_at IS NULL
+                  AND (
+                    (?1 IS NULL AND ?2 IS NULL)
+                    OR (event_ts >= ?1 AND event_ts < ?2 AND event_kind IS NOT NULL)
+                  )
+                "#,
+                params![from_ts.map(i64::from), to_ts.map(i64::from)],
+            )
+            .map_err(Into::into)
     }
 
     /// Summarize local metrics delivery state for user-facing diagnostics.
@@ -1293,7 +1284,7 @@ impl MetricsDatabase {
 
         loop {
             let (summary, last_id) =
-                self.backfill_event_metadata_batch_after(after_id, METADATA_BACKFILL_BATCH_SIZE)?;
+                self.backfill_event_metadata_batch_once(after_id, METADATA_BACKFILL_BATCH_SIZE)?;
             total.scanned += summary.scanned;
             total.updated += summary.updated;
 
@@ -2885,8 +2876,14 @@ mod tests {
             .execute(
                 "UPDATE metrics \
                  SET attempts = 6, last_sync_error = 'stopped', last_sync_at = ?1, \
-                     next_retry_at = ?1, processing_started_at = ?1",
+                     next_retry_at = ?1",
                 params![now as i64],
+            )
+            .unwrap();
+        db.conn
+            .execute(
+                "UPDATE metrics SET processing_started_at = ?1 WHERE id = ?2",
+                params![now as i64, ids[1]],
             )
             .unwrap();
         db.conn
@@ -2898,7 +2895,7 @@ mod tests {
 
         let reset = db.reingest_metrics(Some(from_ts), Some(to_ts)).unwrap();
 
-        assert_eq!(reset, 3);
+        assert_eq!(reset, 2);
         struct DeliveryState {
             id: i64,
             delivered_ts: Option<i64>,
@@ -2932,7 +2929,7 @@ mod tests {
             .unwrap();
 
         for (index, row) in rows.iter().enumerate() {
-            let in_range = matches!(index, 1..=3);
+            let in_range = matches!(index, 2..=3);
             if in_range {
                 assert_eq!(row.delivered_ts, None, "row {} should be pending", row.id);
                 assert_eq!(row.attempts, 0);
@@ -2946,23 +2943,56 @@ mod tests {
                 assert_eq!(row.last_sync_error.as_deref(), Some("stopped"));
                 assert_eq!(row.last_sync_at, Some(now as i64));
                 assert_eq!(row.next_retry_at, now as i64);
-                assert_eq!(row.processing_started_at, Some(now as i64));
+                assert_eq!(
+                    row.processing_started_at,
+                    (index == 1).then_some(now as i64)
+                );
             }
         }
+    }
+
+    #[test]
+    fn test_reingest_metrics_skips_completed_metadata_backfill() {
+        let (mut db, _temp_dir) = create_test_db();
+        let event_ts = seconds_ago(100);
+        let ids = db
+            .insert_events_with_delivered_ts(&[event_json(event_ts)], Some(unix_now()))
+            .unwrap();
+
+        db.backfill_event_metadata_batch_once(0, 100).unwrap();
+        assert!(db.event_metadata_backfill_completed().unwrap());
+        db.conn
+            .execute(
+                "UPDATE metrics SET event_ts = NULL, event_kind = NULL WHERE id = ?1",
+                params![ids[0]],
+            )
+            .unwrap();
+
+        assert_eq!(
+            db.reingest_metrics(Some(event_ts - 1), Some(event_ts + 1))
+                .unwrap(),
+            0
+        );
     }
 
     #[test]
     fn test_reingest_all_resets_rows_without_event_metadata() {
         let (mut db, _temp_dir) = create_test_db();
         let now = unix_now();
-        db.insert_events_with_delivered_ts(
+        let ids = db.insert_events_with_delivered_ts(
             &[event_json(seconds_ago(100)), "not-json".to_string()],
             Some(now),
         )
         .unwrap();
+        db.conn
+            .execute(
+                "UPDATE metrics SET processing_started_at = ?1 WHERE id = ?2",
+                params![now as i64, ids[0]],
+            )
+            .unwrap();
 
-        assert_eq!(db.reingest_metrics(None, None).unwrap(), 2);
-        assert_eq!(db.status().unwrap().pending_retryable, 2);
+        assert_eq!(db.reingest_metrics(None, None).unwrap(), 1);
+        assert_eq!(db.status().unwrap().pending_retryable, 1);
     }
 
     #[test]

--- a/src/metrics/db.rs
+++ b/src/metrics/db.rs
@@ -760,6 +760,61 @@ impl MetricsDatabase {
         Ok(count as usize)
     }
 
+    /// Reset matching metric rows so the telemetry worker can deliver them again.
+    ///
+    /// Bounds are event timestamps and form a half-open `[from_ts, to_ts)` range.
+    /// Passing no bounds resets all rows, including malformed legacy rows that do
+    /// not have cached event metadata.
+    pub fn reingest_metrics(
+        &mut self,
+        from_ts: Option<u32>,
+        to_ts: Option<u32>,
+    ) -> Result<usize, GitAiError> {
+        match (from_ts, to_ts) {
+            (Some(from_ts), Some(to_ts)) if from_ts < to_ts => {
+                // Legacy rows predate cached event metadata. Reuse the existing
+                // bounded-batch backfill before applying an event-time filter so
+                // valid historical events are not silently missed.
+                self.backfill_event_metadata()?;
+                self.conn
+                    .execute(
+                        r#"
+                        UPDATE metrics
+                        SET delivered_ts = NULL,
+                            attempts = 0,
+                            last_sync_error = NULL,
+                            last_sync_at = NULL,
+                            next_retry_at = 0,
+                            processing_started_at = NULL
+                        WHERE event_ts >= ?1
+                          AND event_ts < ?2
+                          AND event_kind IS NOT NULL
+                        "#,
+                        params![i64::from(from_ts), i64::from(to_ts)],
+                    )
+                    .map_err(Into::into)
+            }
+            (None, None) => self
+                .conn
+                .execute(
+                    r#"
+                    UPDATE metrics
+                    SET delivered_ts = NULL,
+                        attempts = 0,
+                        last_sync_error = NULL,
+                        last_sync_at = NULL,
+                        next_retry_at = 0,
+                        processing_started_at = NULL
+                    "#,
+                    [],
+                )
+                .map_err(Into::into),
+            _ => Err(GitAiError::Generic(
+                "metrics reingestion requires no bounds or an ordered from/to pair".to_string(),
+            )),
+        }
+    }
+
     /// Summarize local metrics delivery state for user-facing diagnostics.
     pub fn status(&self) -> Result<MetricsStatus, GitAiError> {
         let now = current_unix_ts();
@@ -2806,6 +2861,107 @@ mod tests {
         assert!(delivered_ts.is_none());
         assert_eq!(attempts, MAX_METRIC_UPLOAD_ATTEMPTS as i64);
         assert_eq!(last_sync_error.as_deref(), Some("validation failed"));
+    }
+
+    #[test]
+    fn test_reingest_metrics_resets_delivery_state_in_half_open_event_time_range() {
+        let (mut db, _temp_dir) = create_test_db();
+        let now = unix_now();
+        let from_ts = seconds_ago(200);
+        let to_ts = seconds_ago(100);
+        let event_jsons = [
+            event_json(from_ts - 1),
+            event_json(from_ts),
+            event_json(from_ts + 50),
+            event_json(to_ts - 1),
+            event_json(to_ts),
+            "not-json".to_string(),
+        ];
+        let ids = db
+            .insert_events_with_delivered_ts(&event_jsons, Some(now))
+            .unwrap();
+
+        db.conn
+            .execute(
+                "UPDATE metrics \
+                 SET attempts = 6, last_sync_error = 'stopped', last_sync_at = ?1, \
+                     next_retry_at = ?1, processing_started_at = ?1",
+                params![now as i64],
+            )
+            .unwrap();
+        db.conn
+            .execute(
+                "UPDATE metrics SET event_ts = NULL, event_kind = NULL WHERE id = ?1",
+                params![ids[2]],
+            )
+            .unwrap();
+
+        let reset = db.reingest_metrics(Some(from_ts), Some(to_ts)).unwrap();
+
+        assert_eq!(reset, 3);
+        let rows: Vec<(
+            i64,
+            Option<i64>,
+            i64,
+            Option<String>,
+            Option<i64>,
+            i64,
+            Option<i64>,
+        )> = db
+            .conn
+            .prepare(
+                "SELECT id, delivered_ts, attempts, last_sync_error, last_sync_at, \
+                        next_retry_at, processing_started_at \
+                 FROM metrics ORDER BY id",
+            )
+            .unwrap()
+            .query_map([], |row| {
+                Ok((
+                    row.get(0)?,
+                    row.get(1)?,
+                    row.get(2)?,
+                    row.get(3)?,
+                    row.get(4)?,
+                    row.get(5)?,
+                    row.get(6)?,
+                ))
+            })
+            .unwrap()
+            .collect::<Result<_, _>>()
+            .unwrap();
+
+        for (index, row) in rows.iter().enumerate() {
+            let in_range = matches!(index, 1..=3);
+            if in_range {
+                assert_eq!(row.1, None, "row {} should be pending", row.0);
+                assert_eq!(row.2, 0);
+                assert_eq!(row.3, None);
+                assert_eq!(row.4, None);
+                assert_eq!(row.5, 0);
+                assert_eq!(row.6, None);
+            } else {
+                assert_eq!(row.1, Some(now as i64), "row {} changed", row.0);
+                assert_eq!(row.2, 6);
+                assert_eq!(row.3.as_deref(), Some("stopped"));
+                assert_eq!(row.4, Some(now as i64));
+                assert_eq!(row.5, now as i64);
+                assert_eq!(row.6, Some(now as i64));
+            }
+        }
+    }
+
+    #[test]
+    fn test_reingest_all_resets_rows_without_event_metadata() {
+        let (mut db, _temp_dir) = create_test_db();
+        let now = unix_now();
+        db.insert_events_with_delivered_ts(
+            &[event_json(seconds_ago(100)), "not-json".to_string()],
+            Some(now),
+        )
+        .unwrap();
+
+        assert_eq!(db.reingest_metrics(None, None).unwrap(), 2);
+        assert_eq!(db.status().unwrap().pending_retryable, 2);
     }
 
     #[test]


### PR DESCRIPTION
Part 1 of #2197.

Adds the transactional local metrics reset used by reingestion. Bounded resets use the existing event metadata backfill and `[from, to)` event-time filtering; all-time resets include malformed legacy rows. Delivery, retry, error, and in-flight state are cleared so matching rows are immediately retryable.

Tests cover bounded edges, legacy metadata backfill, delivered/exhausted/in-flight state, malformed rows, and all-time reset.

Next: #2195