### PR TITLE
Route metrics reingestion through daemon

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -7202,6 +7202,22 @@ impl ActorDaemonCoordinator {
                 }
                 Ok(ControlResponse::ok(None, None))
             }
+            ControlRequest::ReingestMetrics { from_ts, to_ts } => {
+                if let Some(worker) = &self.telemetry_worker {
+                    worker
+                        .reingest_metrics(from_ts, to_ts)
+                        .await
+                        .and_then(|reset| {
+                            serde_json::to_value(json!({ "reset": reset }))
+                                .map(|value| ControlResponse::ok(None, Some(value)))
+                                .map_err(GitAiError::from)
+                        })
+                } else {
+                    Err(GitAiError::Generic(
+                        "telemetry worker is not available".to_string(),
+                    ))
+                }
+            }
             ControlRequest::StatsIngest => Ok(ControlResponse::ok(
                 None,
                 Some(json!({
@@ -9491,6 +9507,7 @@ fn checkpoint_control_response_timeout(
         ControlRequest::Await { timeout_secs } => {
             Duration::from_secs(timeout_secs.saturating_add(5))
         }
+        ControlRequest::ReingestMetrics { .. } => DAEMON_CHECKPOINT_RESPONSE_TIMEOUT,
         ControlRequest::Shutdown => DAEMON_CHECKPOINT_RESPONSE_TIMEOUT,
         _ => DAEMON_CONTROL_RESPONSE_TIMEOUT,
     }

--- a/src/daemon/control_api.rs
+++ b/src/daemon/control_api.rs
@@ -23,6 +23,13 @@ pub enum ControlRequest {
     /// Signal the daemon that new notes are pending in notes-db and should be flushed.
     #[serde(rename = "notes.flush")]
     FlushNotes,
+    /// Reset local metric delivery state for a half-open event-time range, or
+    /// for all rows when both bounds are absent.
+    #[serde(rename = "metrics.reingest")]
+    ReingestMetrics {
+        from_ts: Option<u32>,
+        to_ts: Option<u32>,
+    },
     /// Report ingest loss counters (dropped trace payloads/connections).
     #[serde(rename = "stats.ingest")]
     StatsIngest,
@@ -184,4 +191,25 @@ pub struct CasSyncPayload {
     pub data: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn metrics_reingest_request_uses_stable_wire_shape() {
+        let request = ControlRequest::ReingestMetrics {
+            from_ts: Some(100),
+            to_ts: Some(200),
+        };
+
+        assert_eq!(
+            serde_json::to_value(request).unwrap(),
+            serde_json::json!({
+                "method": "metrics.reingest",
+                "params": { "from_ts": 100, "to_ts": 200 }
+            })
+        );
+    }
 }

--- a/src/daemon/telemetry_worker.rs
+++ b/src/daemon/telemetry_worker.rs
@@ -277,13 +277,13 @@ impl DaemonTelemetryWorkerHandle {
     #[cfg(test)]
     pub fn new_noop() -> Self {
         let (flush_tx, _flush_rx) = tokio::sync::mpsc::unbounded_channel();
-        let (metrics_reingest_tx, metrics_reingest_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (metrics_reingest_tx, _metrics_reingest_rx) =
+            tokio::sync::mpsc::unbounded_channel();
         let (metrics_persist_tx, persist_rx) =
             tokio::sync::mpsc::channel(METRICS_PERSIST_QUEUE_CAPACITY);
         // Keep the receiver alive so noop submissions look like a full-but-
         // healthy queue instead of a dead persist worker.
         std::mem::forget(persist_rx);
-        std::mem::forget(metrics_reingest_rx);
         Self {
             buffer: Arc::new(Mutex::new(TelemetryBuffer::new())),
             flush_tx,
@@ -696,9 +696,6 @@ async fn telemetry_flush_loop(
             }
         }
 
-        let explicitly_requested =
-            !flush_requests.is_empty() || !metrics_reingest_requests.is_empty();
-
         if !metrics_reingest_requests.is_empty() {
             let persist_queue_drained =
                 drain_metrics_persist_requests(&metrics_persist_tx, METRICS_PERSIST_DRAIN_DEADLINE)
@@ -728,11 +725,7 @@ async fn telemetry_flush_loop(
             None
         };
 
-        let flush_mode = if explicitly_requested {
-            FlushMode::Await
-        } else {
-            FlushMode::Periodic
-        };
+        let flush_mode = flush_mode_for_requests(!flush_requests.is_empty());
         // An awaited flush certifies "everything submitted so far is flushed
         // or counted as pending": batches still sitting in the persist queue
         // must reach SQLite first, or the DB-based pending count under-reports
@@ -811,6 +804,14 @@ fn take_telemetry_flush_snapshot(
         None
     } else {
         Some(buffer.take())
+    }
+}
+
+fn flush_mode_for_requests(has_flush_requests: bool) -> FlushMode {
+    if has_flush_requests {
+        FlushMode::Await
+    } else {
+        FlushMode::Periodic
     }
 }
 
@@ -1922,6 +1923,26 @@ mod tests {
         let mut buffer = TelemetryBuffer::new();
 
         assert!(take_telemetry_flush_snapshot(&mut buffer, FlushMode::Await).is_some());
+    }
+
+    #[test]
+    fn reingest_without_flush_request_uses_periodic_flush_mode() {
+        assert_eq!(flush_mode_for_requests(false), FlushMode::Periodic);
+        assert_eq!(flush_mode_for_requests(true), FlushMode::Await);
+    }
+
+    #[tokio::test]
+    async fn noop_worker_reingest_fails_instead_of_hanging() {
+        let handle = DaemonTelemetryWorkerHandle::new_noop();
+
+        let result = tokio::time::timeout(
+            Duration::from_secs(1),
+            handle.reingest_metrics(None, None),
+        )
+        .await
+        .expect("noop reingest should return promptly");
+
+        assert!(result.is_err());
     }
 
     #[test]

--- a/src/daemon/telemetry_worker.rs
+++ b/src/daemon/telemetry_worker.rs
@@ -51,6 +51,12 @@ struct FlushRequest {
     completion: tokio::sync::oneshot::Sender<FlushStatus>,
 }
 
+struct MetricsReingestRequest {
+    from_ts: Option<u32>,
+    to_ts: Option<u32>,
+    completion: tokio::sync::oneshot::Sender<Result<usize, String>>,
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum FlushMode {
     Periodic,
@@ -263,6 +269,7 @@ async fn drain_metrics_persist_requests(
 pub struct DaemonTelemetryWorkerHandle {
     buffer: Arc<Mutex<TelemetryBuffer>>,
     flush_tx: tokio::sync::mpsc::UnboundedSender<FlushRequest>,
+    metrics_reingest_tx: tokio::sync::mpsc::UnboundedSender<MetricsReingestRequest>,
     metrics_persist_tx: tokio::sync::mpsc::Sender<MetricsPersistRequest>,
 }
 
@@ -270,14 +277,17 @@ impl DaemonTelemetryWorkerHandle {
     #[cfg(test)]
     pub fn new_noop() -> Self {
         let (flush_tx, _flush_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (metrics_reingest_tx, metrics_reingest_rx) = tokio::sync::mpsc::unbounded_channel();
         let (metrics_persist_tx, persist_rx) =
             tokio::sync::mpsc::channel(METRICS_PERSIST_QUEUE_CAPACITY);
         // Keep the receiver alive so noop submissions look like a full-but-
         // healthy queue instead of a dead persist worker.
         std::mem::forget(persist_rx);
+        std::mem::forget(metrics_reingest_rx);
         Self {
             buffer: Arc::new(Mutex::new(TelemetryBuffer::new())),
             flush_tx,
+            metrics_reingest_tx,
             metrics_persist_tx,
         }
     }
@@ -363,6 +373,26 @@ impl DaemonTelemetryWorkerHandle {
         completion_rx
             .await
             .map_err(|_| GitAiError::Generic("telemetry flush was cancelled".to_string()))
+    }
+
+    /// Reset matching local metrics in the serialized telemetry loop.
+    pub async fn reingest_metrics(
+        &self,
+        from_ts: Option<u32>,
+        to_ts: Option<u32>,
+    ) -> Result<usize, GitAiError> {
+        let (completion_tx, completion_rx) = tokio::sync::oneshot::channel();
+        self.metrics_reingest_tx
+            .send(MetricsReingestRequest {
+                from_ts,
+                to_ts,
+                completion: completion_tx,
+            })
+            .map_err(|_| GitAiError::Generic("telemetry worker has stopped".to_string()))?;
+        completion_rx
+            .await
+            .map_err(|_| GitAiError::Generic("metrics reingestion was cancelled".to_string()))?
+            .map_err(GitAiError::Generic)
     }
 
     /// Returns the current number of metrics waiting for upload.
@@ -545,11 +575,13 @@ pub fn submit_daemon_internal_daemon_logs(events: Vec<DaemonLogEvent>) -> bool {
 pub fn spawn_telemetry_worker() -> DaemonTelemetryWorkerHandle {
     let buffer = Arc::new(Mutex::new(TelemetryBuffer::new()));
     let (flush_tx, flush_rx) = tokio::sync::mpsc::unbounded_channel();
+    let (metrics_reingest_tx, metrics_reingest_rx) = tokio::sync::mpsc::unbounded_channel();
     let (metrics_persist_tx, metrics_persist_rx) =
         tokio::sync::mpsc::channel(METRICS_PERSIST_QUEUE_CAPACITY);
     let handle = DaemonTelemetryWorkerHandle {
         buffer: buffer.clone(),
         flush_tx,
+        metrics_reingest_tx,
         metrics_persist_tx: metrics_persist_tx.clone(),
     };
     let daemon_id = daemon_run_id().to_string();
@@ -559,7 +591,14 @@ pub fn spawn_telemetry_worker() -> DaemonTelemetryWorkerHandle {
 
     telemetry_runtime.spawn(metrics_persist_loop(metrics_persist_rx));
     telemetry_runtime.spawn(async move {
-        telemetry_flush_loop(buffer, daemon_id, flush_rx, metrics_persist_tx).await;
+        telemetry_flush_loop(
+            buffer,
+            daemon_id,
+            flush_rx,
+            metrics_reingest_rx,
+            metrics_persist_tx,
+        )
+        .await;
     });
 
     handle
@@ -638,17 +677,44 @@ async fn telemetry_flush_loop(
     buffer: Arc<Mutex<TelemetryBuffer>>,
     daemon_id: String,
     mut flush_rx: tokio::sync::mpsc::UnboundedReceiver<FlushRequest>,
+    mut metrics_reingest_rx: tokio::sync::mpsc::UnboundedReceiver<MetricsReingestRequest>,
     metrics_persist_tx: tokio::sync::mpsc::Sender<MetricsPersistRequest>,
 ) {
     let started_at = std::time::Instant::now();
     let mut next_heartbeat_at = started_at + DAEMON_LOG_HEARTBEAT_INTERVAL;
     let mut flush_requests: Vec<FlushRequest> = Vec::new();
+    let mut metrics_reingest_requests: Vec<MetricsReingestRequest> = Vec::new();
 
     loop {
         tokio::select! {
             _ = sleep_until(next_telemetry_flush_at(Instant::now())) => {}
             Some(request) = flush_rx.recv() => {
                 flush_requests.push(request);
+            }
+            Some(request) = metrics_reingest_rx.recv() => {
+                metrics_reingest_requests.push(request);
+            }
+        }
+
+        let explicitly_requested =
+            !flush_requests.is_empty() || !metrics_reingest_requests.is_empty();
+
+        if !metrics_reingest_requests.is_empty() {
+            let persist_queue_drained =
+                drain_metrics_persist_requests(&metrics_persist_tx, METRICS_PERSIST_DRAIN_DEADLINE)
+                    .await;
+            for request in metrics_reingest_requests.drain(..) {
+                let result = if persist_queue_drained {
+                    tokio::task::spawn_blocking(move || {
+                        reingest_metrics_in_db(request.from_ts, request.to_ts)
+                    })
+                    .await
+                    .map_err(|error| format!("metrics reingestion task panicked: {error}"))
+                    .and_then(|result| result.map_err(|error| error.to_string()))
+                } else {
+                    Err("timed out waiting for queued metrics to persist".to_string())
+                };
+                let _ = request.completion.send(result);
             }
         }
 
@@ -662,10 +728,10 @@ async fn telemetry_flush_loop(
             None
         };
 
-        let flush_mode = if flush_requests.is_empty() {
-            FlushMode::Periodic
-        } else {
+        let flush_mode = if explicitly_requested {
             FlushMode::Await
+        } else {
+            FlushMode::Periodic
         };
         // An awaited flush certifies "everything submitted so far is flushed
         // or counted as pending": batches still sitting in the persist queue
@@ -727,6 +793,14 @@ async fn telemetry_flush_loop(
                 .requeue_failed_daemon_logs(requeue_daemon_logs);
         }
     }
+}
+
+fn reingest_metrics_in_db(from_ts: Option<u32>, to_ts: Option<u32>) -> Result<usize, GitAiError> {
+    let db = MetricsDatabase::global()?;
+    let mut db_lock = db
+        .lock()
+        .map_err(|_| GitAiError::Generic("metrics DB lock poisoned".to_string()))?;
+    db_lock.reingest_metrics(from_ts, to_ts)
 }
 
 fn take_telemetry_flush_snapshot(
@@ -1801,10 +1875,12 @@ mod tests {
     #[tokio::test]
     async fn metrics_persist_queue_drops_loudly_when_full() {
         let (flush_tx, _flush_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (metrics_reingest_tx, _metrics_reingest_rx) = tokio::sync::mpsc::unbounded_channel();
         let (metrics_persist_tx, _persist_rx) = tokio::sync::mpsc::channel(1);
         let handle = DaemonTelemetryWorkerHandle {
             buffer: Arc::new(Mutex::new(TelemetryBuffer::new())),
             flush_tx,
+            metrics_reingest_tx,
             metrics_persist_tx,
         };
         let event: MetricEvent = serde_json::from_str(&event_json(1)).unwrap();

--- a/src/daemon/telemetry_worker.rs
+++ b/src/daemon/telemetry_worker.rs
@@ -277,8 +277,7 @@ impl DaemonTelemetryWorkerHandle {
     #[cfg(test)]
     pub fn new_noop() -> Self {
         let (flush_tx, _flush_rx) = tokio::sync::mpsc::unbounded_channel();
-        let (metrics_reingest_tx, _metrics_reingest_rx) =
-            tokio::sync::mpsc::unbounded_channel();
+        let (metrics_reingest_tx, _metrics_reingest_rx) = tokio::sync::mpsc::unbounded_channel();
         let (metrics_persist_tx, persist_rx) =
             tokio::sync::mpsc::channel(METRICS_PERSIST_QUEUE_CAPACITY);
         // Keep the receiver alive so noop submissions look like a full-but-
@@ -1935,12 +1934,10 @@ mod tests {
     async fn noop_worker_reingest_fails_instead_of_hanging() {
         let handle = DaemonTelemetryWorkerHandle::new_noop();
 
-        let result = tokio::time::timeout(
-            Duration::from_secs(1),
-            handle.reingest_metrics(None, None),
-        )
-        .await
-        .expect("noop reingest should return promptly");
+        let result =
+            tokio::time::timeout(Duration::from_secs(1), handle.reingest_metrics(None, None))
+                .await
+                .expect("noop reingest should return promptly");
 
         assert!(result.is_err());
     }


### PR DESCRIPTION
Part 2 of #2197; depends on #2194.

Adds the `metrics.reingest` daemon control request and routes resets through the serialized telemetry loop. The worker drains queued metric persistence, waits behind any active upload, performs the database reset on the telemetry blocking pool, acknowledges the reset count, and immediately wakes normal delivery.

Tests cover the stable control-wire shape. The full daemon behavior is exercised in #2196.

Previous: #2194
Next: #2196