### PR TITLE
Add git-ai reingest command

### DIFF
--- a/src/commands/git_ai_handlers.rs
+++ b/src/commands/git_ai_handlers.rs
@@ -190,6 +190,9 @@ pub fn handle_git_ai(args: &[String]) {
         "flush-metrics-db" => {
             commands::flush_metrics_db::handle_flush_metrics_db(&args[1..]);
         }
+        "reingest" => {
+            commands::reingest::handle_reingest(&args[1..]);
+        }
         "await" => {
             commands::r#await::handle_await(&args[1..]);
         }
@@ -381,6 +384,10 @@ fn print_help() {
     eprintln!("  git-path           Print the path to the underlying git executable");
     eprintln!("  await [beta]       Wait for the background service to finish all work");
     eprintln!("    --timeout <seconds>    Maximum time to wait (default: 30)");
+    eprintln!("  reingest           Redeliver locally stored metric events");
+    eprintln!("    --all                  Reingest all retained events");
+    eprintln!("    --from <time> --to <time>  Reingest an RFC3339 [from, to) range");
+    eprintln!("    --since <duration>      Reingest a recent s/m/h/d/w duration");
     eprintln!("  upgrade            Check for updates and install if available");
     eprintln!("    --force               Reinstall latest version even if already up to date");
     eprintln!("  fetch-notes [remote] Synchronously fetch AI authorship notes");

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -21,6 +21,7 @@ pub mod login;
 pub mod logout;
 pub mod notes_migrate;
 pub mod personal_dashboard;
+pub mod reingest;
 pub mod revision;
 pub mod show;
 pub mod show_prompt;

--- a/src/commands/reingest.rs
+++ b/src/commands/reingest.rs
@@ -158,7 +158,11 @@ fn parse_rfc3339_timestamp(flag: &str, value: &str) -> Result<u32, String> {
 }
 
 fn parse_since_duration(value: &str) -> Result<u64, String> {
-    let (digits, unit) = value.split_at(value.len().saturating_sub(1));
+    let split_index = value
+        .char_indices()
+        .next_back()
+        .map_or(0, |(index, _)| index);
+    let (digits, unit) = value.split_at(split_index);
     let amount = digits
         .parse::<u64>()
         .ok()
@@ -262,6 +266,7 @@ mod tests {
             vec!["--all", "--since", "1d"],
             vec!["--since", "0d"],
             vec!["--since", "1d2h"],
+            vec!["--since", "5µ"],
             vec![
                 "--from",
                 "2023-11-14T22:13:20Z",

--- a/src/commands/reingest.rs
+++ b/src/commands/reingest.rs
@@ -1,0 +1,279 @@
+//! Reset locally stored metric events so the daemon delivers them again.
+
+use crate::daemon::{ControlRequest, send_control_request};
+use chrono::DateTime;
+use serde::Deserialize;
+use std::time::Duration;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ReingestScope {
+    from_ts: Option<u32>,
+    to_ts: Option<u32>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ReingestResponse {
+    reset: usize,
+}
+
+pub(crate) fn handle_reingest(args: &[String]) {
+    if args
+        .iter()
+        .any(|arg| matches!(arg.as_str(), "--help" | "-h" | "help"))
+    {
+        print_usage();
+        return;
+    }
+
+    let now_ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+        .min(u64::from(u32::MAX)) as u32;
+    let scope = match parse_reingest_scope(args, now_ts) {
+        Ok(scope) => scope,
+        Err(error) => {
+            eprintln!("reingest: {error}");
+            print_usage();
+            std::process::exit(1);
+        }
+    };
+
+    let config = match crate::commands::daemon::ensure_daemon_running(Duration::from_secs(5)) {
+        Ok(config) => config,
+        Err(error) => {
+            eprintln!("reingest: failed to reach git-ai background service: {error}");
+            std::process::exit(1);
+        }
+    };
+    let request = ControlRequest::ReingestMetrics {
+        from_ts: scope.from_ts,
+        to_ts: scope.to_ts,
+    };
+    let response = match send_control_request(&config.control_socket_path, &request) {
+        Ok(response) => response,
+        Err(error) => {
+            eprintln!("reingest: failed to send request to background service: {error}");
+            std::process::exit(1);
+        }
+    };
+    if !response.ok {
+        eprintln!(
+            "reingest: {}",
+            response
+                .error
+                .as_deref()
+                .unwrap_or("background service returned an error")
+        );
+        std::process::exit(1);
+    }
+
+    let result = response
+        .data
+        .and_then(|value| serde_json::from_value::<ReingestResponse>(value).ok())
+        .unwrap_or_else(|| {
+            eprintln!("reingest: background service returned an invalid response");
+            std::process::exit(1);
+        });
+    println!(
+        "reingest: reset {} metric event(s); delivery will continue in the background",
+        result.reset
+    );
+}
+
+fn parse_reingest_scope(args: &[String], now_ts: u32) -> Result<ReingestScope, String> {
+    let mut all = false;
+    let mut from = None;
+    let mut to = None;
+    let mut since = None;
+    let mut index = 0;
+
+    while index < args.len() {
+        let flag = args[index].as_str();
+        match flag {
+            "--all" if !all => {
+                all = true;
+                index += 1;
+            }
+            "--all" => return Err("--all may only be specified once".to_string()),
+            "--from" | "--to" | "--since" => {
+                let value = args
+                    .get(index + 1)
+                    .ok_or_else(|| format!("{flag} requires a value"))?;
+                let destination = match flag {
+                    "--from" => &mut from,
+                    "--to" => &mut to,
+                    _ => &mut since,
+                };
+                if destination.replace(value.clone()).is_some() {
+                    return Err(format!("{flag} may only be specified once"));
+                }
+                index += 2;
+            }
+            _ => return Err(format!("unknown argument: {flag}")),
+        }
+    }
+
+    if all {
+        if from.is_some() || to.is_some() || since.is_some() {
+            return Err("--all cannot be combined with time bounds".to_string());
+        }
+        return Ok(ReingestScope {
+            from_ts: None,
+            to_ts: None,
+        });
+    }
+
+    if let Some(since) = since {
+        if from.is_some() || to.is_some() {
+            return Err("--since cannot be combined with --from or --to".to_string());
+        }
+        let duration = parse_since_duration(&since)?;
+        return Ok(ReingestScope {
+            from_ts: Some(now_ts.saturating_sub(duration.min(u64::from(u32::MAX)) as u32)),
+            to_ts: Some(now_ts),
+        });
+    }
+
+    let (Some(from), Some(to)) = (from, to) else {
+        return Err("use --all, --since, or both --from and --to".to_string());
+    };
+    let from_ts = parse_rfc3339_timestamp("--from", &from)?;
+    let to_ts = parse_rfc3339_timestamp("--to", &to)?;
+    if from_ts >= to_ts {
+        return Err("--from must be earlier than --to".to_string());
+    }
+    Ok(ReingestScope {
+        from_ts: Some(from_ts),
+        to_ts: Some(to_ts),
+    })
+}
+
+fn parse_rfc3339_timestamp(flag: &str, value: &str) -> Result<u32, String> {
+    let timestamp = DateTime::parse_from_rfc3339(value)
+        .map_err(|_| format!("{flag} must be an RFC3339 timestamp"))?
+        .timestamp();
+    u32::try_from(timestamp)
+        .map_err(|_| format!("{flag} is outside the supported metric timestamp range"))
+}
+
+fn parse_since_duration(value: &str) -> Result<u64, String> {
+    let (digits, unit) = value.split_at(value.len().saturating_sub(1));
+    let amount = digits
+        .parse::<u64>()
+        .ok()
+        .filter(|amount| *amount > 0)
+        .ok_or_else(|| {
+            "--since must be a positive integer followed by s, m, h, d, or w".to_string()
+        })?;
+    let multiplier = match unit {
+        "s" => 1,
+        "m" => 60,
+        "h" => 60 * 60,
+        "d" => 24 * 60 * 60,
+        "w" => 7 * 24 * 60 * 60,
+        _ => {
+            return Err(
+                "--since must be a positive integer followed by s, m, h, d, or w".to_string(),
+            );
+        }
+    };
+    amount
+        .checked_mul(multiplier)
+        .ok_or_else(|| "--since duration is too large".to_string())
+}
+
+fn print_usage() {
+    eprintln!("Usage:");
+    eprintln!("  git-ai reingest --all");
+    eprintln!("  git-ai reingest --from <RFC3339> --to <RFC3339>");
+    eprintln!("  git-ai reingest --since <duration>");
+    eprintln!();
+    eprintln!("Reset local metric delivery state and let the daemon redeliver matching events.");
+    eprintln!("Explicit bounds use a half-open [from, to) event-time range.");
+    eprintln!("Durations are positive integers with one of: s, m, h, d, w.");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(values: &[&str]) -> Vec<String> {
+        values.iter().map(|value| (*value).to_string()).collect()
+    }
+
+    #[test]
+    fn parses_all_time_scope() {
+        assert_eq!(
+            parse_reingest_scope(&args(&["--all"]), 1_700_000_000).unwrap(),
+            ReingestScope {
+                from_ts: None,
+                to_ts: None,
+            }
+        );
+    }
+
+    #[test]
+    fn parses_half_open_rfc3339_scope_with_offsets() {
+        assert_eq!(
+            parse_reingest_scope(
+                &args(&[
+                    "--from",
+                    "2023-11-14T17:13:20-05:00",
+                    "--to",
+                    "2023-11-14T23:13:20+00:00",
+                ]),
+                1_700_000_000,
+            )
+            .unwrap(),
+            ReingestScope {
+                from_ts: Some(1_700_000_000),
+                to_ts: Some(1_700_003_600),
+            }
+        );
+    }
+
+    #[test]
+    fn parses_supported_since_units() {
+        for (value, seconds) in [
+            ("30s", 30),
+            ("5m", 300),
+            ("2h", 7_200),
+            ("7d", 604_800),
+            ("2w", 1_209_600),
+        ] {
+            assert_eq!(
+                parse_reingest_scope(&args(&["--since", value]), 1_700_000_000).unwrap(),
+                ReingestScope {
+                    from_ts: Some(1_700_000_000 - seconds),
+                    to_ts: Some(1_700_000_000),
+                },
+                "failed to parse {value}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_missing_mixed_or_invalid_scopes() {
+        for invalid in [
+            vec![],
+            vec!["--from", "2023-11-14T22:13:20Z"],
+            vec!["--to", "2023-11-14T22:13:20Z"],
+            vec!["--all", "--since", "1d"],
+            vec!["--since", "0d"],
+            vec!["--since", "1d2h"],
+            vec![
+                "--from",
+                "2023-11-14T22:13:20Z",
+                "--to",
+                "2023-11-14T22:13:20Z",
+            ],
+            vec!["unexpected"],
+        ] {
+            assert!(
+                parse_reingest_scope(&args(&invalid), 1_700_000_000).is_err(),
+                "unexpectedly accepted {invalid:?}"
+            );
+        }
+    }
+}

--- a/src/commands/reingest.rs
+++ b/src/commands/reingest.rs
@@ -60,10 +60,7 @@ pub(crate) fn handle_reingest(args: &[String]) {
     if !response.ok {
         eprintln!(
             "reingest: {}",
-            response
-                .error
-                .as_deref()
-                .unwrap_or("background service returned an error")
+            response_error_message(response.error.as_deref())
         );
         std::process::exit(1);
     }
@@ -79,6 +76,15 @@ pub(crate) fn handle_reingest(args: &[String]) {
         "reingest: reset {} metric event(s); delivery will continue in the background",
         result.reset
     );
+}
+
+fn response_error_message(error: Option<&str>) -> String {
+    let error = error.unwrap_or("background service returned an error");
+    if error.contains("invalid control request") && error.contains("metrics.reingest") {
+        return "the running background service does not support reingestion; run `git-ai bg restart` and retry"
+            .to_string();
+    }
+    error.to_string()
 }
 
 fn parse_reingest_scope(args: &[String], now_ts: u32) -> Result<ReingestScope, String> {
@@ -280,5 +286,19 @@ mod tests {
                 "unexpectedly accepted {invalid:?}"
             );
         }
+    }
+
+    #[test]
+    fn explains_daemon_version_skew() {
+        assert_eq!(
+            response_error_message(Some(
+                "invalid control request: unknown variant `metrics.reingest`"
+            )),
+            "the running background service does not support reingestion; run `git-ai bg restart` and retry"
+        );
+        assert_eq!(
+            response_error_message(Some("database unavailable")),
+            "database unavailable"
+        );
     }
 }

--- a/tests/daemon_mode.rs
+++ b/tests/daemon_mode.rs
@@ -7924,6 +7924,94 @@ fn daemon_marks_repository_filtered_session_events_delivered_without_uploading_t
 }
 
 #[test]
+fn reingest_command_redelivers_bounded_and_all_metrics_through_daemon() {
+    let mut mock_api = MockApiServer::start();
+    let metrics_db_path = std::env::temp_dir().join(format!(
+        "git-ai-reingest-metrics-{}.db",
+        git_ai::uuid::generate_v4()
+    ));
+    let repo = TestRepo::new_with_daemon_env(&[
+        ("GIT_AI_API_BASE_URL", mock_api.base_url()),
+        ("GIT_AI_API_KEY", "test-api-key"),
+        (
+            "GIT_AI_TEST_METRICS_DB_PATH",
+            metrics_db_path.to_str().unwrap(),
+        ),
+    ]);
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as u32;
+    let event = |timestamp: u32, marker: &str| {
+        MetricEvent::with_timestamp(
+            timestamp,
+            &SessionEventValues::new(json!({ "marker": marker })),
+            EventAttributes::with_version("test")
+                .session_id(marker)
+                .trace_id(marker)
+                .to_sparse(),
+        )
+    };
+    let events = [
+        event(now - 300, "before-window"),
+        event(now - 200, "inside-window"),
+        event(now - 100, "after-window"),
+    ];
+    let serialized = events
+        .iter()
+        .map(serde_json::to_string)
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+    MetricsDatabase::open_at_path(&metrics_db_path)
+        .unwrap()
+        .insert_events_with_delivered_ts(&serialized, Some(u64::from(now)))
+        .unwrap();
+
+    let format_time = |timestamp| {
+        chrono::DateTime::<chrono::Utc>::from_timestamp(i64::from(timestamp), 0)
+            .unwrap()
+            .to_rfc3339()
+    };
+    let output = repo
+        .git_ai(&[
+            "reingest",
+            "--from",
+            &format_time(now - 250),
+            "--to",
+            &format_time(now - 150),
+        ])
+        .expect("bounded reingestion should succeed");
+    assert!(output.contains("reset 1 metric event(s)"), "{output}");
+    repo.git_ai(&["await", "--timeout", "30"])
+        .expect("daemon should deliver the bounded reingestion");
+
+    let bounded_uploads = serde_json::to_string(&mock_api.collect_requests()).unwrap();
+    assert!(bounded_uploads.contains("inside-window"));
+    assert!(!bounded_uploads.contains("before-window"));
+    assert!(!bounded_uploads.contains("after-window"));
+
+    let output = repo
+        .git_ai(&["reingest", "--all"])
+        .expect("all-time reingestion should succeed");
+    assert!(output.contains("reset 3 metric event(s)"), "{output}");
+    repo.git_ai(&["await", "--timeout", "30"])
+        .expect("daemon should deliver the all-time reingestion");
+
+    let all_uploads = serde_json::to_string(&mock_api.collect_requests()).unwrap();
+    assert!(all_uploads.contains("before-window"));
+    assert!(all_uploads.contains("inside-window"));
+    assert!(all_uploads.contains("after-window"));
+    assert_eq!(
+        MetricsDatabase::open_at_path(&metrics_db_path)
+            .unwrap()
+            .status()
+            .unwrap()
+            .delivered,
+        3
+    );
+}
+
+#[test]
 fn await_is_marked_beta_and_returns_promptly_when_idle() {
     let repo = TestRepo::new_with_daemon_scope(DaemonTestScope::Dedicated);
 

--- a/tests/daemon_mode.rs
+++ b/tests/daemon_mode.rs
@@ -7926,10 +7926,8 @@ fn daemon_marks_repository_filtered_session_events_delivered_without_uploading_t
 #[test]
 fn reingest_command_redelivers_bounded_and_all_metrics_through_daemon() {
     let mut mock_api = MockApiServer::start();
-    let metrics_db_path = std::env::temp_dir().join(format!(
-        "git-ai-reingest-metrics-{}.db",
-        git_ai::uuid::generate_v4()
-    ));
+    let metrics_db_dir = tempfile::tempdir().expect("reingest metrics temp directory");
+    let metrics_db_path = metrics_db_dir.path().join("metrics.db");
     let repo = TestRepo::new_with_daemon_env(&[
         ("GIT_AI_API_BASE_URL", mock_api.base_url()),
         ("GIT_AI_API_KEY", "test-api-key"),

--- a/tests/daemon_mode.rs
+++ b/tests/daemon_mode.rs
@@ -7897,6 +7897,94 @@ fn daemon_marks_repository_filtered_session_events_delivered_without_uploading_t
 }
 
 #[test]
+fn reingest_command_redelivers_bounded_and_all_metrics_through_daemon() {
+    let mut mock_api = MockApiServer::start();
+    let metrics_db_path = std::env::temp_dir().join(format!(
+        "git-ai-reingest-metrics-{}.db",
+        git_ai::uuid::generate_v4()
+    ));
+    let repo = TestRepo::new_with_daemon_env(&[
+        ("GIT_AI_API_BASE_URL", mock_api.base_url()),
+        ("GIT_AI_API_KEY", "test-api-key"),
+        (
+            "GIT_AI_TEST_METRICS_DB_PATH",
+            metrics_db_path.to_str().unwrap(),
+        ),
+    ]);
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as u32;
+    let event = |timestamp: u32, marker: &str| {
+        MetricEvent::with_timestamp(
+            timestamp,
+            &SessionEventValues::new(json!({ "marker": marker })),
+            EventAttributes::with_version("test")
+                .session_id(marker)
+                .trace_id(marker)
+                .to_sparse(),
+        )
+    };
+    let events = [
+        event(now - 300, "before-window"),
+        event(now - 200, "inside-window"),
+        event(now - 100, "after-window"),
+    ];
+    let serialized = events
+        .iter()
+        .map(serde_json::to_string)
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+    MetricsDatabase::open_at_path(&metrics_db_path)
+        .unwrap()
+        .insert_events_with_delivered_ts(&serialized, Some(u64::from(now)))
+        .unwrap();
+
+    let format_time = |timestamp| {
+        chrono::DateTime::<chrono::Utc>::from_timestamp(i64::from(timestamp), 0)
+            .unwrap()
+            .to_rfc3339()
+    };
+    let output = repo
+        .git_ai(&[
+            "reingest",
+            "--from",
+            &format_time(now - 250),
+            "--to",
+            &format_time(now - 150),
+        ])
+        .expect("bounded reingestion should succeed");
+    assert!(output.contains("reset 1 metric event(s)"), "{output}");
+    repo.git_ai(&["await", "--timeout", "30"])
+        .expect("daemon should deliver the bounded reingestion");
+
+    let bounded_uploads = serde_json::to_string(&mock_api.collect_requests()).unwrap();
+    assert!(bounded_uploads.contains("inside-window"));
+    assert!(!bounded_uploads.contains("before-window"));
+    assert!(!bounded_uploads.contains("after-window"));
+
+    let output = repo
+        .git_ai(&["reingest", "--all"])
+        .expect("all-time reingestion should succeed");
+    assert!(output.contains("reset 3 metric event(s)"), "{output}");
+    repo.git_ai(&["await", "--timeout", "30"])
+        .expect("daemon should deliver the all-time reingestion");
+
+    let all_uploads = serde_json::to_string(&mock_api.collect_requests()).unwrap();
+    assert!(all_uploads.contains("before-window"));
+    assert!(all_uploads.contains("inside-window"));
+    assert!(all_uploads.contains("after-window"));
+    assert_eq!(
+        MetricsDatabase::open_at_path(&metrics_db_path)
+            .unwrap()
+            .status()
+            .unwrap()
+            .delivered,
+        3
+    );
+}
+
+#[test]
 fn await_is_marked_beta_and_returns_promptly_when_idle() {
     let repo = TestRepo::new_with_daemon_scope(DaemonTestScope::Dedicated);
 


### PR DESCRIPTION
Part 3 of #2197; depends on #2195.

Adds `git-ai reingest` with three exclusive scopes: `--all`, RFC3339 `--from/--to`, or a single-unit `--since` duration (`s`, `m`, `h`, `d`, `w`). Explicit bounds are half-open `[from, to)`. The command reports the reset count and returns while daemon delivery continues.

Parser tests cover valid scopes and invalid combinations. A TestRepo-based dedicated-daemon test proves bounded and all-time redelivery through the mock metrics API and `git-ai await`.

Previous: #2195