### PR TITLE
fix(claude): accept case-insensitive hook tool names

### DIFF
--- a/src/commands/checkpoint_agent/bash_tool.rs
+++ b/src/commands/checkpoint_agent/bash_tool.rs
@@ -313,9 +313,9 @@ fn normalize_tool_name(tool_name: &str) -> &str {
 /// Classify a tool name for a given agent.
 pub fn classify_tool(agent: Agent, tool_name: &str) -> ToolClass {
     match agent {
-        Agent::Claude => match tool_name {
-            "Write" | "Edit" | "MultiEdit" | "NotebookEdit" => ToolClass::FileEdit,
-            "Bash" => ToolClass::Bash,
+        Agent::Claude => match tool_name.to_ascii_lowercase().as_str() {
+            "write" | "edit" | "multiedit" | "notebookedit" => ToolClass::FileEdit,
+            "bash" => ToolClass::Bash,
             _ => ToolClass::Skip,
         },
         Agent::Gemini => match tool_name {

--- a/src/commands/checkpoint_agent/presets/claude.rs
+++ b/src/commands/checkpoint_agent/presets/claude.rs
@@ -262,7 +262,7 @@ mod tests {
 
     #[test]
     fn test_claude_preserves_all_mutating_file_tools() {
-        for tool_name in ["Write", "Edit", "MultiEdit"] {
+        for tool_name in ["Write", "Edit", "MultiEdit", "write", "edit", "multiedit"] {
             let pre = make_claude_hook_input("PreToolUse", tool_name);
             assert!(matches!(
                 ClaudePreset.parse(&pre, "t_test123456789a").unwrap()[..],

--- a/tests/integration/bash_tool_conformance.rs
+++ b/tests/integration/bash_tool_conformance.rs
@@ -544,12 +544,19 @@ fn test_bash_tool_orchestration_multiple_tool_uses() {
 #[test]
 fn test_classify_tool_claude() {
     assert_eq!(classify_tool(Agent::Claude, "Write"), ToolClass::FileEdit);
+    assert_eq!(classify_tool(Agent::Claude, "write"), ToolClass::FileEdit);
     assert_eq!(classify_tool(Agent::Claude, "Edit"), ToolClass::FileEdit);
+    assert_eq!(classify_tool(Agent::Claude, "edit"), ToolClass::FileEdit);
     assert_eq!(
         classify_tool(Agent::Claude, "MultiEdit"),
         ToolClass::FileEdit
     );
+    assert_eq!(
+        classify_tool(Agent::Claude, "multiedit"),
+        ToolClass::FileEdit
+    );
     assert_eq!(classify_tool(Agent::Claude, "Bash"), ToolClass::Bash);
+    assert_eq!(classify_tool(Agent::Claude, "bash"), ToolClass::Bash);
     assert_eq!(classify_tool(Agent::Claude, "Read"), ToolClass::Skip);
     assert_eq!(classify_tool(Agent::Claude, "Glob"), ToolClass::Skip);
     assert_eq!(


### PR DESCRIPTION
## Related issue

Fixes #2154

## Background

Claude-compatible hook bridges may emit tool names such as `write`, `edit`, `multiedit`, or `bash` in lowercase. The Claude preset previously classified these as unsupported and silently dropped the hook event.

## Changes

- Classify Claude tool names case-insensitively for the existing `Write`, `Edit`, `MultiEdit`, `NotebookEdit`, and `Bash` vocabulary.
- Add classification-level regression coverage for lowercase variants.
- Add Claude preset regression coverage for lowercase `write`, `edit`, and `multiedit` on both `PreToolUse` and `PostToolUse` paths.

## Compatibility

Existing behavior is unchanged for other agents and for Claude read-only or unknown tool names. Mixed-case variants of the existing Claude tool names are now accepted.

## Verification

- `cargo test test_claude_preserves_all_mutating_file_tools` — passed
- `cargo test --test integration test_classify_tool_claude` — passed
- `cargo fmt -- --check` — passed
- `cargo build` — passed
- `git diff --check` — passed
- `cargo clippy --all-targets --all-features -- -D warnings` — not clean because of 11 pre-existing warnings in unrelated files; no unrelated files were changed.

## Limitations

The full test suite was not run. The original issue also mentions `pwsh`; this PR does not classify that tool as Bash or FileEdit because it is not merely a case variant of the existing vocabulary. That behavior requires maintainer confirmation about the bridge's intended semantics.
