### PR TITLE
Key codex checkpoint streams by rollout filename, not hook session id

### DIFF
--- a/src/commands/checkpoint_agent/presets/codex.rs
+++ b/src/commands/checkpoint_agent/presets/codex.rs
@@ -141,12 +141,25 @@ impl AgentPreset for CodexPreset {
             metadata,
         };
 
-        let stream_source = transcript_path.map(|tp| StreamSource {
-            path: PathBuf::from(tp),
-            format: StreamFormat::CodexJsonl,
-            session_id: generate_session_id(&context.external_session_id, "codex"),
-            external_session_id: context.external_session_id.clone(),
-            external_parent_session_id: None,
+        // Stream identity must come from the rollout FILENAME, exactly like
+        // sweep discovery (see CodexAgent::discover_sessions). Fork/subagent
+        // rollouts report the parent thread's id in hook payloads; keying the
+        // stream by that id would track the same file a second time under a
+        // different identity, re-ingesting and double counting every line.
+        let stream_source = transcript_path.map(|tp| {
+            let path = PathBuf::from(tp);
+            let external_session_id =
+                crate::streams::agents::CodexAgent::external_session_id_from_rollout_path(&path)
+                    .unwrap_or_else(|| context.external_session_id.clone());
+            let external_parent_session_id =
+                crate::streams::agents::CodexAgent::detect_subagent_parent(&path);
+            StreamSource {
+                path,
+                format: StreamFormat::CodexJsonl,
+                session_id: generate_session_id(&external_session_id, "codex"),
+                external_session_id,
+                external_parent_session_id,
+            }
         });
 
         let bash_command = parse::bash_command_from_hook_input(&data);
@@ -304,6 +317,97 @@ mod tests {
         match &events[0] {
             ParsedHookEvent::PostBashCall(e) => {
                 assert_eq!(e.context.agent_id.model, "gpt-5.3-codex");
+            }
+            _ => panic!("Expected PostBashCall"),
+        }
+    }
+
+    #[test]
+    fn test_codex_stream_identity_follows_rollout_filename() {
+        use std::io::Write;
+
+        // Subagent/fork rollouts report the PARENT thread id in hook
+        // payloads, but the stream identity must come from the child file's
+        // own UUID (matching sweep discovery) so the file isn't tracked and
+        // uploaded twice under two identities.
+        let parent_id = "01a00000-0000-7000-8000-000000000001";
+        let child_id = "01a00000-0000-7000-8000-000000000002";
+
+        let dir = tempfile::tempdir().unwrap();
+        let child_path = dir
+            .path()
+            .join(format!("rollout-2026-08-20T18-37-58-{}.jsonl", child_id));
+        let mut f = std::fs::File::create(&child_path).unwrap();
+        f.write_all(
+            format!(
+                r#"{{"type":"session_meta","payload":{{"id":"{}","session_id":"{}","forked_from_id":"{}","thread_source":"subagent","model":"gpt-5.1-codex"}}}}"#,
+                child_id, parent_id, parent_id
+            )
+            .as_bytes(),
+        )
+        .unwrap();
+        f.flush().unwrap();
+
+        let input = json!({
+            "cwd": "/home/user/project",
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Bash",
+            "session_id": parent_id,
+            "tool_use_id": "tu-1",
+            "transcript_path": child_path.to_string_lossy()
+        })
+        .to_string();
+
+        let events = CodexPreset.parse(&input, "t_test123456789a").unwrap();
+        match &events[0] {
+            ParsedHookEvent::PostBashCall(e) => {
+                let source = e.stream_source.as_ref().expect("stream source");
+                assert_eq!(source.external_session_id, child_id);
+                assert_eq!(source.session_id, generate_session_id(child_id, "codex"));
+                assert_eq!(
+                    source.external_parent_session_id.as_deref(),
+                    Some(parent_id),
+                );
+                // Checkpoint attribution keeps the logical session id from
+                // the hook payload.
+                assert_eq!(e.context.external_session_id, parent_id);
+            }
+            _ => panic!("Expected PostBashCall"),
+        }
+    }
+
+    #[test]
+    fn test_codex_plain_session_stream_identity_matches_hook_id() {
+        // The common case: a plain session's hook id IS the rollout filename
+        // UUID, so the filename-derived identity must equal the hook id and
+        // carry no parent — one stream row, same as before the fix.
+        let session = "01a00000-0000-7000-8000-00000000000a";
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir
+            .path()
+            .join(format!("rollout-2026-02-06T20-35-49-{}.jsonl", session));
+        std::fs::write(
+            &path,
+            format!("{{\"type\":\"session_meta\",\"payload\":{{\"id\":\"{session}\"}}}}\n"),
+        )
+        .unwrap();
+
+        let input = json!({
+            "cwd": "/home/user/project",
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Bash",
+            "session_id": session,
+            "tool_use_id": "tu-1",
+            "transcript_path": path.to_string_lossy()
+        })
+        .to_string();
+
+        let events = CodexPreset.parse(&input, "t_test123456789a").unwrap();
+        match &events[0] {
+            ParsedHookEvent::PostBashCall(e) => {
+                let source = e.stream_source.as_ref().expect("stream source");
+                assert_eq!(source.external_session_id, session);
+                assert_eq!(source.external_parent_session_id, None);
             }
             _ => panic!("Expected PostBashCall"),
         }

--- a/src/streams/agents/codex.rs
+++ b/src/streams/agents/codex.rs
@@ -26,6 +26,22 @@ impl CodexAgent {
         Self { batch_size }
     }
 
+    /// Derive the external session id from a rollout file path.
+    ///
+    /// Codex filenames end with the session UUID
+    /// (`rollout-2026-02-06T20-35-49-<uuid>.jsonl`). This is the canonical
+    /// stream identity: sweeps key streams by it, and the checkpoint path
+    /// must match, otherwise the same file gets tracked twice with separate
+    /// watermarks (fork/subagent files report the parent's id in hook
+    /// payloads) and every line is ingested and uploaded twice.
+    pub fn external_session_id_from_rollout_path(path: &Path) -> Option<String> {
+        let stem = path.file_stem().and_then(|s| s.to_str())?;
+        if stem.len() < 36 {
+            return None;
+        }
+        Some(stem[stem.len() - 36..].to_string())
+    }
+
     /// Search for a rollout file matching the given session ID in the Codex home directory.
     ///
     /// Looks in both `sessions` and `archived_sessions` subdirectories for files
@@ -166,14 +182,10 @@ impl Agent for CodexAgent {
 
         for path in paths {
             // Codex filename: rollout-2026-02-06T20-35-49-019c35bd-ad8e-7422-834c-3605bc4ee7ac
-            // The hook payload sends the UUID as session_id/thread_id (last 36 chars)
-            let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+            let Some(external_session_id) = Self::external_session_id_from_rollout_path(&path)
+            else {
                 continue;
             };
-            if stem.len() < 36 {
-                continue;
-            }
-            let external_session_id = stem[stem.len() - 36..].to_string();
             let session_id = generate_session_id(&external_session_id, "codex");
             let external_parent_session_id = Self::detect_subagent_parent(&path);
 
@@ -589,5 +601,31 @@ mod tests {
         let result =
             CodexAgent::detect_subagent_parent(Path::new("/nonexistent/path/rollout.jsonl"));
         assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_external_session_id_from_rollout_path() {
+        // Standard rollout filename: the trailing UUID is the identity.
+        assert_eq!(
+            CodexAgent::external_session_id_from_rollout_path(Path::new(
+                "/x/rollout-2026-02-06T20-35-49-01a00000-0000-7000-8000-000000000001.jsonl"
+            ))
+            .as_deref(),
+            Some("01a00000-0000-7000-8000-000000000001")
+        );
+        // A bare 36-char stem is accepted verbatim.
+        assert_eq!(
+            CodexAgent::external_session_id_from_rollout_path(Path::new(
+                "/x/01a00000-0000-7000-8000-000000000001.jsonl"
+            ))
+            .as_deref(),
+            Some("01a00000-0000-7000-8000-000000000001")
+        );
+        // Too short to hold a UUID: no identity (caller falls back to the
+        // hook-reported id).
+        assert_eq!(
+            CodexAgent::external_session_id_from_rollout_path(Path::new("/x/short.jsonl")),
+            None
+        );
     }
 }

--- a/tests/integration/streams_e2e.rs
+++ b/tests/integration/streams_e2e.rs
@@ -786,3 +786,76 @@ fn test_copilot_agent_streams_otel_path_resolution() {
     assert_eq!(otel_stream.stream_kind, "otel_traces");
     assert!(otel_stream.shared);
 }
+
+#[test]
+fn codex_fork_rollout_checkpoint_tracks_one_stream_keyed_by_filename() {
+    use crate::repos::test_repo::TestRepo;
+    use serde_json::json;
+
+    // A fork/subagent rollout reports the PARENT thread id in hook payloads.
+    // The checkpoint path must key the stream by the rollout FILENAME (like
+    // sweep discovery); keying by the hook id would track the same file a
+    // second time under a different identity and ingest every line twice.
+    let repo = TestRepo::new();
+    let parent_id = "01a00000-0000-7000-8000-0000000000aa";
+    let child_id = "01a00000-0000-7000-8000-0000000000bb";
+
+    let rollout_dir = repo.path().join("rollouts");
+    fs::create_dir_all(&rollout_dir).unwrap();
+    let rollout = rollout_dir.join(format!("rollout-2026-02-06T20-35-49-{child_id}.jsonl"));
+    fs::write(
+        &rollout,
+        format!(
+            "{{\"type\":\"session_meta\",\"payload\":{{\"id\":\"{child_id}\",\"forked_from_id\":\"{parent_id}\",\"thread_source\":\"subagent\",\"model\":\"gpt-5.1-codex\"}}}}\n"
+        ),
+    )
+    .unwrap();
+
+    // Real preset flow: pre/post apply_patch checkpoints carrying the
+    // PARENT id, exactly what codex hooks send from a subagent turn.
+    let file_path = repo.path().join("edited.txt");
+    for hook_event_name in ["PreToolUse", "PostToolUse"] {
+        let hook_input = json!({
+            "cwd": repo.canonical_path().to_string_lossy(),
+            "hook_event_name": hook_event_name,
+            "tool_name": "apply_patch",
+            "tool_use_id": "tu-fork-1",
+            "session_id": parent_id,
+            "transcript_path": rollout.to_string_lossy(),
+            "tool_input": { "patch": format!("*** Update File: {}\n", file_path.to_string_lossy()) }
+        })
+        .to_string();
+        repo.git_ai(&["checkpoint", "codex", "--hook-input", &hook_input])
+            .expect("checkpoint should succeed");
+        if hook_event_name == "PreToolUse" {
+            fs::write(&file_path, "edited\n").unwrap();
+        }
+    }
+    repo.sync_daemon();
+    repo.git_ai(&["await", "--timeout", "60"])
+        .expect("await should drain stream registration");
+
+    let db_path = repo
+        .daemon_home_path()
+        .join(".git-ai")
+        .join("internal")
+        .join("transcripts-db");
+    let db = StreamsDatabase::open(&db_path).unwrap();
+    let rows: Vec<StreamRecord> = db
+        .all_streams()
+        .unwrap()
+        .into_iter()
+        .filter(|r| r.stream_path == rollout.display().to_string())
+        .collect();
+    assert_eq!(
+        rows.len(),
+        1,
+        "the rollout must be tracked exactly once, not once per identity"
+    );
+    assert_eq!(rows[0].external_session_id, child_id, "keyed by filename");
+    assert_eq!(
+        rows[0].external_parent_session_id.as_deref(),
+        Some(parent_id),
+        "parent resolved from session_meta"
+    );
+}


### PR DESCRIPTION
Fork and subagent rollout files report the parent thread's id in hook payloads. The checkpoint-notification path keyed the transcript stream by that id while sweep discovery keys it by the filename UUID, so the same file was tracked twice with independent byte watermarks and every line (including token_count events) was ingested and uploaded twice — once under its own session and again under the parent's.

Derive the stream identity from the resolved rollout filename exactly like sweep discovery, and populate the subagent parent from the file's session_meta.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/2204" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->