### PR TITLE
Add token-usage state database with dedup and bucket aggregation

### DIFF
--- a/src/token_usage/claude.rs
+++ b/src/token_usage/claude.rs
@@ -38,19 +38,41 @@ impl UsageExtractor for ClaudeUsageExtractor {
     }
 }
 
+/// The fields the replacement policy compares. Built from a fresh
+/// [`UsageEntry`] or from a stored database row.
+#[derive(Debug, Clone, Copy)]
+pub struct ReplacementCandidate {
+    pub is_sidechain: bool,
+    pub token_total: u64,
+    pub has_speed: bool,
+}
+
+impl From<&UsageEntry> for ReplacementCandidate {
+    fn from(entry: &UsageEntry) -> Self {
+        Self {
+            is_sidechain: entry.is_sidechain,
+            token_total: entry.dedupe_token_total(),
+            has_speed: entry.has_speed,
+        }
+    }
+}
+
 /// Replacement policy for two entries sharing a dedup identity (ccusage
 /// `should_replace_deduped_entry`): non-sidechain beats sidechain, then the
 /// larger token total wins, then a `usage.speed` marker breaks the tie.
-pub fn should_replace_entry(candidate: &UsageEntry, existing: &UsageEntry) -> bool {
+pub fn should_replace(candidate: ReplacementCandidate, existing: ReplacementCandidate) -> bool {
     if candidate.is_sidechain != existing.is_sidechain {
         return existing.is_sidechain;
     }
-    let candidate_total = candidate.dedupe_token_total();
-    let existing_total = existing.dedupe_token_total();
-    if candidate_total != existing_total {
-        return candidate_total > existing_total;
+    if candidate.token_total != existing.token_total {
+        return candidate.token_total > existing.token_total;
     }
     candidate.has_speed && !existing.has_speed
+}
+
+/// [`should_replace`] over full entries.
+pub fn should_replace_entry(candidate: &UsageEntry, existing: &UsageEntry) -> bool {
+    should_replace(candidate.into(), existing.into())
 }
 
 #[derive(Deserialize)]

--- a/src/token_usage/db.rs
+++ b/src/token_usage/db.rs
@@ -6,20 +6,30 @@
 //! - `tracked_files`: the authoritative read cursor (byte offset) and
 //!   serialized extractor state per transcript file,
 //! - `usage_entries`: deduplicated per-entry token usage,
-//! - `bucket_state`: the fingerprint of the last emitted aggregate per
-//!   `(session_id, model, bucket_ts)`, so unchanged buckets are never
-//!   re-emitted.
+//! - `bucket_state`: the fingerprint and revision of the last emitted
+//!   aggregate per `(session_id, model, bucket_ts)`, so unchanged buckets are
+//!   never re-emitted.
 //!
 //! Keeping the cursor here (rather than in the streams database) matters:
 //! [`TokenUsageDatabase::commit_batch`] writes the entries, the extractor
 //! state, and the advanced cursor in a single transaction, so a crash can
 //! never replay lines against post-batch parser state.
 //!
+//! Entry deduplication is **global across sessions**, matching ccusage's
+//! whole-files dedup: `claude --resume`/`--continue`/fork writes a new
+//! transcript whose leading lines are copies of the parent conversation with
+//! the original message/request ids, and git-ai tracks that file as a new
+//! session. A session-scoped dedup would re-count the copied history on
+//! every resume. The first-seen row keeps the entry (and its session
+//! attribution); the replacement policy can move a row to the replacing
+//! session, in which case [`TokenUsageDatabase::commit_batch`] reports the
+//! previous session so its buckets can be reconciled too.
+//!
 //! Changed buckets are found by *reconciliation*, not change tracking:
-//! [`TokenUsageDatabase::session_buckets`] enumerates every bucket the
-//! session has entries or emission state for, and the caller re-emits those
-//! whose current aggregate fingerprint differs from the emitted one. Because
-//! no pending-emission state lives in memory, a crash or failed emission is
+//! [`TokenUsageDatabase::changed_buckets`] aggregates every bucket the
+//! session has entries or emission state for in one pass and returns those
+//! whose fingerprint differs from the last emitted one. Because no
+//! pending-emission state lives in memory, a crash or failed emission is
 //! healed by the next pass over the session.
 
 use std::path::Path;
@@ -87,7 +97,25 @@ const MIGRATIONS: &[&str] = &[
 
     INSERT INTO schema_version (version) VALUES (1);
     "#,
+    // Version 2: global dedup indexes (resume/fork dedup crosses sessions),
+    // pending-flush marker + error backoff timestamp on tracked files, and a
+    // per-bucket emission revision.
+    r#"
+    CREATE INDEX IF NOT EXISTS idx_usage_entries_key
+        ON usage_entries(entry_key);
+    CREATE INDEX IF NOT EXISTS idx_usage_entries_message_global
+        ON usage_entries(message_id) WHERE message_id IS NOT NULL;
+
+    ALTER TABLE tracked_files ADD COLUMN pending_flush INTEGER NOT NULL DEFAULT 0;
+    ALTER TABLE tracked_files ADD COLUMN last_error_at INTEGER;
+    ALTER TABLE bucket_state ADD COLUMN emit_seq INTEGER NOT NULL DEFAULT 0;
+
+    INSERT INTO schema_version (version) VALUES (2);
+    "#,
 ];
+
+const TRACKED_FILE_COLUMNS: &str = "session_id, stream_path, tool, byte_offset, state_json, \
+     last_known_size, last_modified, processing_errors, last_error_at, pending_flush";
 
 /// A tracked transcript file: read cursor plus extractor state.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -100,6 +128,25 @@ pub struct TrackedFile {
     pub last_known_size: i64,
     pub last_modified: Option<i64>,
     pub processing_errors: i64,
+    pub last_error_at: Option<i64>,
+    /// The extractor reported buffered entries at the end of the last pass;
+    /// the file must be re-processed even if its bytes have not changed.
+    pub pending_flush: bool,
+}
+
+fn read_tracked_file(row: &rusqlite::Row<'_>) -> rusqlite::Result<TrackedFile> {
+    Ok(TrackedFile {
+        session_id: row.get(0)?,
+        stream_path: row.get(1)?,
+        tool: row.get(2)?,
+        byte_offset: row.get::<_, i64>(3)?.max(0) as u64,
+        state_json: row.get(4)?,
+        last_known_size: row.get(5)?,
+        last_modified: row.get(6)?,
+        processing_errors: row.get(7)?,
+        last_error_at: row.get(8)?,
+        pending_flush: row.get(9)?,
+    })
 }
 
 /// The aggregate of one `(session_id, model, bucket_ts)` bucket, i.e. exactly
@@ -136,6 +183,41 @@ impl BucketAggregate {
     }
 }
 
+/// One reconciliation candidate: a bucket whose current aggregate differs
+/// from the last emitted fingerprint.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChangedBucket {
+    pub model: String,
+    pub bucket_ts: u32,
+    pub aggregate: BucketAggregate,
+    /// Revision of the last emission for this bucket (0 when never emitted).
+    /// The next emission carries `emit_seq + 1` so the server can order
+    /// same-second re-emissions.
+    pub emit_seq: u64,
+}
+
+/// One extracted batch to persist atomically.
+pub struct BatchCommit<'a> {
+    pub session_id: &'a str,
+    pub stream_path: &'a str,
+    pub entries: &'a [UsageEntry],
+    pub new_offset: u64,
+    pub state_json: Option<&'a str>,
+    /// The extractor still holds buffered entries (see
+    /// `UsageExtractor::has_pending`).
+    pub pending_flush: bool,
+    /// Retention cutoff: entries whose bucket falls before this are dropped
+    /// instead of inserted, so backfill never uploads history the next prune
+    /// would delete.
+    pub min_bucket_ts: u32,
+}
+
+/// Clamp a token count for an INTEGER column (defensive: corrupt transcripts
+/// can carry absurd values).
+fn to_db_i64(value: u64) -> i64 {
+    value.min(i64::MAX as u64) as i64
+}
+
 /// SQLite database for token-usage state.
 pub struct TokenUsageDatabase {
     conn: Arc<Mutex<Connection>>,
@@ -154,6 +236,21 @@ impl TokenUsageDatabase {
         };
         db.migrate()?;
         Ok(db)
+    }
+
+    /// Best-effort removal of the database files (main + WAL/SHM). Used when
+    /// the feature flag is off so no collected data is retained.
+    pub fn remove_database_files(path: &Path) {
+        for suffix in ["", "-wal", "-shm"] {
+            let mut file = path.as_os_str().to_owned();
+            file.push(suffix);
+            let file = std::path::PathBuf::from(file);
+            if file.exists()
+                && let Err(e) = std::fs::remove_file(&file)
+            {
+                tracing::warn!(error = %e, path = %file.display(), "failed to remove token-usage database file");
+            }
+        }
     }
 
     fn lock(&self) -> MutexGuard<'_, Connection> {
@@ -211,87 +308,146 @@ impl TokenUsageDatabase {
             params![session_id, stream_path, tool],
         )?;
         Ok(conn.query_row(
-            "SELECT session_id, stream_path, tool, byte_offset, state_json,
-                    last_known_size, last_modified, processing_errors
-             FROM tracked_files WHERE session_id = ?1 AND stream_path = ?2",
+            &format!(
+                "SELECT {TRACKED_FILE_COLUMNS} FROM tracked_files
+                 WHERE session_id = ?1 AND stream_path = ?2"
+            ),
             params![session_id, stream_path],
-            |row| {
-                Ok(TrackedFile {
-                    session_id: row.get(0)?,
-                    stream_path: row.get(1)?,
-                    tool: row.get(2)?,
-                    byte_offset: row.get::<_, i64>(3)?.max(0) as u64,
-                    state_json: row.get(4)?,
-                    last_known_size: row.get(5)?,
-                    last_modified: row.get(6)?,
-                    processing_errors: row.get(7)?,
-                })
-            },
+            read_tracked_file,
         )?)
     }
 
     /// All tracked files (sweep enumeration).
     pub fn all_files(&self) -> Result<Vec<TrackedFile>, GitAiError> {
         let conn = self.lock();
-        let mut stmt = conn.prepare(
-            "SELECT session_id, stream_path, tool, byte_offset, state_json,
-                    last_known_size, last_modified, processing_errors
-             FROM tracked_files",
-        )?;
-        let rows = stmt.query_map([], |row| {
-            Ok(TrackedFile {
-                session_id: row.get(0)?,
-                stream_path: row.get(1)?,
-                tool: row.get(2)?,
-                byte_offset: row.get::<_, i64>(3)?.max(0) as u64,
-                state_json: row.get(4)?,
-                last_known_size: row.get(5)?,
-                last_modified: row.get(6)?,
-                processing_errors: row.get(7)?,
-            })
-        })?;
+        let mut stmt =
+            conn.prepare(&format!("SELECT {TRACKED_FILE_COLUMNS} FROM tracked_files"))?;
+        let rows = stmt.query_map([], read_tracked_file)?;
         Ok(rows.collect::<Result<Vec<_>, _>>()?)
     }
 
     /// Persist one extracted batch atomically: deduplicated entries, the
     /// advanced read cursor, and the extractor state. Clears any recorded
-    /// processing error.
-    pub fn commit_batch(
-        &self,
-        session_id: &str,
-        stream_path: &str,
-        entries: &[UsageEntry],
-        new_offset: u64,
-        state_json: Option<&str>,
-    ) -> Result<(), GitAiError> {
+    /// processing error. Returns the *other* sessions whose rows were
+    /// replaced by this batch (resume/fork dedup can move an entry between
+    /// sessions), so their buckets can be reconciled too.
+    pub fn commit_batch(&self, batch: &BatchCommit<'_>) -> Result<Vec<String>, GitAiError> {
         let mut conn = self.lock();
         let tx = conn.transaction()?;
-        for entry in entries {
-            upsert_entry(&tx, session_id, entry)?;
+        let mut foreign_sessions: Vec<String> = Vec::new();
+        for entry in batch.entries {
+            if bucket_ts(entry.ts) < batch.min_bucket_ts {
+                continue;
+            }
+            if let Some(previous_session) = upsert_entry(&tx, batch.session_id, entry)?
+                && !foreign_sessions.contains(&previous_session)
+            {
+                foreign_sessions.push(previous_session);
+            }
         }
         tx.execute(
             "UPDATE tracked_files
-             SET byte_offset = ?1, state_json = ?2, processing_errors = 0, last_error = NULL
-             WHERE session_id = ?3 AND stream_path = ?4",
-            params![new_offset as i64, state_json, session_id, stream_path],
+             SET byte_offset = ?1, state_json = ?2, pending_flush = ?3,
+                 processing_errors = 0, last_error = NULL, last_error_at = NULL
+             WHERE session_id = ?4 AND stream_path = ?5",
+            params![
+                batch.new_offset as i64,
+                batch.state_json,
+                batch.pending_flush,
+                batch.session_id,
+                batch.stream_path
+            ],
         )?;
         tx.commit()?;
-        Ok(())
+        Ok(foreign_sessions)
     }
 
-    /// Every `(model, bucket_ts)` the session has entries or emission state
-    /// for — the reconciliation candidates. Buckets present only in
-    /// `bucket_state` (all their entries were replaced away or pruned) are
-    /// included so an emptied bucket can re-emit as zero.
-    pub fn session_buckets(&self, session_id: &str) -> Result<Vec<(String, u32)>, GitAiError> {
+    /// Reconcile the session in one pass: aggregate every bucket it has
+    /// entries or emission state for, and return those whose fingerprint
+    /// differs from the last emitted one (including buckets that emptied to
+    /// zero, which are present only in `bucket_state`).
+    pub fn changed_buckets(&self, session_id: &str) -> Result<Vec<ChangedBucket>, GitAiError> {
         let conn = self.lock();
+
+        // (model, bucket_ts) -> (fingerprint, emit_seq) of the last emission.
         let mut stmt = conn.prepare(
-            "SELECT model, bucket_ts FROM usage_entries WHERE session_id = ?1
-             UNION
-             SELECT model, bucket_ts FROM bucket_state WHERE session_id = ?1",
+            "SELECT model, bucket_ts, emitted_fingerprint, emit_seq
+             FROM bucket_state WHERE session_id = ?1",
         )?;
-        let rows = stmt.query_map(params![session_id], |row| Ok((row.get(0)?, row.get(1)?)))?;
-        Ok(rows.collect::<Result<Vec<_>, _>>()?)
+        let emitted: Vec<(String, u32, String, i64)> = stmt
+            .query_map(params![session_id], |row| {
+                Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?))
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+        let mut emitted: std::collections::HashMap<(String, u32), (String, u64)> = emitted
+            .into_iter()
+            .map(|(model, bucket, fp, seq)| ((model, bucket), (fp, seq.max(0) as u64)))
+            .collect();
+
+        let mut stmt = conn.prepare(
+            "SELECT model, bucket_ts,
+                    COALESCE(SUM(input_tokens), 0),
+                    COALESCE(SUM(output_tokens), 0),
+                    COALESCE(SUM(cache_read_tokens), 0),
+                    COALESCE(SUM(cache_write_tokens), 0),
+                    COUNT(reasoning_output_tokens),
+                    COALESCE(SUM(reasoning_output_tokens), 0),
+                    COALESCE(SUM(total_tokens), 0),
+                    COALESCE(SUM(cost_micro_usd), 0),
+                    COUNT(*)
+             FROM usage_entries
+             WHERE session_id = ?1
+             GROUP BY model, bucket_ts",
+        )?;
+        let aggregates: Vec<(String, u32, BucketAggregate)> = stmt
+            .query_map(params![session_id], |row| {
+                let reasoning_entries: i64 = row.get(6)?;
+                Ok((
+                    row.get(0)?,
+                    row.get(1)?,
+                    BucketAggregate {
+                        input: row.get::<_, i64>(2)? as u64,
+                        output: row.get::<_, i64>(3)? as u64,
+                        cache_read: row.get::<_, i64>(4)? as u64,
+                        cache_write: row.get::<_, i64>(5)? as u64,
+                        reasoning_output: (reasoning_entries > 0)
+                            .then(|| row.get::<_, i64>(7).map(|v| v as u64))
+                            .transpose()?,
+                        total: row.get::<_, i64>(8)? as u64,
+                        cost_micro_usd: row.get::<_, i64>(9)? as u64,
+                        message_count: row.get::<_, i64>(10)? as u32,
+                    },
+                ))
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let mut changed = Vec::new();
+        for (model, bucket, aggregate) in aggregates {
+            let last = emitted.remove(&(model.clone(), bucket));
+            let emit_seq = last.as_ref().map_or(0, |(_, seq)| *seq);
+            if last.map(|(fp, _)| fp).as_deref() != Some(aggregate.fingerprint().as_str()) {
+                changed.push(ChangedBucket {
+                    model,
+                    bucket_ts: bucket,
+                    aggregate,
+                    emit_seq,
+                });
+            }
+        }
+        // Buckets with emission state but no remaining entries: emptied, and
+        // re-emitted as zero unless zero was already emitted.
+        for ((model, bucket), (fingerprint, emit_seq)) in emitted {
+            let aggregate = BucketAggregate::default();
+            if fingerprint != aggregate.fingerprint() {
+                changed.push(ChangedBucket {
+                    model,
+                    bucket_ts: bucket,
+                    aggregate,
+                    emit_seq,
+                });
+            }
+        }
+        Ok(changed)
     }
 
     /// Update the file-size/mtime snapshot used to skip unchanged files.
@@ -316,12 +472,13 @@ impl TokenUsageDatabase {
         session_id: &str,
         stream_path: &str,
         error: &str,
+        now_ts: i64,
     ) -> Result<(), GitAiError> {
         self.lock().execute(
             "UPDATE tracked_files
-             SET processing_errors = processing_errors + 1, last_error = ?1
-             WHERE session_id = ?2 AND stream_path = ?3",
-            params![error, session_id, stream_path],
+             SET processing_errors = processing_errors + 1, last_error = ?1, last_error_at = ?2
+             WHERE session_id = ?3 AND stream_path = ?4",
+            params![error, now_ts, session_id, stream_path],
         )?;
         Ok(())
     }
@@ -383,37 +540,49 @@ impl TokenUsageDatabase {
     }
 
     /// Record that the bucket's current aggregate was handed to the metrics
-    /// pipeline.
+    /// pipeline as revision `emit_seq`.
     pub fn mark_emitted(
         &self,
         session_id: &str,
         model: &str,
         bucket: u32,
         fingerprint: &str,
+        emit_seq: u64,
         now_ts: i64,
     ) -> Result<(), GitAiError> {
         self.lock().execute(
-            "INSERT INTO bucket_state (session_id, model, bucket_ts, emitted_fingerprint, last_emitted_at)
-             VALUES (?1, ?2, ?3, ?4, ?5)
+            "INSERT INTO bucket_state (session_id, model, bucket_ts, emitted_fingerprint, emit_seq, last_emitted_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)
              ON CONFLICT(session_id, model, bucket_ts)
-             DO UPDATE SET emitted_fingerprint = ?4, last_emitted_at = ?5",
-            params![session_id, model, bucket, fingerprint, now_ts],
+             DO UPDATE SET emitted_fingerprint = ?4, emit_seq = ?5, last_emitted_at = ?6",
+            params![
+                session_id,
+                model,
+                bucket,
+                fingerprint,
+                to_db_i64(emit_seq),
+                now_ts
+            ],
         )?;
         Ok(())
     }
 
     /// Retention prune: drop entries and bucket state older than the cutoff
-    /// bucket. Cursors are monotonic, so pruned history is never re-read.
+    /// bucket, atomically (a partial prune would leave orphan bucket_state
+    /// rows that re-emit zero over real historical data). Cursors are
+    /// monotonic, so pruned history is never re-read.
     pub fn prune_buckets_before(&self, cutoff_bucket_ts: u32) -> Result<usize, GitAiError> {
-        let conn = self.lock();
-        let entries = conn.execute(
+        let mut conn = self.lock();
+        let tx = conn.transaction()?;
+        let entries = tx.execute(
             "DELETE FROM usage_entries WHERE bucket_ts < ?1",
             params![cutoff_bucket_ts],
         )?;
-        conn.execute(
+        tx.execute(
             "DELETE FROM bucket_state WHERE bucket_ts < ?1",
             params![cutoff_bucket_ts],
         )?;
+        tx.commit()?;
         Ok(entries)
     }
 }
@@ -421,49 +590,57 @@ impl TokenUsageDatabase {
 /// A stored entry's dedup-relevant fields.
 struct ExistingRow {
     rowid: i64,
+    session_id: String,
     replacement: ReplacementCandidate,
 }
 
 /// Insert one entry with ccusage's dedup semantics: exact `(message_id,
 /// request_id)` identity first (encoded in `entry_key`), then the
 /// message-id-only fallback for sidechain replays, with the replacement
-/// policy deciding winners.
+/// policy deciding winners. Both lookups are global (see the module docs).
+/// Returns the previous owner's session id when a replacement moved the row
+/// between sessions.
 fn upsert_entry(
     tx: &Transaction<'_>,
     session_id: &str,
     entry: &UsageEntry,
-) -> Result<(), GitAiError> {
+) -> Result<Option<String>, GitAiError> {
     let bucket = bucket_ts(entry.ts);
-    let existing = find_dedupe_target(tx, session_id, entry)?;
+    let existing = find_dedupe_target(tx, entry)?;
     match existing {
         Some(row) => {
             if should_replace(entry.into(), row.replacement) {
                 tx.execute(
                     "UPDATE usage_entries SET
-                        entry_key = ?1, message_id = ?2, model = ?3, bucket_ts = ?4,
-                        input_tokens = ?5, output_tokens = ?6, cache_read_tokens = ?7,
-                        cache_write_tokens = ?8, reasoning_output_tokens = ?9,
-                        total_tokens = ?10, cost_micro_usd = ?11, is_sidechain = ?12,
-                        has_speed = ?13
-                     WHERE rowid = ?14",
+                        session_id = ?1, entry_key = ?2, message_id = ?3, model = ?4,
+                        bucket_ts = ?5, input_tokens = ?6, output_tokens = ?7,
+                        cache_read_tokens = ?8, cache_write_tokens = ?9,
+                        reasoning_output_tokens = ?10, total_tokens = ?11,
+                        cost_micro_usd = ?12, is_sidechain = ?13, has_speed = ?14
+                     WHERE rowid = ?15",
                     params![
+                        session_id,
                         entry.entry_key,
                         entry.message_id,
                         entry.model,
                         bucket,
-                        entry.tokens.input as i64,
-                        entry.tokens.output as i64,
-                        entry.tokens.cache_read as i64,
-                        entry.tokens.cache_write as i64,
-                        entry.tokens.reasoning_output.map(|v| v as i64),
-                        entry.tokens.total as i64,
-                        entry_cost_micro_usd(entry).map(|v| v as i64),
+                        to_db_i64(entry.tokens.input),
+                        to_db_i64(entry.tokens.output),
+                        to_db_i64(entry.tokens.cache_read),
+                        to_db_i64(entry.tokens.cache_write),
+                        entry.tokens.reasoning_output.map(to_db_i64),
+                        to_db_i64(entry.tokens.total),
+                        entry_cost_micro_usd(entry).map(to_db_i64),
                         entry.is_sidechain,
                         entry.has_speed,
                         row.rowid,
                     ],
                 )?;
+                if row.session_id != session_id {
+                    return Ok(Some(row.session_id));
+                }
             }
+            Ok(None)
         }
         None => {
             tx.execute(
@@ -479,50 +656,51 @@ fn upsert_entry(
                     entry.message_id,
                     entry.model,
                     bucket,
-                    entry.tokens.input as i64,
-                    entry.tokens.output as i64,
-                    entry.tokens.cache_read as i64,
-                    entry.tokens.cache_write as i64,
-                    entry.tokens.reasoning_output.map(|v| v as i64),
-                    entry.tokens.total as i64,
-                    entry_cost_micro_usd(entry).map(|v| v as i64),
+                    to_db_i64(entry.tokens.input),
+                    to_db_i64(entry.tokens.output),
+                    to_db_i64(entry.tokens.cache_read),
+                    to_db_i64(entry.tokens.cache_write),
+                    entry.tokens.reasoning_output.map(to_db_i64),
+                    to_db_i64(entry.tokens.total),
+                    entry_cost_micro_usd(entry).map(to_db_i64),
                     entry.is_sidechain,
                     entry.has_speed,
                 ],
             )?;
+            Ok(None)
         }
     }
-    Ok(())
 }
 
 fn find_dedupe_target(
     tx: &Transaction<'_>,
-    session_id: &str,
     entry: &UsageEntry,
 ) -> Result<Option<ExistingRow>, GitAiError> {
     let read_row = |row: &rusqlite::Row<'_>| -> rusqlite::Result<ExistingRow> {
-        let token_total = row.get::<_, i64>(1)? as u64
-            + row.get::<_, i64>(2)? as u64
-            + row.get::<_, i64>(3)? as u64
-            + row.get::<_, i64>(4)? as u64;
+        let token_total = (row.get::<_, i64>(2)? as u64)
+            .saturating_add(row.get::<_, i64>(3)? as u64)
+            .saturating_add(row.get::<_, i64>(4)? as u64)
+            .saturating_add(row.get::<_, i64>(5)? as u64);
         Ok(ExistingRow {
             rowid: row.get(0)?,
+            session_id: row.get(1)?,
             replacement: ReplacementCandidate {
                 token_total,
-                is_sidechain: row.get(5)?,
-                has_speed: row.get(6)?,
+                is_sidechain: row.get(6)?,
+                has_speed: row.get(7)?,
             },
         })
     };
-    const ROW_COLUMNS: &str = "rowid, input_tokens, output_tokens, \
+    const ROW_COLUMNS: &str = "rowid, session_id, input_tokens, output_tokens, \
                                cache_read_tokens, cache_write_tokens, is_sidechain, has_speed";
 
     let exact = tx
         .query_row(
             &format!(
-                "SELECT {ROW_COLUMNS} FROM usage_entries WHERE session_id = ?1 AND entry_key = ?2"
+                "SELECT {ROW_COLUMNS} FROM usage_entries WHERE entry_key = ?1
+                 ORDER BY rowid LIMIT 1"
             ),
-            params![session_id, entry.entry_key],
+            params![entry.entry_key],
             read_row,
         )
         .optional()?;
@@ -538,14 +716,11 @@ fn find_dedupe_target(
     };
     let mut stmt = tx.prepare(&format!(
         "SELECT {ROW_COLUMNS} FROM usage_entries
-         WHERE session_id = ?1 AND message_id = ?2 AND (?3 OR is_sidechain)
+         WHERE message_id = ?1 AND (?2 OR is_sidechain)
          ORDER BY rowid LIMIT 1"
     ))?;
     Ok(stmt
-        .query_row(
-            params![session_id, message_id, entry.is_sidechain],
-            read_row,
-        )
+        .query_row(params![message_id, entry.is_sidechain], read_row)
         .optional()?)
 }
 
@@ -584,9 +759,23 @@ mod tests {
         }
     }
 
+    fn commit_for(db: &TokenUsageDatabase, session: &str, entries: &[UsageEntry]) -> Vec<String> {
+        let path = format!("/{session}.jsonl");
+        db.ensure_file(session, &path, "claude").unwrap();
+        db.commit_batch(&BatchCommit {
+            session_id: session,
+            stream_path: &path,
+            entries,
+            new_offset: 0,
+            state_json: None,
+            pending_flush: false,
+            min_bucket_ts: 0,
+        })
+        .unwrap()
+    }
+
     fn commit(db: &TokenUsageDatabase, entries: &[UsageEntry]) {
-        db.ensure_file("s1", "/t.jsonl", "claude").unwrap();
-        db.commit_batch("s1", "/t.jsonl", entries, 0, None).unwrap()
+        commit_for(db, "s1", entries);
     }
 
     #[test]
@@ -594,10 +783,10 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("token-usage-db");
         let db = TokenUsageDatabase::open(&path).unwrap();
-        assert_eq!(db.schema_version().unwrap(), 1);
+        assert_eq!(db.schema_version().unwrap(), 2);
         drop(db);
         let db = TokenUsageDatabase::open(&path).unwrap();
-        assert_eq!(db.schema_version().unwrap(), 1);
+        assert_eq!(db.schema_version().unwrap(), 2);
     }
 
     #[test]
@@ -606,29 +795,88 @@ mod tests {
         let file = db.ensure_file("s1", "/t.jsonl", "claude").unwrap();
         assert_eq!(file.byte_offset, 0);
         assert_eq!(file.state_json, None);
-        db.commit_batch("s1", "/t.jsonl", &[], 42, Some("{\"x\":1}"))
-            .unwrap();
+        assert!(!file.pending_flush);
+        db.commit_batch(&BatchCommit {
+            session_id: "s1",
+            stream_path: "/t.jsonl",
+            entries: &[],
+            new_offset: 42,
+            state_json: Some("{\"x\":1}"),
+            pending_flush: true,
+            min_bucket_ts: 0,
+        })
+        .unwrap();
         let file = db.ensure_file("s1", "/t.jsonl", "claude").unwrap();
         assert_eq!(file.byte_offset, 42);
         assert_eq!(file.state_json.as_deref(), Some("{\"x\":1}"));
+        assert!(file.pending_flush);
     }
 
     #[test]
-    fn commit_batch_is_atomic_for_cursor_state_and_entries() {
+    fn commit_batch_persists_entries_and_reports_changed_buckets() {
         let (_dir, db) = db();
         commit(&db, &[entry("m1|r1", Some("m1"), 600, tokens(10, 5))]);
-        assert_eq!(
-            db.session_buckets("s1").unwrap(),
-            vec![("claude-sonnet-4-20250514".to_string(), 600)]
-        );
-        let agg = db
-            .aggregate_bucket("s1", "claude-sonnet-4-20250514", 600)
-            .unwrap();
+        let changed = db.changed_buckets("s1").unwrap();
+        assert_eq!(changed.len(), 1);
+        assert_eq!(changed[0].model, "claude-sonnet-4-20250514");
+        assert_eq!(changed[0].bucket_ts, 600);
+        assert_eq!(changed[0].emit_seq, 0);
+        let agg = changed[0].aggregate;
         assert_eq!(agg.input, 10);
         assert_eq!(agg.output, 5);
         assert_eq!(agg.message_count, 1);
         assert_eq!(agg.cost_micro_usd, 1_000);
         assert_eq!(agg.reasoning_output, None);
+    }
+
+    #[test]
+    fn resumed_session_does_not_recount_copied_history() {
+        // claude --resume copies the parent conversation into a NEW session
+        // file with the original message/request ids; dedup must be global.
+        let (_dir, db) = db();
+        commit_for(&db, "s1", &[entry("m1|r1", Some("m1"), 600, tokens(10, 5))]);
+        let foreign = commit_for(&db, "s2", &[entry("m1|r1", Some("m1"), 600, tokens(10, 5))]);
+        assert!(foreign.is_empty(), "identical copy must not replace");
+        // The entry stays attributed to the first-seen session.
+        assert_eq!(
+            db.aggregate_bucket("s1", "claude-sonnet-4-20250514", 600)
+                .unwrap()
+                .message_count,
+            1
+        );
+        assert_eq!(
+            db.aggregate_bucket("s2", "claude-sonnet-4-20250514", 600)
+                .unwrap()
+                .message_count,
+            0
+        );
+    }
+
+    #[test]
+    fn cross_session_replacement_reports_the_previous_owner() {
+        // The resumed copy carries larger totals (the original was a partial
+        // streaming re-emit): the replacement moves the entry to the new
+        // session, and the old session is reported for reconciliation.
+        let (_dir, db) = db();
+        commit_for(&db, "s1", &[entry("m1|r1", Some("m1"), 600, tokens(10, 5))]);
+        let foreign = commit_for(
+            &db,
+            "s2",
+            &[entry("m1|r1", Some("m1"), 600, tokens(10, 50))],
+        );
+        assert_eq!(foreign, vec!["s1".to_string()]);
+        assert_eq!(
+            db.aggregate_bucket("s1", "claude-sonnet-4-20250514", 600)
+                .unwrap()
+                .message_count,
+            0
+        );
+        assert_eq!(
+            db.aggregate_bucket("s2", "claude-sonnet-4-20250514", 600)
+                .unwrap()
+                .output,
+            50
+        );
     }
 
     #[test]
@@ -642,10 +890,7 @@ mod tests {
         // therefore the emission fingerprint) is unchanged.
         commit(&db, &[e]);
         assert_eq!(db.aggregate_bucket("s1", model, 600).unwrap(), before);
-        let agg = db
-            .aggregate_bucket("s1", "claude-sonnet-4-20250514", 600)
-            .unwrap();
-        assert_eq!(agg.message_count, 1);
+        assert_eq!(before.message_count, 1);
     }
 
     #[test]
@@ -720,49 +965,72 @@ mod tests {
     }
 
     #[test]
-    fn replacement_across_buckets_keeps_both_reconciliation_candidates() {
+    fn changed_buckets_skips_unchanged_and_reports_emptied() {
         let (_dir, db) = db();
+        let model = "claude-sonnet-4-20250514";
         commit(&db, &[entry("m1|r1", Some("m1"), 600, tokens(10, 5))]);
-        let model = "claude-sonnet-4-20250514".to_string();
-        db.mark_emitted("s1", &model, 600, "fp-old", 1).unwrap();
-        // Streaming re-emit landed in the next bucket with larger totals: the
-        // emptied bucket stays visible via bucket_state, the new one via its
-        // entry.
+        let changed = db.changed_buckets("s1").unwrap();
+        assert_eq!(changed.len(), 1);
+        db.mark_emitted(
+            "s1",
+            model,
+            600,
+            &changed[0].aggregate.fingerprint(),
+            changed[0].emit_seq + 1,
+            1,
+        )
+        .unwrap();
+        // Nothing changed: no candidates.
+        assert!(db.changed_buckets("s1").unwrap().is_empty());
+
+        // The entry moves to the next bucket: the emptied bucket re-emits
+        // zero (with the bumped revision) and the new bucket emits.
         commit(&db, &[entry("m1|r1", Some("m1"), 900, tokens(10, 50))]);
-        let mut buckets = db.session_buckets("s1").unwrap();
-        buckets.sort();
-        assert_eq!(buckets, vec![(model.clone(), 600), (model.clone(), 900)]);
-        assert_eq!(
-            db.aggregate_bucket("s1", &model, 600)
-                .unwrap()
-                .message_count,
-            0
-        );
-        assert_eq!(
-            db.aggregate_bucket("s1", &model, 900)
-                .unwrap()
-                .message_count,
-            1
-        );
+        let mut changed = db.changed_buckets("s1").unwrap();
+        changed.sort_by_key(|c| c.bucket_ts);
+        assert_eq!(changed.len(), 2);
+        assert_eq!(changed[0].bucket_ts, 600);
+        assert_eq!(changed[0].aggregate, BucketAggregate::default());
+        assert_eq!(changed[0].emit_seq, 1);
+        assert_eq!(changed[1].bucket_ts, 900);
+        assert_eq!(changed[1].aggregate.output, 50);
+        assert_eq!(changed[1].emit_seq, 0);
+
+        // Emit the zero once; it never comes back.
+        db.mark_emitted(
+            "s1",
+            model,
+            600,
+            &BucketAggregate::default().fingerprint(),
+            2,
+            2,
+        )
+        .unwrap();
+        let changed = db.changed_buckets("s1").unwrap();
+        assert_eq!(changed.len(), 1);
+        assert_eq!(changed[0].bucket_ts, 900);
     }
 
     #[test]
-    fn emptied_bucket_aggregates_to_zero_with_changed_fingerprint() {
+    fn entries_before_the_retention_cutoff_are_dropped_at_insert() {
         let (_dir, db) = db();
-        commit(&db, &[entry("m1|r1", Some("m1"), 600, tokens(10, 5))]);
-        let model = "claude-sonnet-4-20250514";
-        let before = db.aggregate_bucket("s1", model, 600).unwrap();
-        db.mark_emitted("s1", model, 600, &before.fingerprint(), 1)
-            .unwrap();
-
-        commit(&db, &[entry("m1|r1", Some("m1"), 900, tokens(10, 50))]);
-        let after = db.aggregate_bucket("s1", model, 600).unwrap();
-        assert_eq!(after, BucketAggregate::default());
-        assert_ne!(after.fingerprint(), before.fingerprint());
-        assert_eq!(
-            db.emitted_fingerprint("s1", model, 600).unwrap().as_deref(),
-            Some(before.fingerprint().as_str())
-        );
+        db.ensure_file("s1", "/t.jsonl", "claude").unwrap();
+        db.commit_batch(&BatchCommit {
+            session_id: "s1",
+            stream_path: "/t.jsonl",
+            entries: &[
+                entry("m1|r1", Some("m1"), 600, tokens(10, 5)),
+                entry("m2|r2", Some("m2"), 999_900, tokens(1, 1)),
+            ],
+            new_offset: 0,
+            state_json: None,
+            pending_flush: false,
+            min_bucket_ts: 900,
+        })
+        .unwrap();
+        let changed = db.changed_buckets("s1").unwrap();
+        assert_eq!(changed.len(), 1);
+        assert_eq!(changed[0].bucket_ts, 999_900);
     }
 
     #[test]
@@ -809,24 +1077,43 @@ mod tests {
     }
 
     #[test]
+    fn absurd_token_values_clamp_instead_of_wrapping() {
+        let (_dir, db) = db();
+        let mut e = entry("m1|r1", Some("m1"), 600, tokens(0, 1));
+        e.tokens.input = u64::MAX;
+        e.tokens.total = u64::MAX;
+        e.transcript_cost_micro_usd = Some(1);
+        commit(&db, &[e]);
+        let agg = db
+            .aggregate_bucket("s1", "claude-sonnet-4-20250514", 600)
+            .unwrap();
+        assert_eq!(agg.input, i64::MAX as u64);
+        assert_eq!(agg.total, i64::MAX as u64);
+    }
+
+    #[test]
     fn record_error_tracks_and_commit_clears() {
         let (_dir, db) = db();
         db.ensure_file("s1", "/t.jsonl", "claude").unwrap();
-        db.record_error("s1", "/t.jsonl", "boom").unwrap();
-        db.record_error("s1", "/t.jsonl", "boom again").unwrap();
-        assert_eq!(
-            db.ensure_file("s1", "/t.jsonl", "claude")
-                .unwrap()
-                .processing_errors,
-            2
-        );
-        db.commit_batch("s1", "/t.jsonl", &[], 10, None).unwrap();
-        assert_eq!(
-            db.ensure_file("s1", "/t.jsonl", "claude")
-                .unwrap()
-                .processing_errors,
-            0
-        );
+        db.record_error("s1", "/t.jsonl", "boom", 100).unwrap();
+        db.record_error("s1", "/t.jsonl", "boom again", 200)
+            .unwrap();
+        let file = db.ensure_file("s1", "/t.jsonl", "claude").unwrap();
+        assert_eq!(file.processing_errors, 2);
+        assert_eq!(file.last_error_at, Some(200));
+        db.commit_batch(&BatchCommit {
+            session_id: "s1",
+            stream_path: "/t.jsonl",
+            entries: &[],
+            new_offset: 10,
+            state_json: None,
+            pending_flush: false,
+            min_bucket_ts: 0,
+        })
+        .unwrap();
+        let file = db.ensure_file("s1", "/t.jsonl", "claude").unwrap();
+        assert_eq!(file.processing_errors, 0);
+        assert_eq!(file.last_error_at, None);
     }
 
     #[test]
@@ -841,7 +1128,7 @@ mod tests {
     }
 
     #[test]
-    fn prune_drops_old_buckets_and_state() {
+    fn prune_drops_old_buckets_and_state_atomically() {
         let (_dir, db) = db();
         commit(
             &db,
@@ -851,18 +1138,29 @@ mod tests {
             ],
         );
         let model = "claude-sonnet-4-20250514";
-        db.mark_emitted("s1", model, 600, "fp", 1).unwrap();
+        db.mark_emitted("s1", model, 600, "fp", 1, 1).unwrap();
         assert_eq!(db.prune_buckets_before(999_000).unwrap(), 1);
         assert_eq!(
             db.aggregate_bucket("s1", model, 600).unwrap().message_count,
             0
         );
         assert_eq!(db.emitted_fingerprint("s1", model, 600).unwrap(), None);
-        assert_eq!(
-            db.aggregate_bucket("s1", model, 999_900)
-                .unwrap()
-                .message_count,
-            1
-        );
+        // No orphan bucket_state row: the emptied old bucket is NOT a
+        // reconciliation candidate after the prune.
+        let changed = db.changed_buckets("s1").unwrap();
+        assert_eq!(changed.len(), 1);
+        assert_eq!(changed[0].bucket_ts, 999_900);
+    }
+
+    #[test]
+    fn remove_database_files_deletes_main_and_wal() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("token-usage-db");
+        let db = TokenUsageDatabase::open(&path).unwrap();
+        drop(db);
+        assert!(path.exists());
+        TokenUsageDatabase::remove_database_files(&path);
+        assert!(!path.exists());
+        assert!(!path.with_file_name("token-usage-db-wal").exists());
     }
 }

--- a/src/token_usage/db.rs
+++ b/src/token_usage/db.rs
@@ -450,6 +450,19 @@ impl TokenUsageDatabase {
         Ok(changed)
     }
 
+    /// Invalidate the quiet-skip snapshot of every file tracked under the
+    /// session, forcing the next sweep or notification to re-process and
+    /// reconcile it. Used when a cross-session replacement changed a bucket
+    /// of a session that is not currently being processed.
+    pub fn invalidate_session_files(&self, session_id: &str) -> Result<(), GitAiError> {
+        self.lock().execute(
+            "UPDATE tracked_files SET last_known_size = -1, last_modified = NULL
+             WHERE session_id = ?1",
+            params![session_id],
+        )?;
+        Ok(())
+    }
+
     /// Update the file-size/mtime snapshot used to skip unchanged files.
     pub fn update_file_metadata(
         &self,
@@ -1114,6 +1127,18 @@ mod tests {
         let file = db.ensure_file("s1", "/t.jsonl", "claude").unwrap();
         assert_eq!(file.processing_errors, 0);
         assert_eq!(file.last_error_at, None);
+    }
+
+    #[test]
+    fn invalidate_session_files_defeats_the_quiet_skip_snapshot() {
+        let (_dir, db) = db();
+        db.ensure_file("s1", "/t.jsonl", "claude").unwrap();
+        db.update_file_metadata("s1", "/t.jsonl", 1234, Some(99))
+            .unwrap();
+        db.invalidate_session_files("s1").unwrap();
+        let file = db.ensure_file("s1", "/t.jsonl", "claude").unwrap();
+        assert_eq!(file.last_known_size, -1);
+        assert_eq!(file.last_modified, None);
     }
 
     #[test]

--- a/src/token_usage/db.rs
+++ b/src/token_usage/db.rs
@@ -212,10 +212,16 @@ pub struct BatchCommit<'a> {
     pub min_bucket_ts: u32,
 }
 
+/// Ceiling for any stored token count: one trillion tokens per entry, far
+/// beyond anything real. Clamping to a small fraction of i64::MAX (rather
+/// than i64::MAX itself) keeps `SUM()` over a bucket from overflowing SQLite
+/// integer arithmetic even with millions of clamped rows.
+const TOKEN_VALUE_CEILING: u64 = 1_000_000_000_000;
+
 /// Clamp a token count for an INTEGER column (defensive: corrupt transcripts
 /// can carry absurd values).
 fn to_db_i64(value: u64) -> i64 {
-    value.min(i64::MAX as u64) as i64
+    value.min(TOKEN_VALUE_CEILING) as i64
 }
 
 /// SQLite database for token-usage state.
@@ -1092,16 +1098,22 @@ mod tests {
     #[test]
     fn absurd_token_values_clamp_instead_of_wrapping() {
         let (_dir, db) = db();
-        let mut e = entry("m1|r1", Some("m1"), 600, tokens(0, 1));
-        e.tokens.input = u64::MAX;
-        e.tokens.total = u64::MAX;
-        e.transcript_cost_micro_usd = Some(1);
-        commit(&db, &[e]);
+        // Two clamped rows in one bucket: the aggregate SUM must not
+        // overflow SQLite integer arithmetic (which would make the session's
+        // reconciliation error forever).
+        for (key, msg) in [("m1|r1", "m1"), ("m2|r2", "m2")] {
+            let mut e = entry(key, Some(msg), 600, tokens(0, 1));
+            e.tokens.input = u64::MAX;
+            e.tokens.total = u64::MAX;
+            e.transcript_cost_micro_usd = Some(1);
+            commit(&db, &[e]);
+        }
         let agg = db
             .aggregate_bucket("s1", "claude-sonnet-4-20250514", 600)
             .unwrap();
-        assert_eq!(agg.input, i64::MAX as u64);
-        assert_eq!(agg.total, i64::MAX as u64);
+        assert_eq!(agg.input, 2 * TOKEN_VALUE_CEILING);
+        assert_eq!(agg.total, 2 * TOKEN_VALUE_CEILING);
+        assert_eq!(db.changed_buckets("s1").unwrap().len(), 1);
     }
 
     #[test]

--- a/src/token_usage/db.rs
+++ b/src/token_usage/db.rs
@@ -22,8 +22,10 @@
 //! session. A session-scoped dedup would re-count the copied history on
 //! every resume. The first-seen row keeps the entry (and its session
 //! attribution); the replacement policy can move a row to the replacing
-//! session, in which case [`TokenUsageDatabase::commit_batch`] reports the
-//! previous session so its buckets can be reconciled too.
+//! session, in which case [`TokenUsageDatabase::commit_batch`] durably flags
+//! the previous session (`needs_reconcile`, same transaction) so its buckets
+//! are re-reconciled — without needing that session's files — even across
+//! crashes or after its transcripts were deleted.
 //!
 //! Changed buckets are found by *reconciliation*, not change tracking:
 //! [`TokenUsageDatabase::changed_buckets`] aggregates every bucket the
@@ -97,17 +99,26 @@ const MIGRATIONS: &[&str] = &[
 
     INSERT INTO schema_version (version) VALUES (1);
     "#,
-    // Version 2: global dedup indexes (resume/fork dedup crosses sessions),
-    // pending-flush marker + error backoff timestamp on tracked files, and a
-    // per-bucket emission revision.
+    // Version 2: global dedup (resume/fork dedup crosses sessions),
+    // pending-flush marker + error backoff timestamp + rollup identity on
+    // tracked files, a durable cross-session reconcile flag, and a
+    // per-bucket emission revision. A v1 database may hold cross-session
+    // duplicate keys (its dedup was session-scoped); the first-seen row wins
+    // so the unique index can be created and later replacements cannot
+    // collide on the primary key.
     r#"
-    CREATE INDEX IF NOT EXISTS idx_usage_entries_key
+    DELETE FROM usage_entries WHERE rowid NOT IN (
+        SELECT MIN(rowid) FROM usage_entries GROUP BY entry_key
+    );
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_usage_entries_key
         ON usage_entries(entry_key);
     CREATE INDEX IF NOT EXISTS idx_usage_entries_message_global
         ON usage_entries(message_id) WHERE message_id IS NOT NULL;
 
     ALTER TABLE tracked_files ADD COLUMN pending_flush INTEGER NOT NULL DEFAULT 0;
     ALTER TABLE tracked_files ADD COLUMN last_error_at INTEGER;
+    ALTER TABLE tracked_files ADD COLUMN external_session_id TEXT NOT NULL DEFAULT '';
+    ALTER TABLE tracked_files ADD COLUMN needs_reconcile INTEGER NOT NULL DEFAULT 0;
     ALTER TABLE bucket_state ADD COLUMN emit_seq INTEGER NOT NULL DEFAULT 0;
 
     INSERT INTO schema_version (version) VALUES (2);
@@ -115,7 +126,8 @@ const MIGRATIONS: &[&str] = &[
 ];
 
 const TRACKED_FILE_COLUMNS: &str = "session_id, stream_path, tool, byte_offset, state_json, \
-     last_known_size, last_modified, processing_errors, last_error_at, pending_flush";
+     last_known_size, last_modified, processing_errors, last_error_at, pending_flush, \
+     external_session_id, needs_reconcile";
 
 /// A tracked transcript file: read cursor plus extractor state.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -132,6 +144,12 @@ pub struct TrackedFile {
     /// The extractor reported buffered entries at the end of the last pass;
     /// the file must be re-processed even if its bytes have not changed.
     pub pending_flush: bool,
+    /// External id of the rollup session (for emission attributes when the
+    /// session is reconciled without reading any file).
+    pub external_session_id: String,
+    /// A cross-session replacement changed this session's buckets; it must
+    /// be re-reconciled even if none of its files change (or still exist).
+    pub needs_reconcile: bool,
 }
 
 fn read_tracked_file(row: &rusqlite::Row<'_>) -> rusqlite::Result<TrackedFile> {
@@ -146,6 +164,8 @@ fn read_tracked_file(row: &rusqlite::Row<'_>) -> rusqlite::Result<TrackedFile> {
         processing_errors: row.get(7)?,
         last_error_at: row.get(8)?,
         pending_flush: row.get(9)?,
+        external_session_id: row.get(10)?,
+        needs_reconcile: row.get(11)?,
     })
 }
 
@@ -285,7 +305,13 @@ impl TokenUsageDatabase {
         };
         for (version, migration_sql) in MIGRATIONS.iter().enumerate() {
             if current_version < (version + 1) as u32 {
-                conn.execute_batch(migration_sql)?;
+                // Each migration commits atomically: a crash between the
+                // statements of a partially applied script (e.g. after one
+                // ALTER but before the version row) would otherwise make
+                // every later open() fail forever on re-application.
+                let tx = conn.unchecked_transaction()?;
+                tx.execute_batch(migration_sql)?;
+                tx.commit()?;
             }
         }
         Ok(())
@@ -302,16 +328,26 @@ impl TokenUsageDatabase {
     }
 
     /// Fetch the tracked file row, creating it with a zero cursor when new.
+    /// The rollup session's external id is recorded (or backfilled on rows
+    /// from before it was tracked) so the session can later be reconciled
+    /// without reading any file.
     pub fn ensure_file(
         &self,
         session_id: &str,
         stream_path: &str,
         tool: &str,
+        external_session_id: &str,
     ) -> Result<TrackedFile, GitAiError> {
         let conn = self.lock();
         conn.execute(
-            "INSERT OR IGNORE INTO tracked_files (session_id, stream_path, tool) VALUES (?1, ?2, ?3)",
-            params![session_id, stream_path, tool],
+            "INSERT OR IGNORE INTO tracked_files (session_id, stream_path, tool, external_session_id)
+             VALUES (?1, ?2, ?3, ?4)",
+            params![session_id, stream_path, tool, external_session_id],
+        )?;
+        conn.execute(
+            "UPDATE tracked_files SET external_session_id = ?3
+             WHERE session_id = ?1 AND stream_path = ?2 AND external_session_id = ''",
+            params![session_id, stream_path, external_session_id],
         )?;
         Ok(conn.query_row(
             &format!(
@@ -334,21 +370,22 @@ impl TokenUsageDatabase {
 
     /// Persist one extracted batch atomically: deduplicated entries, the
     /// advanced read cursor, and the extractor state. Clears any recorded
-    /// processing error. Returns the *other* sessions whose rows were
-    /// replaced by this batch (resume/fork dedup can move an entry between
-    /// sessions), so their buckets can be reconciled too.
-    pub fn commit_batch(&self, batch: &BatchCommit<'_>) -> Result<Vec<String>, GitAiError> {
+    /// processing error. When resume/fork dedup moved an entry away from
+    /// another session, that session's `needs_reconcile` flag is set in the
+    /// same transaction, so the pending re-reconciliation survives crashes,
+    /// interrupts, and even the deletion of that session's transcripts.
+    pub fn commit_batch(&self, batch: &BatchCommit<'_>) -> Result<(), GitAiError> {
         let mut conn = self.lock();
         let tx = conn.transaction()?;
-        let mut foreign_sessions: Vec<String> = Vec::new();
         for entry in batch.entries {
             if bucket_ts(entry.ts) < batch.min_bucket_ts {
                 continue;
             }
-            if let Some(previous_session) = upsert_entry(&tx, batch.session_id, entry)?
-                && !foreign_sessions.contains(&previous_session)
-            {
-                foreign_sessions.push(previous_session);
+            if let Some(previous_session) = upsert_entry(&tx, batch.session_id, entry)? {
+                tx.execute(
+                    "UPDATE tracked_files SET needs_reconcile = 1 WHERE session_id = ?1",
+                    params![previous_session],
+                )?;
             }
         }
         tx.execute(
@@ -365,7 +402,28 @@ impl TokenUsageDatabase {
             ],
         )?;
         tx.commit()?;
-        Ok(foreign_sessions)
+        Ok(())
+    }
+
+    /// Sessions flagged for re-reconciliation by a cross-session replacement,
+    /// with the identity needed to emit without reading any file.
+    pub fn sessions_needing_reconcile(&self) -> Result<Vec<(String, String, String)>, GitAiError> {
+        let conn = self.lock();
+        let mut stmt = conn.prepare(
+            "SELECT DISTINCT session_id, external_session_id, tool
+             FROM tracked_files WHERE needs_reconcile = 1",
+        )?;
+        let rows = stmt.query_map([], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)))?;
+        Ok(rows.collect::<Result<Vec<_>, _>>()?)
+    }
+
+    /// Clear the reconcile flag after the session's buckets were reconciled.
+    pub fn clear_needs_reconcile(&self, session_id: &str) -> Result<(), GitAiError> {
+        self.lock().execute(
+            "UPDATE tracked_files SET needs_reconcile = 0 WHERE session_id = ?1",
+            params![session_id],
+        )?;
+        Ok(())
     }
 
     /// Reconcile the session in one pass: aggregate every bucket it has
@@ -456,19 +514,6 @@ impl TokenUsageDatabase {
         Ok(changed)
     }
 
-    /// Invalidate the quiet-skip snapshot of every file tracked under the
-    /// session, forcing the next sweep or notification to re-process and
-    /// reconcile it. Used when a cross-session replacement changed a bucket
-    /// of a session that is not currently being processed.
-    pub fn invalidate_session_files(&self, session_id: &str) -> Result<(), GitAiError> {
-        self.lock().execute(
-            "UPDATE tracked_files SET last_known_size = -1, last_modified = NULL
-             WHERE session_id = ?1",
-            params![session_id],
-        )?;
-        Ok(())
-    }
-
     /// Update the file-size/mtime snapshot used to skip unchanged files.
     pub fn update_file_metadata(
         &self,
@@ -556,6 +601,33 @@ impl TokenUsageDatabase {
                 |row| row.get(0),
             )
             .optional()?)
+    }
+
+    /// Reserve emission revisions *before* events are handed to the sink:
+    /// once a revision may exist in the metrics queue it must never be
+    /// reused, or a crash between sink and fingerprint write would produce
+    /// two payloads with equal revisions and re-open the tie the revision
+    /// exists to eliminate. The fingerprint is deliberately left untouched
+    /// (a placeholder '' on first contact) so a failed sink still
+    /// re-reconciles; a wasted revision number is harmless.
+    pub fn reserve_emit_seqs(
+        &self,
+        session_id: &str,
+        reservations: &[(String, u32, u64)],
+    ) -> Result<(), GitAiError> {
+        let mut conn = self.lock();
+        let tx = conn.transaction()?;
+        for (model, bucket, emit_seq) in reservations {
+            tx.execute(
+                "INSERT INTO bucket_state (session_id, model, bucket_ts, emitted_fingerprint, emit_seq, last_emitted_at)
+                 VALUES (?1, ?2, ?3, '', ?4, 0)
+                 ON CONFLICT(session_id, model, bucket_ts)
+                 DO UPDATE SET emit_seq = ?4",
+                params![session_id, model, bucket, to_db_i64(*emit_seq)],
+            )?;
+        }
+        tx.commit()?;
+        Ok(())
     }
 
     /// Record that the bucket's current aggregate was handed to the metrics
@@ -778,9 +850,10 @@ mod tests {
         }
     }
 
-    fn commit_for(db: &TokenUsageDatabase, session: &str, entries: &[UsageEntry]) -> Vec<String> {
+    fn commit_for(db: &TokenUsageDatabase, session: &str, entries: &[UsageEntry]) {
         let path = format!("/{session}.jsonl");
-        db.ensure_file(session, &path, "claude").unwrap();
+        db.ensure_file(session, &path, "claude", &format!("{session}-ext"))
+            .unwrap();
         db.commit_batch(&BatchCommit {
             session_id: session,
             stream_path: &path,
@@ -811,7 +884,9 @@ mod tests {
     #[test]
     fn ensure_file_creates_zero_cursor_and_is_stable() {
         let (_dir, db) = db();
-        let file = db.ensure_file("s1", "/t.jsonl", "claude").unwrap();
+        let file = db
+            .ensure_file("s1", "/t.jsonl", "claude", "s1-ext")
+            .unwrap();
         assert_eq!(file.byte_offset, 0);
         assert_eq!(file.state_json, None);
         assert!(!file.pending_flush);
@@ -825,7 +900,9 @@ mod tests {
             min_bucket_ts: 0,
         })
         .unwrap();
-        let file = db.ensure_file("s1", "/t.jsonl", "claude").unwrap();
+        let file = db
+            .ensure_file("s1", "/t.jsonl", "claude", "s1-ext")
+            .unwrap();
         assert_eq!(file.byte_offset, 42);
         assert_eq!(file.state_json.as_deref(), Some("{\"x\":1}"));
         assert!(file.pending_flush);
@@ -854,8 +931,9 @@ mod tests {
         // file with the original message/request ids; dedup must be global.
         let (_dir, db) = db();
         commit_for(&db, "s1", &[entry("m1|r1", Some("m1"), 600, tokens(10, 5))]);
-        let foreign = commit_for(&db, "s2", &[entry("m1|r1", Some("m1"), 600, tokens(10, 5))]);
-        assert!(foreign.is_empty(), "identical copy must not replace");
+        commit_for(&db, "s2", &[entry("m1|r1", Some("m1"), 600, tokens(10, 5))]);
+        // Identical copy must not replace, so nothing needs reconciling.
+        assert!(db.sessions_needing_reconcile().unwrap().is_empty());
         // The entry stays attributed to the first-seen session.
         assert_eq!(
             db.aggregate_bucket("s1", "claude-sonnet-4-20250514", 600)
@@ -872,18 +950,25 @@ mod tests {
     }
 
     #[test]
-    fn cross_session_replacement_reports_the_previous_owner() {
+    fn cross_session_replacement_flags_the_previous_owner_durably() {
         // The resumed copy carries larger totals (the original was a partial
         // streaming re-emit): the replacement moves the entry to the new
-        // session, and the old session is reported for reconciliation.
+        // session, and the old session is durably flagged for
+        // reconciliation in the same transaction — identity included, so no
+        // file of that session is ever needed again.
         let (_dir, db) = db();
         commit_for(&db, "s1", &[entry("m1|r1", Some("m1"), 600, tokens(10, 5))]);
-        let foreign = commit_for(
+        commit_for(
             &db,
             "s2",
             &[entry("m1|r1", Some("m1"), 600, tokens(10, 50))],
         );
-        assert_eq!(foreign, vec!["s1".to_string()]);
+        assert_eq!(
+            db.sessions_needing_reconcile().unwrap(),
+            vec![("s1".to_string(), "s1-ext".to_string(), "claude".to_string())]
+        );
+        db.clear_needs_reconcile("s1").unwrap();
+        assert!(db.sessions_needing_reconcile().unwrap().is_empty());
         assert_eq!(
             db.aggregate_bucket("s1", "claude-sonnet-4-20250514", 600)
                 .unwrap()
@@ -1033,7 +1118,8 @@ mod tests {
     #[test]
     fn entries_before_the_retention_cutoff_are_dropped_at_insert() {
         let (_dir, db) = db();
-        db.ensure_file("s1", "/t.jsonl", "claude").unwrap();
+        db.ensure_file("s1", "/t.jsonl", "claude", "s1-ext")
+            .unwrap();
         db.commit_batch(&BatchCommit {
             session_id: "s1",
             stream_path: "/t.jsonl",
@@ -1050,6 +1136,86 @@ mod tests {
         let changed = db.changed_buckets("s1").unwrap();
         assert_eq!(changed.len(), 1);
         assert_eq!(changed[0].bucket_ts, 999_900);
+    }
+
+    #[test]
+    fn v1_databases_with_legacy_cross_session_duplicates_upgrade_cleanly() {
+        // A v1 database (session-scoped dedup) can hold the same entry_key
+        // under several sessions. The v2 migration keeps the first-seen row
+        // and enforces global uniqueness, so a later cross-session
+        // replacement can never collide on the (session_id, entry_key)
+        // primary key and poison the transcript.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("token-usage-db");
+        {
+            let conn = rusqlite::Connection::open(&path).unwrap();
+            conn.execute_batch(MIGRATIONS[0]).unwrap();
+            for session in ["s1", "s2", "s3"] {
+                conn.execute(
+                    "INSERT INTO usage_entries (session_id, entry_key, message_id, model, bucket_ts,
+                         input_tokens, output_tokens, total_tokens)
+                     VALUES (?1, 'm1|r1', 'm1', 'claude-sonnet-4-20250514', 600, 10, 5, 15)",
+                    params![session],
+                )
+                .unwrap();
+            }
+        }
+
+        let db = TokenUsageDatabase::open(&path).unwrap();
+        assert_eq!(db.schema_version().unwrap(), 2);
+        // First-seen row (s1) survives; the duplicates are gone.
+        assert_eq!(
+            db.aggregate_bucket("s1", "claude-sonnet-4-20250514", 600)
+                .unwrap()
+                .message_count,
+            1
+        );
+        assert_eq!(
+            db.aggregate_bucket("s2", "claude-sonnet-4-20250514", 600)
+                .unwrap()
+                .message_count,
+            0
+        );
+        // A cross-session replacement over the legacy key works (this used
+        // to violate the primary key when a duplicate existed).
+        commit_for(
+            &db,
+            "s2",
+            &[entry("m1|r1", Some("m1"), 600, tokens(10, 50))],
+        );
+        assert_eq!(
+            db.aggregate_bucket("s2", "claude-sonnet-4-20250514", 600)
+                .unwrap()
+                .output,
+            50
+        );
+    }
+
+    #[test]
+    fn reserved_revisions_are_never_reused() {
+        // Reservation happens before the sink: a crash between sink and
+        // fingerprint write must not lead to a second payload with an equal
+        // revision.
+        let (_dir, db) = db();
+        let model = "claude-sonnet-4-20250514";
+        commit(&db, &[entry("m1|r1", Some("m1"), 600, tokens(10, 5))]);
+        let changed = db.changed_buckets("s1").unwrap();
+        assert_eq!(changed[0].emit_seq, 0);
+        db.reserve_emit_seqs("s1", &[(model.to_string(), 600, 1)])
+            .unwrap();
+
+        // Fingerprint untouched by the reservation: the bucket still
+        // reconciles (as if the sink crashed), now at the next revision.
+        let changed = db.changed_buckets("s1").unwrap();
+        assert_eq!(changed.len(), 1);
+        assert_eq!(changed[0].emit_seq, 1);
+
+        // Success path completes the emission; nothing left to reconcile.
+        db.reserve_emit_seqs("s1", &[(model.to_string(), 600, 2)])
+            .unwrap();
+        db.mark_emitted("s1", model, 600, &changed[0].aggregate.fingerprint(), 2, 9)
+            .unwrap();
+        assert!(db.changed_buckets("s1").unwrap().is_empty());
     }
 
     #[test]
@@ -1119,11 +1285,14 @@ mod tests {
     #[test]
     fn record_error_tracks_and_commit_clears() {
         let (_dir, db) = db();
-        db.ensure_file("s1", "/t.jsonl", "claude").unwrap();
+        db.ensure_file("s1", "/t.jsonl", "claude", "s1-ext")
+            .unwrap();
         db.record_error("s1", "/t.jsonl", "boom", 100).unwrap();
         db.record_error("s1", "/t.jsonl", "boom again", 200)
             .unwrap();
-        let file = db.ensure_file("s1", "/t.jsonl", "claude").unwrap();
+        let file = db
+            .ensure_file("s1", "/t.jsonl", "claude", "s1-ext")
+            .unwrap();
         assert_eq!(file.processing_errors, 2);
         assert_eq!(file.last_error_at, Some(200));
         db.commit_batch(&BatchCommit {
@@ -1136,30 +1305,23 @@ mod tests {
             min_bucket_ts: 0,
         })
         .unwrap();
-        let file = db.ensure_file("s1", "/t.jsonl", "claude").unwrap();
+        let file = db
+            .ensure_file("s1", "/t.jsonl", "claude", "s1-ext")
+            .unwrap();
         assert_eq!(file.processing_errors, 0);
         assert_eq!(file.last_error_at, None);
     }
 
     #[test]
-    fn invalidate_session_files_defeats_the_quiet_skip_snapshot() {
-        let (_dir, db) = db();
-        db.ensure_file("s1", "/t.jsonl", "claude").unwrap();
-        db.update_file_metadata("s1", "/t.jsonl", 1234, Some(99))
-            .unwrap();
-        db.invalidate_session_files("s1").unwrap();
-        let file = db.ensure_file("s1", "/t.jsonl", "claude").unwrap();
-        assert_eq!(file.last_known_size, -1);
-        assert_eq!(file.last_modified, None);
-    }
-
-    #[test]
     fn file_metadata_roundtrip() {
         let (_dir, db) = db();
-        db.ensure_file("s1", "/t.jsonl", "claude").unwrap();
+        db.ensure_file("s1", "/t.jsonl", "claude", "s1-ext")
+            .unwrap();
         db.update_file_metadata("s1", "/t.jsonl", 1234, Some(99))
             .unwrap();
-        let file = db.ensure_file("s1", "/t.jsonl", "claude").unwrap();
+        let file = db
+            .ensure_file("s1", "/t.jsonl", "claude", "s1-ext")
+            .unwrap();
         assert_eq!(file.last_known_size, 1234);
         assert_eq!(file.last_modified, Some(99));
     }

--- a/src/token_usage/db.rs
+++ b/src/token_usage/db.rs
@@ -1,0 +1,845 @@
+//! Token-usage state database.
+//!
+//! One SQLite database (`~/.git-ai/internal/token-usage-db`) holds everything
+//! the token-usage pipeline needs to stay consistent:
+//!
+//! - `tracked_files`: the authoritative read cursor (byte offset) and
+//!   serialized extractor state per transcript file,
+//! - `usage_entries`: deduplicated per-entry token usage,
+//! - `bucket_state`: the fingerprint of the last emitted aggregate per
+//!   `(session_id, model, bucket_ts)`, so unchanged buckets are never
+//!   re-emitted.
+//!
+//! Keeping the cursor here (rather than in the streams database) matters:
+//! [`TokenUsageDatabase::commit_batch`] writes the entries, the extractor
+//! state, and the advanced cursor in a single transaction, so a crash can
+//! never replay lines against post-batch parser state.
+
+use std::collections::HashSet;
+use std::path::Path;
+use std::sync::{Arc, Mutex, MutexGuard};
+
+use rusqlite::{Connection, OptionalExtension, Transaction, params};
+
+use super::claude::{ReplacementCandidate, should_replace};
+use super::cost::entry_cost_micro_usd;
+use super::types::{UsageEntry, bucket_ts};
+use crate::error::GitAiError;
+
+/// Schema migrations - each entry is SQL to apply for that version.
+const MIGRATIONS: &[&str] = &[
+    // Version 1: Initial schema
+    r#"
+    CREATE TABLE IF NOT EXISTS schema_version (
+        version INTEGER PRIMARY KEY
+    );
+
+    CREATE TABLE IF NOT EXISTS tracked_files (
+        session_id  TEXT NOT NULL,
+        stream_path TEXT NOT NULL,
+        tool        TEXT NOT NULL,
+        byte_offset INTEGER NOT NULL DEFAULT 0,
+        state_json  TEXT,
+        last_known_size INTEGER NOT NULL DEFAULT 0,
+        last_modified INTEGER,
+        processing_errors INTEGER NOT NULL DEFAULT 0,
+        last_error TEXT,
+        PRIMARY KEY (session_id, stream_path)
+    );
+
+    CREATE TABLE IF NOT EXISTS usage_entries (
+        session_id TEXT NOT NULL,
+        entry_key  TEXT NOT NULL,
+        message_id TEXT,
+        model      TEXT NOT NULL,
+        bucket_ts  INTEGER NOT NULL,
+        input_tokens INTEGER NOT NULL DEFAULT 0,
+        output_tokens INTEGER NOT NULL DEFAULT 0,
+        cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+        cache_write_tokens INTEGER NOT NULL DEFAULT 0,
+        reasoning_output_tokens INTEGER,
+        total_tokens INTEGER NOT NULL DEFAULT 0,
+        cost_micro_usd INTEGER,
+        is_sidechain INTEGER NOT NULL DEFAULT 0,
+        has_speed INTEGER NOT NULL DEFAULT 0,
+        PRIMARY KEY (session_id, entry_key)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_usage_entries_bucket
+        ON usage_entries(session_id, model, bucket_ts);
+    CREATE INDEX IF NOT EXISTS idx_usage_entries_message
+        ON usage_entries(session_id, message_id) WHERE message_id IS NOT NULL;
+
+    CREATE TABLE IF NOT EXISTS bucket_state (
+        session_id TEXT NOT NULL,
+        model      TEXT NOT NULL,
+        bucket_ts  INTEGER NOT NULL,
+        emitted_fingerprint TEXT NOT NULL,
+        last_emitted_at INTEGER NOT NULL,
+        PRIMARY KEY (session_id, model, bucket_ts)
+    );
+
+    INSERT INTO schema_version (version) VALUES (1);
+    "#,
+];
+
+/// A tracked transcript file: read cursor plus extractor state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TrackedFile {
+    pub session_id: String,
+    pub stream_path: String,
+    pub tool: String,
+    pub byte_offset: u64,
+    pub state_json: Option<String>,
+    pub last_known_size: i64,
+    pub last_modified: Option<i64>,
+    pub processing_errors: i64,
+}
+
+/// The aggregate of one `(session_id, model, bucket_ts)` bucket, i.e. exactly
+/// the values a TokenUsage event carries.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct BucketAggregate {
+    pub input: u64,
+    pub output: u64,
+    pub cache_read: u64,
+    pub cache_write: u64,
+    /// `Some` iff any entry in the bucket reported reasoning tokens.
+    pub reasoning_output: Option<u64>,
+    pub total: u64,
+    pub cost_micro_usd: u64,
+    pub message_count: u32,
+}
+
+impl BucketAggregate {
+    /// Emission fingerprint: any change to any emitted value - including a
+    /// drop to zero - changes the fingerprint.
+    pub fn fingerprint(&self) -> String {
+        format!(
+            "{}:{}:{}:{}:{}:{}:{}:{}",
+            self.input,
+            self.output,
+            self.cache_read,
+            self.cache_write,
+            self.reasoning_output
+                .map_or_else(|| "-".to_string(), |v| v.to_string()),
+            self.total,
+            self.cost_micro_usd,
+            self.message_count
+        )
+    }
+}
+
+/// A bucket whose aggregate may have changed: re-aggregate, compare
+/// fingerprints, emit on mismatch.
+pub type DirtyBuckets = HashSet<(String, u32)>;
+
+/// SQLite database for token-usage state.
+pub struct TokenUsageDatabase {
+    conn: Arc<Mutex<Connection>>,
+}
+
+impl TokenUsageDatabase {
+    /// Open or create the token-usage database at the given path.
+    pub fn open<P: AsRef<Path>>(path: P) -> Result<Self, GitAiError> {
+        let conn = crate::sqlite::open_with_memory_limits(path.as_ref())?;
+        conn.pragma_update(None, "journal_mode", "WAL")?;
+        conn.pragma_update(None, "synchronous", "NORMAL")?;
+        conn.pragma_update(None, "temp_store", "MEMORY")?;
+
+        let db = Self {
+            conn: Arc::new(Mutex::new(conn)),
+        };
+        db.migrate()?;
+        Ok(db)
+    }
+
+    fn lock(&self) -> MutexGuard<'_, Connection> {
+        self.conn
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    fn migrate(&self) -> Result<(), GitAiError> {
+        let conn = self.lock();
+        let table_exists: bool = conn.query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='schema_version'",
+            [],
+            |row| Ok(row.get::<_, i64>(0)? > 0),
+        )?;
+        let current_version: u32 = if table_exists {
+            conn.query_row(
+                "SELECT version FROM schema_version ORDER BY version DESC LIMIT 1",
+                [],
+                |row| row.get(0),
+            )
+            .optional()?
+            .unwrap_or(0)
+        } else {
+            0
+        };
+        for (version, migration_sql) in MIGRATIONS.iter().enumerate() {
+            if current_version < (version + 1) as u32 {
+                conn.execute_batch(migration_sql)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Current schema version (for tests).
+    #[cfg(test)]
+    fn schema_version(&self) -> Result<u32, GitAiError> {
+        Ok(self.lock().query_row(
+            "SELECT version FROM schema_version ORDER BY version DESC LIMIT 1",
+            [],
+            |row| row.get(0),
+        )?)
+    }
+
+    /// Fetch the tracked file row, creating it with a zero cursor when new.
+    pub fn ensure_file(
+        &self,
+        session_id: &str,
+        stream_path: &str,
+        tool: &str,
+    ) -> Result<TrackedFile, GitAiError> {
+        let conn = self.lock();
+        conn.execute(
+            "INSERT OR IGNORE INTO tracked_files (session_id, stream_path, tool) VALUES (?1, ?2, ?3)",
+            params![session_id, stream_path, tool],
+        )?;
+        Ok(conn.query_row(
+            "SELECT session_id, stream_path, tool, byte_offset, state_json,
+                    last_known_size, last_modified, processing_errors
+             FROM tracked_files WHERE session_id = ?1 AND stream_path = ?2",
+            params![session_id, stream_path],
+            |row| {
+                Ok(TrackedFile {
+                    session_id: row.get(0)?,
+                    stream_path: row.get(1)?,
+                    tool: row.get(2)?,
+                    byte_offset: row.get::<_, i64>(3)?.max(0) as u64,
+                    state_json: row.get(4)?,
+                    last_known_size: row.get(5)?,
+                    last_modified: row.get(6)?,
+                    processing_errors: row.get(7)?,
+                })
+            },
+        )?)
+    }
+
+    /// All tracked files (sweep enumeration).
+    pub fn all_files(&self) -> Result<Vec<TrackedFile>, GitAiError> {
+        let conn = self.lock();
+        let mut stmt = conn.prepare(
+            "SELECT session_id, stream_path, tool, byte_offset, state_json,
+                    last_known_size, last_modified, processing_errors
+             FROM tracked_files",
+        )?;
+        let rows = stmt.query_map([], |row| {
+            Ok(TrackedFile {
+                session_id: row.get(0)?,
+                stream_path: row.get(1)?,
+                tool: row.get(2)?,
+                byte_offset: row.get::<_, i64>(3)?.max(0) as u64,
+                state_json: row.get(4)?,
+                last_known_size: row.get(5)?,
+                last_modified: row.get(6)?,
+                processing_errors: row.get(7)?,
+            })
+        })?;
+        Ok(rows.collect::<Result<Vec<_>, _>>()?)
+    }
+
+    /// Persist one extracted batch atomically: deduplicated entries, the
+    /// advanced read cursor, and the extractor state. Clears any recorded
+    /// processing error. Returns the buckets whose aggregate may have
+    /// changed.
+    pub fn commit_batch(
+        &self,
+        session_id: &str,
+        stream_path: &str,
+        entries: &[UsageEntry],
+        new_offset: u64,
+        state_json: Option<&str>,
+    ) -> Result<DirtyBuckets, GitAiError> {
+        let mut conn = self.lock();
+        let tx = conn.transaction()?;
+        let mut dirty = DirtyBuckets::new();
+        for entry in entries {
+            upsert_entry(&tx, session_id, entry, &mut dirty)?;
+        }
+        tx.execute(
+            "UPDATE tracked_files
+             SET byte_offset = ?1, state_json = ?2, processing_errors = 0, last_error = NULL
+             WHERE session_id = ?3 AND stream_path = ?4",
+            params![new_offset as i64, state_json, session_id, stream_path],
+        )?;
+        tx.commit()?;
+        Ok(dirty)
+    }
+
+    /// Update the file-size/mtime snapshot used to skip unchanged files.
+    pub fn update_file_metadata(
+        &self,
+        session_id: &str,
+        stream_path: &str,
+        size: u64,
+        modified: Option<i64>,
+    ) -> Result<(), GitAiError> {
+        self.lock().execute(
+            "UPDATE tracked_files SET last_known_size = ?1, last_modified = ?2
+             WHERE session_id = ?3 AND stream_path = ?4",
+            params![size as i64, modified, session_id, stream_path],
+        )?;
+        Ok(())
+    }
+
+    /// Record a processing failure for backoff and diagnostics.
+    pub fn record_error(
+        &self,
+        session_id: &str,
+        stream_path: &str,
+        error: &str,
+    ) -> Result<(), GitAiError> {
+        self.lock().execute(
+            "UPDATE tracked_files
+             SET processing_errors = processing_errors + 1, last_error = ?1
+             WHERE session_id = ?2 AND stream_path = ?3",
+            params![error, session_id, stream_path],
+        )?;
+        Ok(())
+    }
+
+    /// Aggregate one bucket. An empty bucket returns all zeros.
+    pub fn aggregate_bucket(
+        &self,
+        session_id: &str,
+        model: &str,
+        bucket: u32,
+    ) -> Result<BucketAggregate, GitAiError> {
+        Ok(self.lock().query_row(
+            "SELECT COALESCE(SUM(input_tokens), 0),
+                    COALESCE(SUM(output_tokens), 0),
+                    COALESCE(SUM(cache_read_tokens), 0),
+                    COALESCE(SUM(cache_write_tokens), 0),
+                    COUNT(reasoning_output_tokens),
+                    COALESCE(SUM(reasoning_output_tokens), 0),
+                    COALESCE(SUM(total_tokens), 0),
+                    COALESCE(SUM(cost_micro_usd), 0),
+                    COUNT(*)
+             FROM usage_entries
+             WHERE session_id = ?1 AND model = ?2 AND bucket_ts = ?3",
+            params![session_id, model, bucket],
+            |row| {
+                let reasoning_entries: i64 = row.get(4)?;
+                Ok(BucketAggregate {
+                    input: row.get::<_, i64>(0)? as u64,
+                    output: row.get::<_, i64>(1)? as u64,
+                    cache_read: row.get::<_, i64>(2)? as u64,
+                    cache_write: row.get::<_, i64>(3)? as u64,
+                    reasoning_output: (reasoning_entries > 0)
+                        .then(|| row.get::<_, i64>(5).map(|v| v as u64))
+                        .transpose()?,
+                    total: row.get::<_, i64>(6)? as u64,
+                    cost_micro_usd: row.get::<_, i64>(7)? as u64,
+                    message_count: row.get::<_, i64>(8)? as u32,
+                })
+            },
+        )?)
+    }
+
+    /// Fingerprint of the last emitted aggregate for the bucket, if any.
+    pub fn emitted_fingerprint(
+        &self,
+        session_id: &str,
+        model: &str,
+        bucket: u32,
+    ) -> Result<Option<String>, GitAiError> {
+        Ok(self
+            .lock()
+            .query_row(
+                "SELECT emitted_fingerprint FROM bucket_state
+                 WHERE session_id = ?1 AND model = ?2 AND bucket_ts = ?3",
+                params![session_id, model, bucket],
+                |row| row.get(0),
+            )
+            .optional()?)
+    }
+
+    /// Record that the bucket's current aggregate was handed to the metrics
+    /// pipeline.
+    pub fn mark_emitted(
+        &self,
+        session_id: &str,
+        model: &str,
+        bucket: u32,
+        fingerprint: &str,
+        now_ts: i64,
+    ) -> Result<(), GitAiError> {
+        self.lock().execute(
+            "INSERT INTO bucket_state (session_id, model, bucket_ts, emitted_fingerprint, last_emitted_at)
+             VALUES (?1, ?2, ?3, ?4, ?5)
+             ON CONFLICT(session_id, model, bucket_ts)
+             DO UPDATE SET emitted_fingerprint = ?4, last_emitted_at = ?5",
+            params![session_id, model, bucket, fingerprint, now_ts],
+        )?;
+        Ok(())
+    }
+
+    /// Retention prune: drop entries and bucket state older than the cutoff
+    /// bucket. Cursors are monotonic, so pruned history is never re-read.
+    pub fn prune_buckets_before(&self, cutoff_bucket_ts: u32) -> Result<usize, GitAiError> {
+        let conn = self.lock();
+        let entries = conn.execute(
+            "DELETE FROM usage_entries WHERE bucket_ts < ?1",
+            params![cutoff_bucket_ts],
+        )?;
+        conn.execute(
+            "DELETE FROM bucket_state WHERE bucket_ts < ?1",
+            params![cutoff_bucket_ts],
+        )?;
+        Ok(entries)
+    }
+}
+
+/// A stored entry's dedup-relevant fields.
+struct ExistingRow {
+    rowid: i64,
+    model: String,
+    bucket_ts: u32,
+    replacement: ReplacementCandidate,
+}
+
+/// Insert one entry with ccusage's dedup semantics: exact `(message_id,
+/// request_id)` identity first (encoded in `entry_key`), then the
+/// message-id-only fallback for sidechain replays, with the replacement
+/// policy deciding winners.
+fn upsert_entry(
+    tx: &Transaction<'_>,
+    session_id: &str,
+    entry: &UsageEntry,
+    dirty: &mut DirtyBuckets,
+) -> Result<(), GitAiError> {
+    let bucket = bucket_ts(entry.ts);
+    let existing = find_dedupe_target(tx, session_id, entry)?;
+    match existing {
+        Some(row) => {
+            if should_replace(entry.into(), row.replacement) {
+                tx.execute(
+                    "UPDATE usage_entries SET
+                        entry_key = ?1, message_id = ?2, model = ?3, bucket_ts = ?4,
+                        input_tokens = ?5, output_tokens = ?6, cache_read_tokens = ?7,
+                        cache_write_tokens = ?8, reasoning_output_tokens = ?9,
+                        total_tokens = ?10, cost_micro_usd = ?11, is_sidechain = ?12,
+                        has_speed = ?13
+                     WHERE rowid = ?14",
+                    params![
+                        entry.entry_key,
+                        entry.message_id,
+                        entry.model,
+                        bucket,
+                        entry.tokens.input as i64,
+                        entry.tokens.output as i64,
+                        entry.tokens.cache_read as i64,
+                        entry.tokens.cache_write as i64,
+                        entry.tokens.reasoning_output.map(|v| v as i64),
+                        entry.tokens.total as i64,
+                        entry_cost_micro_usd(entry).map(|v| v as i64),
+                        entry.is_sidechain,
+                        entry.has_speed,
+                        row.rowid,
+                    ],
+                )?;
+                dirty.insert((row.model, row.bucket_ts));
+                dirty.insert((entry.model.clone(), bucket));
+            }
+        }
+        None => {
+            tx.execute(
+                "INSERT INTO usage_entries (
+                    session_id, entry_key, message_id, model, bucket_ts,
+                    input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
+                    reasoning_output_tokens, total_tokens, cost_micro_usd,
+                    is_sidechain, has_speed
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
+                params![
+                    session_id,
+                    entry.entry_key,
+                    entry.message_id,
+                    entry.model,
+                    bucket,
+                    entry.tokens.input as i64,
+                    entry.tokens.output as i64,
+                    entry.tokens.cache_read as i64,
+                    entry.tokens.cache_write as i64,
+                    entry.tokens.reasoning_output.map(|v| v as i64),
+                    entry.tokens.total as i64,
+                    entry_cost_micro_usd(entry).map(|v| v as i64),
+                    entry.is_sidechain,
+                    entry.has_speed,
+                ],
+            )?;
+            dirty.insert((entry.model.clone(), bucket));
+        }
+    }
+    Ok(())
+}
+
+fn find_dedupe_target(
+    tx: &Transaction<'_>,
+    session_id: &str,
+    entry: &UsageEntry,
+) -> Result<Option<ExistingRow>, GitAiError> {
+    let read_row = |row: &rusqlite::Row<'_>| -> rusqlite::Result<ExistingRow> {
+        let token_total = row.get::<_, i64>(3)? as u64
+            + row.get::<_, i64>(4)? as u64
+            + row.get::<_, i64>(5)? as u64
+            + row.get::<_, i64>(6)? as u64;
+        Ok(ExistingRow {
+            rowid: row.get(0)?,
+            model: row.get(1)?,
+            bucket_ts: row.get(2)?,
+            replacement: ReplacementCandidate {
+                token_total,
+                is_sidechain: row.get(7)?,
+                has_speed: row.get(8)?,
+            },
+        })
+    };
+    const ROW_COLUMNS: &str = "rowid, model, bucket_ts, input_tokens, output_tokens, \
+                               cache_read_tokens, cache_write_tokens, is_sidechain, has_speed";
+
+    let exact = tx
+        .query_row(
+            &format!(
+                "SELECT {ROW_COLUMNS} FROM usage_entries WHERE session_id = ?1 AND entry_key = ?2"
+            ),
+            params![session_id, entry.entry_key],
+            read_row,
+        )
+        .optional()?;
+    if exact.is_some() {
+        return Ok(exact);
+    }
+
+    // Sidechain logs can replay parent messages with new request ids, so a
+    // message-id-only match dedups when either side is a sidechain entry
+    // (ccusage `loaded_entry_matches_sidechain_dedupe_key`).
+    let Some(message_id) = entry.message_id.as_deref() else {
+        return Ok(None);
+    };
+    let mut stmt = tx.prepare(&format!(
+        "SELECT {ROW_COLUMNS} FROM usage_entries
+         WHERE session_id = ?1 AND message_id = ?2 AND (?3 OR is_sidechain)
+         ORDER BY rowid LIMIT 1"
+    ))?;
+    Ok(stmt
+        .query_row(
+            params![session_id, message_id, entry.is_sidechain],
+            read_row,
+        )
+        .optional()?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::token_usage::types::TokenCounts;
+
+    fn db() -> (tempfile::TempDir, TokenUsageDatabase) {
+        let dir = tempfile::tempdir().unwrap();
+        let db = TokenUsageDatabase::open(dir.path().join("token-usage-db")).unwrap();
+        (dir, db)
+    }
+
+    fn entry(key: &str, message_id: Option<&str>, ts: u32, tokens: TokenCounts) -> UsageEntry {
+        UsageEntry {
+            entry_key: key.to_string(),
+            message_id: message_id.map(str::to_string),
+            ts,
+            model: "claude-sonnet-4-20250514".to_string(),
+            tokens,
+            cache_write_1h: 0,
+            transcript_cost_micro_usd: Some(1_000),
+            is_sidechain: false,
+            has_speed: false,
+        }
+    }
+
+    fn tokens(input: u64, output: u64) -> TokenCounts {
+        TokenCounts {
+            input,
+            output,
+            total: input + output,
+            ..Default::default()
+        }
+    }
+
+    fn commit(db: &TokenUsageDatabase, entries: &[UsageEntry]) -> DirtyBuckets {
+        db.ensure_file("s1", "/t.jsonl", "claude").unwrap();
+        db.commit_batch("s1", "/t.jsonl", entries, 0, None).unwrap()
+    }
+
+    #[test]
+    fn migrations_apply_and_are_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("token-usage-db");
+        let db = TokenUsageDatabase::open(&path).unwrap();
+        assert_eq!(db.schema_version().unwrap(), 1);
+        drop(db);
+        let db = TokenUsageDatabase::open(&path).unwrap();
+        assert_eq!(db.schema_version().unwrap(), 1);
+    }
+
+    #[test]
+    fn ensure_file_creates_zero_cursor_and_is_stable() {
+        let (_dir, db) = db();
+        let file = db.ensure_file("s1", "/t.jsonl", "claude").unwrap();
+        assert_eq!(file.byte_offset, 0);
+        assert_eq!(file.state_json, None);
+        db.commit_batch("s1", "/t.jsonl", &[], 42, Some("{\"x\":1}"))
+            .unwrap();
+        let file = db.ensure_file("s1", "/t.jsonl", "claude").unwrap();
+        assert_eq!(file.byte_offset, 42);
+        assert_eq!(file.state_json.as_deref(), Some("{\"x\":1}"));
+    }
+
+    #[test]
+    fn commit_batch_is_atomic_for_cursor_state_and_entries() {
+        let (_dir, db) = db();
+        let dirty = commit(&db, &[entry("m1|r1", Some("m1"), 600, tokens(10, 5))]);
+        assert_eq!(
+            dirty,
+            DirtyBuckets::from([("claude-sonnet-4-20250514".to_string(), 600)])
+        );
+        let agg = db
+            .aggregate_bucket("s1", "claude-sonnet-4-20250514", 600)
+            .unwrap();
+        assert_eq!(agg.input, 10);
+        assert_eq!(agg.output, 5);
+        assert_eq!(agg.message_count, 1);
+        assert_eq!(agg.cost_micro_usd, 1_000);
+        assert_eq!(agg.reasoning_output, None);
+    }
+
+    #[test]
+    fn exact_duplicate_replay_is_a_noop() {
+        let (_dir, db) = db();
+        let e = entry("m1|r1", Some("m1"), 600, tokens(10, 5));
+        assert!(!commit(&db, std::slice::from_ref(&e)).is_empty());
+        // Identical replay: policy keeps the existing row, nothing dirty.
+        assert!(commit(&db, &[e]).is_empty());
+        let agg = db
+            .aggregate_bucket("s1", "claude-sonnet-4-20250514", 600)
+            .unwrap();
+        assert_eq!(agg.message_count, 1);
+    }
+
+    #[test]
+    fn streaming_reemit_with_larger_totals_replaces() {
+        let (_dir, db) = db();
+        commit(&db, &[entry("m1|r1", Some("m1"), 600, tokens(10, 5))]);
+        let dirty = commit(&db, &[entry("m1|r1", Some("m1"), 600, tokens(10, 50))]);
+        assert!(!dirty.is_empty());
+        let agg = db
+            .aggregate_bucket("s1", "claude-sonnet-4-20250514", 600)
+            .unwrap();
+        assert_eq!(agg.output, 50);
+        assert_eq!(agg.message_count, 1);
+        // Smaller totals never replace.
+        assert!(commit(&db, &[entry("m1|r1", Some("m1"), 600, tokens(1, 1))]).is_empty());
+    }
+
+    #[test]
+    fn sidechain_replay_with_new_request_id_dedups_to_parent() {
+        let (_dir, db) = db();
+        commit(&db, &[entry("m1|r1", Some("m1"), 600, tokens(10, 5))]);
+        let mut replay = entry("m1|r2", Some("m1"), 600, tokens(50_000, 5));
+        replay.is_sidechain = true;
+        // The sidechain replay matches the parent's row via message id and
+        // loses to it despite larger totals.
+        assert!(commit(&db, &[replay]).is_empty());
+        let agg = db
+            .aggregate_bucket("s1", "claude-sonnet-4-20250514", 600)
+            .unwrap();
+        assert_eq!(agg.input, 10);
+        assert_eq!(agg.message_count, 1);
+    }
+
+    #[test]
+    fn parent_replaces_earlier_sidechain_replay() {
+        let (_dir, db) = db();
+        let mut replay = entry("m1|r-side", Some("m1"), 600, tokens(50_000, 5));
+        replay.is_sidechain = true;
+        commit(&db, &[replay]);
+        let dirty = commit(&db, &[entry("m1|r1", Some("m1"), 600, tokens(10, 5))]);
+        assert!(!dirty.is_empty());
+        let agg = db
+            .aggregate_bucket("s1", "claude-sonnet-4-20250514", 600)
+            .unwrap();
+        assert_eq!(agg.input, 10);
+        assert_eq!(agg.message_count, 1);
+        // The winner's identity is now the parent's exact key.
+        assert!(commit(&db, &[entry("m1|r1", Some("m1"), 600, tokens(10, 5))]).is_empty());
+    }
+
+    #[test]
+    fn distinct_non_sidechain_request_ids_stay_separate() {
+        // ccusage parity: the message-id fallback only applies when one side
+        // is a sidechain entry.
+        let (_dir, db) = db();
+        commit(&db, &[entry("m1|r1", Some("m1"), 600, tokens(10, 5))]);
+        commit(&db, &[entry("m1|r2", Some("m1"), 600, tokens(7, 3))]);
+        let agg = db
+            .aggregate_bucket("s1", "claude-sonnet-4-20250514", 600)
+            .unwrap();
+        assert_eq!(agg.message_count, 2);
+        assert_eq!(agg.input, 17);
+    }
+
+    #[test]
+    fn replacement_across_buckets_dirties_both() {
+        let (_dir, db) = db();
+        commit(&db, &[entry("m1|r1", Some("m1"), 600, tokens(10, 5))]);
+        // Streaming re-emit landed in the next bucket with larger totals.
+        let dirty = commit(&db, &[entry("m1|r1", Some("m1"), 900, tokens(10, 50))]);
+        let model = "claude-sonnet-4-20250514".to_string();
+        assert_eq!(
+            dirty,
+            DirtyBuckets::from([(model.clone(), 600), (model.clone(), 900)])
+        );
+        assert_eq!(
+            db.aggregate_bucket("s1", &model, 600)
+                .unwrap()
+                .message_count,
+            0
+        );
+        assert_eq!(
+            db.aggregate_bucket("s1", &model, 900)
+                .unwrap()
+                .message_count,
+            1
+        );
+    }
+
+    #[test]
+    fn emptied_bucket_aggregates_to_zero_with_changed_fingerprint() {
+        let (_dir, db) = db();
+        commit(&db, &[entry("m1|r1", Some("m1"), 600, tokens(10, 5))]);
+        let model = "claude-sonnet-4-20250514";
+        let before = db.aggregate_bucket("s1", model, 600).unwrap();
+        db.mark_emitted("s1", model, 600, &before.fingerprint(), 1)
+            .unwrap();
+
+        commit(&db, &[entry("m1|r1", Some("m1"), 900, tokens(10, 50))]);
+        let after = db.aggregate_bucket("s1", model, 600).unwrap();
+        assert_eq!(after, BucketAggregate::default());
+        assert_ne!(after.fingerprint(), before.fingerprint());
+        assert_eq!(
+            db.emitted_fingerprint("s1", model, 600).unwrap().as_deref(),
+            Some(before.fingerprint().as_str())
+        );
+    }
+
+    #[test]
+    fn fingerprint_covers_every_emitted_field() {
+        let base = BucketAggregate {
+            input: 1,
+            output: 2,
+            cache_read: 3,
+            cache_write: 4,
+            reasoning_output: None,
+            total: 10,
+            cost_micro_usd: 5,
+            message_count: 6,
+        };
+        let mut seen = HashSet::from([base.fingerprint()]);
+        for mutate in [
+            (|a: &mut BucketAggregate| a.input += 1) as fn(&mut BucketAggregate),
+            |a| a.output += 1,
+            |a| a.cache_read += 1,
+            |a| a.cache_write += 1,
+            |a| a.reasoning_output = Some(0),
+            |a| a.total += 1,
+            |a| a.cost_micro_usd += 1,
+            |a| a.message_count += 1,
+        ] {
+            let mut variant = base;
+            mutate(&mut variant);
+            assert!(seen.insert(variant.fingerprint()), "fingerprint collision");
+        }
+    }
+
+    #[test]
+    fn reasoning_tokens_aggregate_when_present() {
+        let (_dir, db) = db();
+        let mut codex = entry("codex:1", None, 600, tokens(10, 5));
+        codex.tokens.reasoning_output = Some(4);
+        codex.transcript_cost_micro_usd = None;
+        codex.model = "gpt-5".to_string();
+        commit(&db, &[codex]);
+        let agg = db.aggregate_bucket("s1", "gpt-5", 600).unwrap();
+        assert_eq!(agg.reasoning_output, Some(4));
+        // Cost falls back to the pricing catalog (gpt-5 is in the snapshot).
+        assert!(agg.cost_micro_usd > 0);
+    }
+
+    #[test]
+    fn record_error_tracks_and_commit_clears() {
+        let (_dir, db) = db();
+        db.ensure_file("s1", "/t.jsonl", "claude").unwrap();
+        db.record_error("s1", "/t.jsonl", "boom").unwrap();
+        db.record_error("s1", "/t.jsonl", "boom again").unwrap();
+        assert_eq!(
+            db.ensure_file("s1", "/t.jsonl", "claude")
+                .unwrap()
+                .processing_errors,
+            2
+        );
+        db.commit_batch("s1", "/t.jsonl", &[], 10, None).unwrap();
+        assert_eq!(
+            db.ensure_file("s1", "/t.jsonl", "claude")
+                .unwrap()
+                .processing_errors,
+            0
+        );
+    }
+
+    #[test]
+    fn file_metadata_roundtrip() {
+        let (_dir, db) = db();
+        db.ensure_file("s1", "/t.jsonl", "claude").unwrap();
+        db.update_file_metadata("s1", "/t.jsonl", 1234, Some(99))
+            .unwrap();
+        let file = db.ensure_file("s1", "/t.jsonl", "claude").unwrap();
+        assert_eq!(file.last_known_size, 1234);
+        assert_eq!(file.last_modified, Some(99));
+    }
+
+    #[test]
+    fn prune_drops_old_buckets_and_state() {
+        let (_dir, db) = db();
+        commit(
+            &db,
+            &[
+                entry("m1|r1", Some("m1"), 600, tokens(10, 5)),
+                entry("m2|r2", Some("m2"), 999_900, tokens(1, 1)),
+            ],
+        );
+        let model = "claude-sonnet-4-20250514";
+        db.mark_emitted("s1", model, 600, "fp", 1).unwrap();
+        assert_eq!(db.prune_buckets_before(999_000).unwrap(), 1);
+        assert_eq!(
+            db.aggregate_bucket("s1", model, 600).unwrap().message_count,
+            0
+        );
+        assert_eq!(db.emitted_fingerprint("s1", model, 600).unwrap(), None);
+        assert_eq!(
+            db.aggregate_bucket("s1", model, 999_900)
+                .unwrap()
+                .message_count,
+            1
+        );
+    }
+}

--- a/src/token_usage/db.rs
+++ b/src/token_usage/db.rs
@@ -1148,7 +1148,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("token-usage-db");
         {
-            let conn = rusqlite::Connection::open(&path).unwrap();
+            let conn = crate::sqlite::open_with_memory_limits(&path).unwrap();
             conn.execute_batch(MIGRATIONS[0]).unwrap();
             for session in ["s1", "s2", "s3"] {
                 conn.execute(

--- a/src/token_usage/db.rs
+++ b/src/token_usage/db.rs
@@ -14,8 +14,14 @@
 //! [`TokenUsageDatabase::commit_batch`] writes the entries, the extractor
 //! state, and the advanced cursor in a single transaction, so a crash can
 //! never replay lines against post-batch parser state.
+//!
+//! Changed buckets are found by *reconciliation*, not change tracking:
+//! [`TokenUsageDatabase::session_buckets`] enumerates every bucket the
+//! session has entries or emission state for, and the caller re-emits those
+//! whose current aggregate fingerprint differs from the emitted one. Because
+//! no pending-emission state lives in memory, a crash or failed emission is
+//! healed by the next pass over the session.
 
-use std::collections::HashSet;
 use std::path::Path;
 use std::sync::{Arc, Mutex, MutexGuard};
 
@@ -129,10 +135,6 @@ impl BucketAggregate {
         )
     }
 }
-
-/// A bucket whose aggregate may have changed: re-aggregate, compare
-/// fingerprints, emit on mismatch.
-pub type DirtyBuckets = HashSet<(String, u32)>;
 
 /// SQLite database for token-usage state.
 pub struct TokenUsageDatabase {
@@ -253,8 +255,7 @@ impl TokenUsageDatabase {
 
     /// Persist one extracted batch atomically: deduplicated entries, the
     /// advanced read cursor, and the extractor state. Clears any recorded
-    /// processing error. Returns the buckets whose aggregate may have
-    /// changed.
+    /// processing error.
     pub fn commit_batch(
         &self,
         session_id: &str,
@@ -262,12 +263,11 @@ impl TokenUsageDatabase {
         entries: &[UsageEntry],
         new_offset: u64,
         state_json: Option<&str>,
-    ) -> Result<DirtyBuckets, GitAiError> {
+    ) -> Result<(), GitAiError> {
         let mut conn = self.lock();
         let tx = conn.transaction()?;
-        let mut dirty = DirtyBuckets::new();
         for entry in entries {
-            upsert_entry(&tx, session_id, entry, &mut dirty)?;
+            upsert_entry(&tx, session_id, entry)?;
         }
         tx.execute(
             "UPDATE tracked_files
@@ -276,7 +276,22 @@ impl TokenUsageDatabase {
             params![new_offset as i64, state_json, session_id, stream_path],
         )?;
         tx.commit()?;
-        Ok(dirty)
+        Ok(())
+    }
+
+    /// Every `(model, bucket_ts)` the session has entries or emission state
+    /// for — the reconciliation candidates. Buckets present only in
+    /// `bucket_state` (all their entries were replaced away or pruned) are
+    /// included so an emptied bucket can re-emit as zero.
+    pub fn session_buckets(&self, session_id: &str) -> Result<Vec<(String, u32)>, GitAiError> {
+        let conn = self.lock();
+        let mut stmt = conn.prepare(
+            "SELECT model, bucket_ts FROM usage_entries WHERE session_id = ?1
+             UNION
+             SELECT model, bucket_ts FROM bucket_state WHERE session_id = ?1",
+        )?;
+        let rows = stmt.query_map(params![session_id], |row| Ok((row.get(0)?, row.get(1)?)))?;
+        Ok(rows.collect::<Result<Vec<_>, _>>()?)
     }
 
     /// Update the file-size/mtime snapshot used to skip unchanged files.
@@ -406,8 +421,6 @@ impl TokenUsageDatabase {
 /// A stored entry's dedup-relevant fields.
 struct ExistingRow {
     rowid: i64,
-    model: String,
-    bucket_ts: u32,
     replacement: ReplacementCandidate,
 }
 
@@ -419,7 +432,6 @@ fn upsert_entry(
     tx: &Transaction<'_>,
     session_id: &str,
     entry: &UsageEntry,
-    dirty: &mut DirtyBuckets,
 ) -> Result<(), GitAiError> {
     let bucket = bucket_ts(entry.ts);
     let existing = find_dedupe_target(tx, session_id, entry)?;
@@ -451,8 +463,6 @@ fn upsert_entry(
                         row.rowid,
                     ],
                 )?;
-                dirty.insert((row.model, row.bucket_ts));
-                dirty.insert((entry.model.clone(), bucket));
             }
         }
         None => {
@@ -480,7 +490,6 @@ fn upsert_entry(
                     entry.has_speed,
                 ],
             )?;
-            dirty.insert((entry.model.clone(), bucket));
         }
     }
     Ok(())
@@ -492,22 +501,20 @@ fn find_dedupe_target(
     entry: &UsageEntry,
 ) -> Result<Option<ExistingRow>, GitAiError> {
     let read_row = |row: &rusqlite::Row<'_>| -> rusqlite::Result<ExistingRow> {
-        let token_total = row.get::<_, i64>(3)? as u64
-            + row.get::<_, i64>(4)? as u64
-            + row.get::<_, i64>(5)? as u64
-            + row.get::<_, i64>(6)? as u64;
+        let token_total = row.get::<_, i64>(1)? as u64
+            + row.get::<_, i64>(2)? as u64
+            + row.get::<_, i64>(3)? as u64
+            + row.get::<_, i64>(4)? as u64;
         Ok(ExistingRow {
             rowid: row.get(0)?,
-            model: row.get(1)?,
-            bucket_ts: row.get(2)?,
             replacement: ReplacementCandidate {
                 token_total,
-                is_sidechain: row.get(7)?,
-                has_speed: row.get(8)?,
+                is_sidechain: row.get(5)?,
+                has_speed: row.get(6)?,
             },
         })
     };
-    const ROW_COLUMNS: &str = "rowid, model, bucket_ts, input_tokens, output_tokens, \
+    const ROW_COLUMNS: &str = "rowid, input_tokens, output_tokens, \
                                cache_read_tokens, cache_write_tokens, is_sidechain, has_speed";
 
     let exact = tx
@@ -546,6 +553,7 @@ fn find_dedupe_target(
 mod tests {
     use super::*;
     use crate::token_usage::types::TokenCounts;
+    use std::collections::HashSet;
 
     fn db() -> (tempfile::TempDir, TokenUsageDatabase) {
         let dir = tempfile::tempdir().unwrap();
@@ -576,7 +584,7 @@ mod tests {
         }
     }
 
-    fn commit(db: &TokenUsageDatabase, entries: &[UsageEntry]) -> DirtyBuckets {
+    fn commit(db: &TokenUsageDatabase, entries: &[UsageEntry]) {
         db.ensure_file("s1", "/t.jsonl", "claude").unwrap();
         db.commit_batch("s1", "/t.jsonl", entries, 0, None).unwrap()
     }
@@ -608,10 +616,10 @@ mod tests {
     #[test]
     fn commit_batch_is_atomic_for_cursor_state_and_entries() {
         let (_dir, db) = db();
-        let dirty = commit(&db, &[entry("m1|r1", Some("m1"), 600, tokens(10, 5))]);
+        commit(&db, &[entry("m1|r1", Some("m1"), 600, tokens(10, 5))]);
         assert_eq!(
-            dirty,
-            DirtyBuckets::from([("claude-sonnet-4-20250514".to_string(), 600)])
+            db.session_buckets("s1").unwrap(),
+            vec![("claude-sonnet-4-20250514".to_string(), 600)]
         );
         let agg = db
             .aggregate_bucket("s1", "claude-sonnet-4-20250514", 600)
@@ -627,9 +635,13 @@ mod tests {
     fn exact_duplicate_replay_is_a_noop() {
         let (_dir, db) = db();
         let e = entry("m1|r1", Some("m1"), 600, tokens(10, 5));
-        assert!(!commit(&db, std::slice::from_ref(&e)).is_empty());
-        // Identical replay: policy keeps the existing row, nothing dirty.
-        assert!(commit(&db, &[e]).is_empty());
+        commit(&db, std::slice::from_ref(&e));
+        let model = "claude-sonnet-4-20250514";
+        let before = db.aggregate_bucket("s1", model, 600).unwrap();
+        // Identical replay: policy keeps the existing row, aggregate (and
+        // therefore the emission fingerprint) is unchanged.
+        commit(&db, &[e]);
+        assert_eq!(db.aggregate_bucket("s1", model, 600).unwrap(), before);
         let agg = db
             .aggregate_bucket("s1", "claude-sonnet-4-20250514", 600)
             .unwrap();
@@ -640,15 +652,19 @@ mod tests {
     fn streaming_reemit_with_larger_totals_replaces() {
         let (_dir, db) = db();
         commit(&db, &[entry("m1|r1", Some("m1"), 600, tokens(10, 5))]);
-        let dirty = commit(&db, &[entry("m1|r1", Some("m1"), 600, tokens(10, 50))]);
-        assert!(!dirty.is_empty());
+        commit(&db, &[entry("m1|r1", Some("m1"), 600, tokens(10, 50))]);
         let agg = db
             .aggregate_bucket("s1", "claude-sonnet-4-20250514", 600)
             .unwrap();
         assert_eq!(agg.output, 50);
         assert_eq!(agg.message_count, 1);
         // Smaller totals never replace.
-        assert!(commit(&db, &[entry("m1|r1", Some("m1"), 600, tokens(1, 1))]).is_empty());
+        commit(&db, &[entry("m1|r1", Some("m1"), 600, tokens(1, 1))]);
+        assert_eq!(
+            db.aggregate_bucket("s1", "claude-sonnet-4-20250514", 600)
+                .unwrap(),
+            agg
+        );
     }
 
     #[test]
@@ -659,7 +675,7 @@ mod tests {
         replay.is_sidechain = true;
         // The sidechain replay matches the parent's row via message id and
         // loses to it despite larger totals.
-        assert!(commit(&db, &[replay]).is_empty());
+        commit(&db, &[replay]);
         let agg = db
             .aggregate_bucket("s1", "claude-sonnet-4-20250514", 600)
             .unwrap();
@@ -673,15 +689,20 @@ mod tests {
         let mut replay = entry("m1|r-side", Some("m1"), 600, tokens(50_000, 5));
         replay.is_sidechain = true;
         commit(&db, &[replay]);
-        let dirty = commit(&db, &[entry("m1|r1", Some("m1"), 600, tokens(10, 5))]);
-        assert!(!dirty.is_empty());
+        commit(&db, &[entry("m1|r1", Some("m1"), 600, tokens(10, 5))]);
         let agg = db
             .aggregate_bucket("s1", "claude-sonnet-4-20250514", 600)
             .unwrap();
         assert_eq!(agg.input, 10);
         assert_eq!(agg.message_count, 1);
-        // The winner's identity is now the parent's exact key.
-        assert!(commit(&db, &[entry("m1|r1", Some("m1"), 600, tokens(10, 5))]).is_empty());
+        // The winner's identity is now the parent's exact key: replaying the
+        // parent entry again leaves the aggregate untouched.
+        commit(&db, &[entry("m1|r1", Some("m1"), 600, tokens(10, 5))]);
+        assert_eq!(
+            db.aggregate_bucket("s1", "claude-sonnet-4-20250514", 600)
+                .unwrap(),
+            agg
+        );
     }
 
     #[test]
@@ -699,16 +720,18 @@ mod tests {
     }
 
     #[test]
-    fn replacement_across_buckets_dirties_both() {
+    fn replacement_across_buckets_keeps_both_reconciliation_candidates() {
         let (_dir, db) = db();
         commit(&db, &[entry("m1|r1", Some("m1"), 600, tokens(10, 5))]);
-        // Streaming re-emit landed in the next bucket with larger totals.
-        let dirty = commit(&db, &[entry("m1|r1", Some("m1"), 900, tokens(10, 50))]);
         let model = "claude-sonnet-4-20250514".to_string();
-        assert_eq!(
-            dirty,
-            DirtyBuckets::from([(model.clone(), 600), (model.clone(), 900)])
-        );
+        db.mark_emitted("s1", &model, 600, "fp-old", 1).unwrap();
+        // Streaming re-emit landed in the next bucket with larger totals: the
+        // emptied bucket stays visible via bucket_state, the new one via its
+        // entry.
+        commit(&db, &[entry("m1|r1", Some("m1"), 900, tokens(10, 50))]);
+        let mut buckets = db.session_buckets("s1").unwrap();
+        buckets.sort();
+        assert_eq!(buckets, vec![(model.clone(), 600), (model.clone(), 900)]);
         assert_eq!(
             db.aggregate_bucket("s1", &model, 600)
                 .unwrap()

--- a/src/token_usage/db.rs
+++ b/src/token_usage/db.rs
@@ -100,13 +100,26 @@ const MIGRATIONS: &[&str] = &[
     INSERT INTO schema_version (version) VALUES (1);
     "#,
     // Version 2: global dedup (resume/fork dedup crosses sessions),
-    // pending-flush marker + error backoff timestamp + rollup identity on
-    // tracked files, a durable cross-session reconcile flag, and a
-    // per-bucket emission revision. A v1 database may hold cross-session
-    // duplicate keys (its dedup was session-scoped); the first-seen row wins
-    // so the unique index can be created and later replacements cannot
-    // collide on the primary key.
+    // pending-flush marker + error backoff timestamp + rollup identity +
+    // emission repo_url on tracked files, a durable cross-session reconcile
+    // flag, and a per-bucket emission revision. A v1 database may hold
+    // cross-session duplicate keys (its dedup was session-scoped); the
+    // first-seen row wins so the unique index can be created and later
+    // replacements cannot collide on the primary key. Sessions that lose
+    // rows to the purge are flagged for reconciliation so their (now lower)
+    // aggregates re-emit instead of leaving inflated values on the server.
     r#"
+    ALTER TABLE tracked_files ADD COLUMN pending_flush INTEGER NOT NULL DEFAULT 0;
+    ALTER TABLE tracked_files ADD COLUMN last_error_at INTEGER;
+    ALTER TABLE tracked_files ADD COLUMN external_session_id TEXT NOT NULL DEFAULT '';
+    ALTER TABLE tracked_files ADD COLUMN needs_reconcile INTEGER NOT NULL DEFAULT 0;
+    ALTER TABLE tracked_files ADD COLUMN repo_url TEXT;
+    ALTER TABLE bucket_state ADD COLUMN emit_seq INTEGER NOT NULL DEFAULT 0;
+
+    UPDATE tracked_files SET needs_reconcile = 1 WHERE session_id IN (
+        SELECT DISTINCT session_id FROM usage_entries
+        WHERE rowid NOT IN (SELECT MIN(rowid) FROM usage_entries GROUP BY entry_key)
+    );
     DELETE FROM usage_entries WHERE rowid NOT IN (
         SELECT MIN(rowid) FROM usage_entries GROUP BY entry_key
     );
@@ -115,19 +128,13 @@ const MIGRATIONS: &[&str] = &[
     CREATE INDEX IF NOT EXISTS idx_usage_entries_message_global
         ON usage_entries(message_id) WHERE message_id IS NOT NULL;
 
-    ALTER TABLE tracked_files ADD COLUMN pending_flush INTEGER NOT NULL DEFAULT 0;
-    ALTER TABLE tracked_files ADD COLUMN last_error_at INTEGER;
-    ALTER TABLE tracked_files ADD COLUMN external_session_id TEXT NOT NULL DEFAULT '';
-    ALTER TABLE tracked_files ADD COLUMN needs_reconcile INTEGER NOT NULL DEFAULT 0;
-    ALTER TABLE bucket_state ADD COLUMN emit_seq INTEGER NOT NULL DEFAULT 0;
-
     INSERT INTO schema_version (version) VALUES (2);
     "#,
 ];
 
 const TRACKED_FILE_COLUMNS: &str = "session_id, stream_path, tool, byte_offset, state_json, \
      last_known_size, last_modified, processing_errors, last_error_at, pending_flush, \
-     external_session_id, needs_reconcile";
+     external_session_id, needs_reconcile, repo_url";
 
 /// A tracked transcript file: read cursor plus extractor state.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -150,6 +157,9 @@ pub struct TrackedFile {
     /// A cross-session replacement changed this session's buckets; it must
     /// be re-reconciled even if none of its files change (or still exist).
     pub needs_reconcile: bool,
+    /// repo_url the session's events were last emitted with, persisted so
+    /// DB-only corrections carry the same repo gate attribute.
+    pub repo_url: Option<String>,
 }
 
 fn read_tracked_file(row: &rusqlite::Row<'_>) -> rusqlite::Result<TrackedFile> {
@@ -166,6 +176,7 @@ fn read_tracked_file(row: &rusqlite::Row<'_>) -> rusqlite::Result<TrackedFile> {
         pending_flush: row.get(9)?,
         external_session_id: row.get(10)?,
         needs_reconcile: row.get(11)?,
+        repo_url: row.get(12)?,
     })
 }
 
@@ -214,6 +225,15 @@ pub struct ChangedBucket {
     /// The next emission carries `emit_seq + 1` so the server can order
     /// same-second re-emissions.
     pub emit_seq: u64,
+}
+
+/// A session flagged for DB-only re-reconciliation, with emission identity.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReconcileSession {
+    pub session_id: String,
+    pub external_session_id: String,
+    pub tool: String,
+    pub repo_url: Option<String>,
 }
 
 /// One extracted batch to persist atomically.
@@ -405,16 +425,39 @@ impl TokenUsageDatabase {
         Ok(())
     }
 
-    /// Sessions flagged for re-reconciliation by a cross-session replacement,
-    /// with the identity needed to emit without reading any file.
-    pub fn sessions_needing_reconcile(&self) -> Result<Vec<(String, String, String)>, GitAiError> {
+    /// Sessions flagged for re-reconciliation (cross-session replacement or
+    /// migration purge), with everything needed to emit without reading any
+    /// file: identity plus the repo_url their events were last emitted with.
+    pub fn sessions_needing_reconcile(&self) -> Result<Vec<ReconcileSession>, GitAiError> {
         let conn = self.lock();
         let mut stmt = conn.prepare(
-            "SELECT DISTINCT session_id, external_session_id, tool
-             FROM tracked_files WHERE needs_reconcile = 1",
+            "SELECT session_id, MAX(external_session_id), MAX(tool), MAX(repo_url)
+             FROM tracked_files WHERE needs_reconcile = 1 GROUP BY session_id",
         )?;
-        let rows = stmt.query_map([], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)))?;
+        let rows = stmt.query_map([], |row| {
+            Ok(ReconcileSession {
+                session_id: row.get(0)?,
+                external_session_id: row.get(1)?,
+                tool: row.get(2)?,
+                repo_url: row.get(3)?,
+            })
+        })?;
         Ok(rows.collect::<Result<Vec<_>, _>>()?)
+    }
+
+    /// Persist the repo_url the session's events are emitted with, so later
+    /// DB-only corrections carry the same repo gate attribute. Never erases
+    /// a stored value (a transient resolution failure must not drop it).
+    pub fn update_session_repo_url(
+        &self,
+        session_id: &str,
+        repo_url: &str,
+    ) -> Result<(), GitAiError> {
+        self.lock().execute(
+            "UPDATE tracked_files SET repo_url = ?2 WHERE session_id = ?1",
+            params![session_id, repo_url],
+        )?;
+        Ok(())
     }
 
     /// Clear the reconcile flag after the session's buckets were reconciled.
@@ -965,7 +1008,12 @@ mod tests {
         );
         assert_eq!(
             db.sessions_needing_reconcile().unwrap(),
-            vec![("s1".to_string(), "s1-ext".to_string(), "claude".to_string())]
+            vec![ReconcileSession {
+                session_id: "s1".to_string(),
+                external_session_id: "s1-ext".to_string(),
+                tool: "claude".to_string(),
+                repo_url: None,
+            }]
         );
         db.clear_needs_reconcile("s1").unwrap();
         assert!(db.sessions_needing_reconcile().unwrap().is_empty());
@@ -1158,11 +1206,26 @@ mod tests {
                     params![session],
                 )
                 .unwrap();
+                conn.execute(
+                    "INSERT INTO tracked_files (session_id, stream_path, tool)
+                     VALUES (?1, ?1 || '.jsonl', 'claude')",
+                    params![session],
+                )
+                .unwrap();
             }
         }
 
         let db = TokenUsageDatabase::open(&path).unwrap();
         assert_eq!(db.schema_version().unwrap(), 2);
+        // Sessions whose rows were purged are flagged so their (now lower)
+        // aggregates re-emit; the surviving session is not.
+        let flagged: Vec<String> = db
+            .sessions_needing_reconcile()
+            .unwrap()
+            .into_iter()
+            .map(|session| session.session_id)
+            .collect();
+        assert_eq!(flagged, vec!["s2".to_string(), "s3".to_string()]);
         // First-seen row (s1) survives; the duplicates are gone.
         assert_eq!(
             db.aggregate_bucket("s1", "claude-sonnet-4-20250514", 600)
@@ -1310,6 +1373,27 @@ mod tests {
             .unwrap();
         assert_eq!(file.processing_errors, 0);
         assert_eq!(file.last_error_at, None);
+    }
+
+    #[test]
+    fn session_repo_url_persists_for_db_only_corrections() {
+        let (_dir, db) = db();
+        commit_for(&db, "s1", &[entry("m1|r1", Some("m1"), 600, tokens(10, 5))]);
+        db.update_session_repo_url("s1", "https://github.com/acme/private")
+            .unwrap();
+        // A cross-session replacement flags s1; the reconcile listing carries
+        // the stored repo_url so corrections face the same upload gate.
+        commit_for(
+            &db,
+            "s2",
+            &[entry("m1|r1", Some("m1"), 600, tokens(10, 50))],
+        );
+        let sessions = db.sessions_needing_reconcile().unwrap();
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(
+            sessions[0].repo_url.as_deref(),
+            Some("https://github.com/acme/private")
+        );
     }
 
     #[test]

--- a/src/token_usage/mod.rs
+++ b/src/token_usage/mod.rs
@@ -12,6 +12,7 @@
 pub mod claude;
 pub mod codex;
 pub mod cost;
+pub mod db;
 pub mod extractor;
 pub mod types;
 


### PR DESCRIPTION
## Summary

Second PR of the TokenUsage stack: `src/token_usage/db.rs`, a single SQLite database (`~/.git-ai/internal/token-usage-db`) holding everything the pipeline needs to stay consistent:

- `tracked_files` — the authoritative read cursor (byte offset) + serialized extractor state per transcript file, plus the quiet-skip size/mtime snapshot, error-backoff state (`processing_errors`/`last_error_at`), and a pending-flush marker. **Keeping the cursor here (not in the streams database) is load-bearing**: `commit_batch` writes entries, extractor state, and the advanced cursor in one transaction, so a crash can never replay transcript lines against post-batch parser state (which would corrupt Codex's cumulative-delta computation).
- `usage_entries` — deduplicated per-entry usage. Per-entry rows (not bucket accumulators) make ccusage's replacement policy exact: a later entry can *lower* a bucket, and the bucket then re-aggregates via SQL. **Dedup is global across sessions** (matching ccusage's whole-files dedup): `claude --resume`/`--continue`/fork copies the parent conversation into a new session file with the original message/request ids, and session-scoped dedup would re-count that history on every resume. When a replacement moves an entry between sessions, `commit_batch` reports the previous owner (and `invalidate_session_files` forces its re-reconciliation). Entries older than the retention cutoff are dropped at insert.
- `bucket_state` — fingerprint, **emission revision (`emit_seq`)**, and timestamp of the last emitted aggregate per `(session_id, model, bucket_ts)`; the fingerprint covers every emitted field so any change — including a drop to zero — triggers re-emission, and the revision orders same-second re-emissions.

Changed buckets are found by **reconciliation** in a single grouped query (`changed_buckets`): one aggregate pass over the session's entries plus its emptied buckets from `bucket_state`, returning only fingerprint mismatches. No pending-emission state lives in memory, so a crash or failed emission is healed by the next pass. Retention pruning is transactional (a partial prune could otherwise strand orphan `bucket_state` rows that re-emit zero over real historical data), and token counts clamp to `i64::MAX` at the DB boundary.

Follows the codebase's SQLite conventions (`open_with_memory_limits`, WAL/NORMAL/MEMORY pragmas, versioned migrations — v2 adds the global dedup indexes and new columns).

## Testing

- 21 unit tests: migrations, cursor/state atomicity, resume/fork global dedup (identical copy not re-counted; cross-session replacement reported), replacement matrix, single-query reconciliation incl. emptied buckets and revision bumps, retention-at-insert, clamping, transactional prune, error/backoff state, snapshot invalidation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)