### PR TITLE
Add TokenUsage metric event wire format and feature flag

### DIFF
--- a/src/feature_flags.rs
+++ b/src/feature_flags.rs
@@ -86,6 +86,7 @@ define_feature_flags!(
     bash_checkpoints_v2: bash_checkpoints_v2, debug = false, release = false,
     daemon_log_upload: daemon_log_upload, debug = true, release = true,
     rewrite_metrics_events: rewrite_metrics_events, debug = true, release = false,
+    token_usage_metrics: token_usage_metrics, debug = true, release = false,
 );
 
 impl FeatureFlags {
@@ -143,6 +144,7 @@ mod tests {
             assert!(!flags.bash_checkpoints_v2);
             assert!(flags.daemon_log_upload);
             assert!(flags.rewrite_metrics_events);
+            assert!(flags.token_usage_metrics);
         }
         #[cfg(not(debug_assertions))]
         {
@@ -154,6 +156,7 @@ mod tests {
             assert!(!flags.bash_checkpoints_v2);
             assert!(flags.daemon_log_upload);
             assert!(!flags.rewrite_metrics_events);
+            assert!(!flags.token_usage_metrics);
         }
     }
 
@@ -275,6 +278,7 @@ mod tests {
             bash_checkpoints_v2: true,
             daemon_log_upload: true,
             rewrite_metrics_events: true,
+            token_usage_metrics: true,
         };
 
         let serialized = serde_json::to_string(&flags).unwrap();
@@ -286,6 +290,7 @@ mod tests {
         assert!(serialized.contains("bash_checkpoints_v2"));
         assert!(serialized.contains("daemon_log_upload"));
         assert!(serialized.contains("rewrite_metrics_events"));
+        assert!(serialized.contains("token_usage_metrics"));
     }
 
     #[test]
@@ -299,6 +304,7 @@ mod tests {
             bash_checkpoints_v2: true,
             daemon_log_upload: true,
             rewrite_metrics_events: true,
+            token_usage_metrics: true,
         };
         let cloned = flags.clone();
         assert_eq!(cloned.lite_mode, flags.lite_mode);
@@ -309,6 +315,7 @@ mod tests {
         assert_eq!(cloned.bash_checkpoints_v2, flags.bash_checkpoints_v2);
         assert_eq!(cloned.daemon_log_upload, flags.daemon_log_upload);
         assert_eq!(cloned.rewrite_metrics_events, flags.rewrite_metrics_events);
+        assert_eq!(cloned.token_usage_metrics, flags.token_usage_metrics);
     }
 
     #[test]

--- a/src/metrics/events.rs
+++ b/src/metrics/events.rs
@@ -2357,16 +2357,19 @@ pub mod token_usage_pos {
     pub const EST_COST_MICRO_USD: usize = 7; // u64 - estimated cost in 1e-6 USD
     pub const CREDITS: usize = 8; // f64 - reserved for credit-based agents
     pub const MESSAGE_COUNT: usize = 9; // u32 - deduplicated entries in the bucket
+    pub const EMITTED_SEQ: usize = 10; // u64 - per-bucket emission revision
 }
 
 /// Values for Event ID 9: token_usage
 ///
 /// One event per (session_id, model, bucket_ts): the deduplicated token usage
 /// and estimated cost of a 5-minute UTC bucket. The server upserts on that
-/// key with newest event_ts winning, so a bucket is re-emitted whenever its
-/// aggregate changes (including corrections downward and drops to zero).
-/// Uses EventAttributes for standard metadata (repo_url, tool, model,
-/// session ids, etc.); the model attribute is the bucket's model.
+/// key keeping the highest emitted_seq (a strictly increasing per-bucket
+/// revision), so a bucket is re-emitted whenever its aggregate changes
+/// (including corrections downward and drops to zero) and same-second
+/// re-emissions cannot tie on the u32-second event_ts. Uses EventAttributes
+/// for standard metadata (repo_url, tool, model, session ids, etc.); the
+/// model attribute is the bucket's model.
 ///
 /// **Fields:**
 /// | Position | Name | Type |
@@ -2381,6 +2384,7 @@ pub mod token_usage_pos {
 /// | 7 | est_cost_micro_usd | u64 |
 /// | 8 | credits | f64 (reserved, unset) |
 /// | 9 | message_count | u32 |
+/// | 10 | emitted_seq | u64 |
 #[derive(Debug, Clone, Default)]
 pub struct TokenUsageValues {
     pub bucket_ts: PosField<u64>,
@@ -2393,6 +2397,7 @@ pub struct TokenUsageValues {
     pub est_cost_micro_usd: PosField<u64>,
     pub credits: PosField<f64>,
     pub message_count: PosField<u32>,
+    pub emitted_seq: PosField<u64>,
 }
 
 impl TokenUsageValues {
@@ -2453,6 +2458,11 @@ impl TokenUsageValues {
         self.message_count = Some(Some(value));
         self
     }
+
+    pub fn emitted_seq(mut self, value: u64) -> Self {
+        self.emitted_seq = Some(Some(value));
+        self
+    }
 }
 
 impl PosEncoded for TokenUsageValues {
@@ -2508,6 +2518,11 @@ impl PosEncoded for TokenUsageValues {
             token_usage_pos::MESSAGE_COUNT,
             u32_to_json(&self.message_count),
         );
+        sparse_set(
+            &mut map,
+            token_usage_pos::EMITTED_SEQ,
+            u64_to_json(&self.emitted_seq),
+        );
         map
     }
 
@@ -2523,6 +2538,7 @@ impl PosEncoded for TokenUsageValues {
             est_cost_micro_usd: sparse_get_u64(arr, token_usage_pos::EST_COST_MICRO_USD),
             credits: sparse_get_f64(arr, token_usage_pos::CREDITS),
             message_count: sparse_get_u32(arr, token_usage_pos::MESSAGE_COUNT),
+            emitted_seq: sparse_get_u64(arr, token_usage_pos::EMITTED_SEQ),
         }
     }
 }
@@ -2562,7 +2578,8 @@ mod token_usage_tests {
             .total_tokens(380)
             .reasoning_output_tokens_opt(Some(12))
             .est_cost_micro_usd(4_567)
-            .message_count(3);
+            .message_count(3)
+            .emitted_seq(7);
 
         let sparse = PosEncoded::to_sparse(&values);
         let restored = <TokenUsageValues as PosEncoded>::from_sparse(&sparse);
@@ -2576,6 +2593,7 @@ mod token_usage_tests {
         assert_eq!(restored.est_cost_micro_usd, Some(Some(4_567)));
         assert_eq!(restored.credits, None);
         assert_eq!(restored.message_count, Some(Some(3)));
+        assert_eq!(restored.emitted_seq, Some(Some(7)));
     }
 
     #[test]

--- a/src/metrics/events.rs
+++ b/src/metrics/events.rs
@@ -2597,6 +2597,33 @@ mod token_usage_tests {
     }
 
     #[test]
+    fn test_token_usage_wire_encoding_is_pinned() {
+        // The sparse positions are the server's decoding contract: a silent
+        // renumbering would corrupt field decoding for every uploaded event.
+        let values = TokenUsageValues::new()
+            .bucket_ts(1_767_225_600)
+            .input_tokens(1)
+            .output_tokens(2)
+            .cache_read_tokens(3)
+            .cache_write_tokens(4)
+            .total_tokens(10)
+            .reasoning_output_tokens_opt(Some(5))
+            .est_cost_micro_usd(6)
+            .credits(7.5)
+            .message_count(8)
+            .emitted_seq(9);
+        let sparse = PosEncoded::to_sparse(&values);
+        let ordered: std::collections::BTreeMap<usize, &serde_json::Value> = sparse
+            .iter()
+            .map(|(k, v)| (k.parse::<usize>().unwrap(), v))
+            .collect();
+        insta::assert_snapshot!(
+            serde_json::to_string(&ordered).unwrap(),
+            @r#"{"0":1767225600,"1":1,"2":2,"3":3,"4":4,"5":10,"6":5,"7":6,"8":7.5,"9":8,"10":9}"#
+        );
+    }
+
+    #[test]
     fn test_reasoning_tokens_omitted_when_absent() {
         let values = TokenUsageValues::new()
             .bucket_ts(300)

--- a/src/metrics/events.rs
+++ b/src/metrics/events.rs
@@ -1,9 +1,9 @@
 //! Event-specific value structs for metrics.
 
 use super::pos_encoded::{
-    PosEncoded, PosField, sparse_get_string, sparse_get_u32, sparse_get_u64, sparse_get_vec_string,
-    sparse_get_vec_u32, sparse_set, string_to_json, u32_to_json, u64_to_json, vec_string_to_json,
-    vec_u32_to_json,
+    PosEncoded, PosField, f64_to_json, sparse_get_f64, sparse_get_string, sparse_get_u32,
+    sparse_get_u64, sparse_get_vec_string, sparse_get_vec_u32, sparse_set, string_to_json,
+    u32_to_json, u64_to_json, vec_string_to_json, vec_u32_to_json,
 };
 use super::types::{EventValues, MetricEventId, SparseArray};
 
@@ -2342,5 +2342,249 @@ mod session_event_tests {
     fn test_otel_trace_values_event_id() {
         assert_eq!(OtelTraceValues::event_id(), MetricEventId::OtelTrace);
         assert_eq!(OtelTraceValues::event_id() as u16, 6);
+    }
+}
+
+/// Value positions for "token_usage" event.
+pub mod token_usage_pos {
+    pub const BUCKET_TS: usize = 0; // u64 - 5-minute UTC bucket start (unix seconds)
+    pub const INPUT_TOKENS: usize = 1; // u64
+    pub const OUTPUT_TOKENS: usize = 2; // u64
+    pub const CACHE_READ_TOKENS: usize = 3; // u64
+    pub const CACHE_WRITE_TOKENS: usize = 4; // u64
+    pub const TOTAL_TOKENS: usize = 5; // u64
+    pub const REASONING_OUTPUT_TOKENS: usize = 6; // u64 - subset of output, agents that report it
+    pub const EST_COST_MICRO_USD: usize = 7; // u64 - estimated cost in 1e-6 USD
+    pub const CREDITS: usize = 8; // f64 - reserved for credit-based agents
+    pub const MESSAGE_COUNT: usize = 9; // u32 - deduplicated entries in the bucket
+}
+
+/// Values for Event ID 9: token_usage
+///
+/// One event per (session_id, model, bucket_ts): the deduplicated token usage
+/// and estimated cost of a 5-minute UTC bucket. The server upserts on that
+/// key with newest event_ts winning, so a bucket is re-emitted whenever its
+/// aggregate changes (including corrections downward and drops to zero).
+/// Uses EventAttributes for standard metadata (repo_url, tool, model,
+/// session ids, etc.); the model attribute is the bucket's model.
+///
+/// **Fields:**
+/// | Position | Name | Type |
+/// |----------|------|------|
+/// | 0 | bucket_ts | u64 |
+/// | 1 | input_tokens | u64 |
+/// | 2 | output_tokens | u64 |
+/// | 3 | cache_read_tokens | u64 |
+/// | 4 | cache_write_tokens | u64 |
+/// | 5 | total_tokens | u64 |
+/// | 6 | reasoning_output_tokens | u64 (unset when the agent reports none) |
+/// | 7 | est_cost_micro_usd | u64 |
+/// | 8 | credits | f64 (reserved, unset) |
+/// | 9 | message_count | u32 |
+#[derive(Debug, Clone, Default)]
+pub struct TokenUsageValues {
+    pub bucket_ts: PosField<u64>,
+    pub input_tokens: PosField<u64>,
+    pub output_tokens: PosField<u64>,
+    pub cache_read_tokens: PosField<u64>,
+    pub cache_write_tokens: PosField<u64>,
+    pub total_tokens: PosField<u64>,
+    pub reasoning_output_tokens: PosField<u64>,
+    pub est_cost_micro_usd: PosField<u64>,
+    pub credits: PosField<f64>,
+    pub message_count: PosField<u32>,
+}
+
+impl TokenUsageValues {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn bucket_ts(mut self, value: u64) -> Self {
+        self.bucket_ts = Some(Some(value));
+        self
+    }
+
+    pub fn input_tokens(mut self, value: u64) -> Self {
+        self.input_tokens = Some(Some(value));
+        self
+    }
+
+    pub fn output_tokens(mut self, value: u64) -> Self {
+        self.output_tokens = Some(Some(value));
+        self
+    }
+
+    pub fn cache_read_tokens(mut self, value: u64) -> Self {
+        self.cache_read_tokens = Some(Some(value));
+        self
+    }
+
+    pub fn cache_write_tokens(mut self, value: u64) -> Self {
+        self.cache_write_tokens = Some(Some(value));
+        self
+    }
+
+    pub fn total_tokens(mut self, value: u64) -> Self {
+        self.total_tokens = Some(Some(value));
+        self
+    }
+
+    /// Left unset (not zero) when the agent reports no reasoning tokens.
+    pub fn reasoning_output_tokens_opt(mut self, value: Option<u64>) -> Self {
+        if let Some(value) = value {
+            self.reasoning_output_tokens = Some(Some(value));
+        }
+        self
+    }
+
+    pub fn est_cost_micro_usd(mut self, value: u64) -> Self {
+        self.est_cost_micro_usd = Some(Some(value));
+        self
+    }
+
+    #[allow(dead_code)]
+    pub fn credits(mut self, value: f64) -> Self {
+        self.credits = Some(Some(value));
+        self
+    }
+
+    pub fn message_count(mut self, value: u32) -> Self {
+        self.message_count = Some(Some(value));
+        self
+    }
+}
+
+impl PosEncoded for TokenUsageValues {
+    fn to_sparse(&self) -> SparseArray {
+        let mut map = SparseArray::new();
+        sparse_set(
+            &mut map,
+            token_usage_pos::BUCKET_TS,
+            u64_to_json(&self.bucket_ts),
+        );
+        sparse_set(
+            &mut map,
+            token_usage_pos::INPUT_TOKENS,
+            u64_to_json(&self.input_tokens),
+        );
+        sparse_set(
+            &mut map,
+            token_usage_pos::OUTPUT_TOKENS,
+            u64_to_json(&self.output_tokens),
+        );
+        sparse_set(
+            &mut map,
+            token_usage_pos::CACHE_READ_TOKENS,
+            u64_to_json(&self.cache_read_tokens),
+        );
+        sparse_set(
+            &mut map,
+            token_usage_pos::CACHE_WRITE_TOKENS,
+            u64_to_json(&self.cache_write_tokens),
+        );
+        sparse_set(
+            &mut map,
+            token_usage_pos::TOTAL_TOKENS,
+            u64_to_json(&self.total_tokens),
+        );
+        sparse_set(
+            &mut map,
+            token_usage_pos::REASONING_OUTPUT_TOKENS,
+            u64_to_json(&self.reasoning_output_tokens),
+        );
+        sparse_set(
+            &mut map,
+            token_usage_pos::EST_COST_MICRO_USD,
+            u64_to_json(&self.est_cost_micro_usd),
+        );
+        sparse_set(
+            &mut map,
+            token_usage_pos::CREDITS,
+            f64_to_json(&self.credits),
+        );
+        sparse_set(
+            &mut map,
+            token_usage_pos::MESSAGE_COUNT,
+            u32_to_json(&self.message_count),
+        );
+        map
+    }
+
+    fn from_sparse(arr: &SparseArray) -> Self {
+        Self {
+            bucket_ts: sparse_get_u64(arr, token_usage_pos::BUCKET_TS),
+            input_tokens: sparse_get_u64(arr, token_usage_pos::INPUT_TOKENS),
+            output_tokens: sparse_get_u64(arr, token_usage_pos::OUTPUT_TOKENS),
+            cache_read_tokens: sparse_get_u64(arr, token_usage_pos::CACHE_READ_TOKENS),
+            cache_write_tokens: sparse_get_u64(arr, token_usage_pos::CACHE_WRITE_TOKENS),
+            total_tokens: sparse_get_u64(arr, token_usage_pos::TOTAL_TOKENS),
+            reasoning_output_tokens: sparse_get_u64(arr, token_usage_pos::REASONING_OUTPUT_TOKENS),
+            est_cost_micro_usd: sparse_get_u64(arr, token_usage_pos::EST_COST_MICRO_USD),
+            credits: sparse_get_f64(arr, token_usage_pos::CREDITS),
+            message_count: sparse_get_u32(arr, token_usage_pos::MESSAGE_COUNT),
+        }
+    }
+}
+
+impl EventValues for TokenUsageValues {
+    fn event_id() -> MetricEventId {
+        MetricEventId::TokenUsage
+    }
+
+    fn to_sparse(&self) -> SparseArray {
+        PosEncoded::to_sparse(self)
+    }
+
+    fn from_sparse(arr: &SparseArray) -> Self {
+        PosEncoded::from_sparse(arr)
+    }
+}
+
+#[cfg(test)]
+mod token_usage_tests {
+    use super::*;
+
+    #[test]
+    fn test_token_usage_values_event_id() {
+        assert_eq!(TokenUsageValues::event_id(), MetricEventId::TokenUsage);
+        assert_eq!(TokenUsageValues::event_id() as u16, 9);
+    }
+
+    #[test]
+    fn test_token_usage_values_sparse_roundtrip() {
+        let values = TokenUsageValues::new()
+            .bucket_ts(1_700_000_100)
+            .input_tokens(100)
+            .output_tokens(50)
+            .cache_read_tokens(200)
+            .cache_write_tokens(30)
+            .total_tokens(380)
+            .reasoning_output_tokens_opt(Some(12))
+            .est_cost_micro_usd(4_567)
+            .message_count(3);
+
+        let sparse = PosEncoded::to_sparse(&values);
+        let restored = <TokenUsageValues as PosEncoded>::from_sparse(&sparse);
+        assert_eq!(restored.bucket_ts, Some(Some(1_700_000_100)));
+        assert_eq!(restored.input_tokens, Some(Some(100)));
+        assert_eq!(restored.output_tokens, Some(Some(50)));
+        assert_eq!(restored.cache_read_tokens, Some(Some(200)));
+        assert_eq!(restored.cache_write_tokens, Some(Some(30)));
+        assert_eq!(restored.total_tokens, Some(Some(380)));
+        assert_eq!(restored.reasoning_output_tokens, Some(Some(12)));
+        assert_eq!(restored.est_cost_micro_usd, Some(Some(4_567)));
+        assert_eq!(restored.credits, None);
+        assert_eq!(restored.message_count, Some(Some(3)));
+    }
+
+    #[test]
+    fn test_reasoning_tokens_omitted_when_absent() {
+        let values = TokenUsageValues::new()
+            .bucket_ts(300)
+            .reasoning_output_tokens_opt(None);
+        let sparse = PosEncoded::to_sparse(&values);
+        assert!(!sparse.contains_key(&token_usage_pos::REASONING_OUTPUT_TOKENS.to_string()));
+        assert!(!sparse.contains_key(&token_usage_pos::CREDITS.to_string()));
     }
 }

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -17,7 +17,7 @@ pub mod types;
 pub use attrs::EventAttributes;
 pub use events::{
     AgentUsageValues, CheckpointValues, CommittedValues, InstallHooksValues, OtelTraceValues,
-    RewriteCommittedValues, SessionEventValues,
+    RewriteCommittedValues, SessionEventValues, TokenUsageValues,
 };
 pub use pos_encoded::PosEncoded;
 pub use types::{EventValues, METRICS_API_VERSION, MetricEvent, MetricsBatch};

--- a/src/metrics/types.rs
+++ b/src/metrics/types.rs
@@ -24,6 +24,7 @@ pub enum MetricEventId {
     OtelTrace = 6,
     RewriteCommitted = 7,
     DaemonIngestAnomaly = 8,
+    TokenUsage = 9,
 }
 
 /// Trait for event-specific values.
@@ -200,6 +201,7 @@ mod tests {
         assert_eq!(MetricEventId::InstallHooks as u16, 3);
         assert_eq!(MetricEventId::Checkpoint as u16, 4);
         assert_eq!(MetricEventId::RewriteCommitted as u16, 7);
+        assert_eq!(MetricEventId::TokenUsage as u16, 9);
     }
 
     #[test]

--- a/tests/integration/performance.rs
+++ b/tests/integration/performance.rs
@@ -23,6 +23,7 @@ fn setup() {
         bash_checkpoints_v2: false,
         daemon_log_upload: true,
         rewrite_metrics_events: false,
+        token_usage_metrics: false,
     };
 
     git_ai::config::Config::set_test_feature_flags(test_flags.clone());


### PR DESCRIPTION
## Summary

Third PR of the TokenUsage stack: the wire format and feature flag.

- `MetricEventId::TokenUsage = 9` with pos-encoded `TokenUsageValues`: `bucket_ts` (5-minute UTC bucket start), input/output/cache_read/cache_write/total tokens, optional `reasoning_output_tokens` (agents that report it, e.g. Codex — a subset of output, unset for Claude), `est_cost_micro_usd` (u64 micro-USD keeps values integer-exact for fingerprinting; the server divides by 1e6), reserved `credits` (f64, unset in v1), `message_count`, and `emitted_seq`.
- One event per `(session_id, model, bucket_ts)`; the server upserts on that key keeping the **highest `emitted_seq`** — a strictly increasing per-bucket revision — so re-emissions (including downward corrections and drops to zero) always supersede prior values even when they land within the same u32 second or upload out of order.
- New `token_usage_metrics` feature flag: **on in debug** so the whole test suite exercises the pipeline, **off in release** until the feature ships.

## Testing

- Sparse round-trip and unset-field-omission unit tests for `TokenUsageValues` (incl. `emitted_seq`); event id assertion; feature-flag default/serialization/clone tests updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)