### PR TITLE
Add token-usage daemon worker with backfill and event emission

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2786,6 +2786,9 @@ pub struct ActorDaemonCoordinator {
     stream_worker: Option<crate::daemon::stream_worker::StreamWorkerHandle>,
     token_usage_worker: Option<crate::daemon::token_usage_worker::TokenUsageWorkerHandle>,
     transcript_shutdown_notify: std::sync::OnceLock<Arc<tokio::sync::Notify>>,
+    // Separate from the transcript worker's Notify: notify_one wakes exactly
+    // one waiter, so each worker needs its own.
+    token_usage_shutdown_notify: std::sync::OnceLock<Arc<tokio::sync::Notify>>,
     streams_db: Option<Arc<crate::streams::db::StreamsDatabase>>,
     next_trace_ingest_seq: AtomicUsize,
     queued_trace_payloads: AtomicUsize,
@@ -2917,6 +2920,7 @@ impl ActorDaemonCoordinator {
             stream_worker: None,
             token_usage_worker: None,
             transcript_shutdown_notify: std::sync::OnceLock::new(),
+            token_usage_shutdown_notify: std::sync::OnceLock::new(),
             streams_db: None,
             next_trace_ingest_seq: AtomicUsize::new(0),
             queued_trace_payloads: AtomicUsize::new(0),
@@ -3232,6 +3236,9 @@ impl ActorDaemonCoordinator {
         self.shutdown_notify.notify_waiters();
         if let Some(transcript_shutdown) = self.transcript_shutdown_notify.get() {
             transcript_shutdown.notify_one();
+        }
+        if let Some(token_usage_shutdown) = self.token_usage_shutdown_notify.get() {
+            token_usage_shutdown.notify_one();
         }
         // Hold the condvar mutex so notify_all cannot race with the
         // check-then-wait sequence in daemon_update_check_loop.
@@ -9253,6 +9260,9 @@ pub(crate) async fn run_daemon(config: DaemonConfig) -> Result<DaemonExitAction,
             Ok(streams_db) => {
                 let streams_db = std::sync::Arc::new(streams_db);
                 let shutdown_notify = Arc::new(tokio::sync::Notify::new());
+                // Each worker needs its own shutdown Notify: request_shutdown
+                // uses notify_one, which wakes exactly one waiter.
+                let token_usage_shutdown_notify = Arc::new(tokio::sync::Notify::new());
                 // The token-usage worker is fed by stream-worker completions,
                 // so it lives inside the transcript_streaming gate. Its own
                 // token_usage_metrics flag is re-read per trigger.
@@ -9264,7 +9274,7 @@ pub(crate) async fn run_daemon(config: DaemonConfig) -> Result<DaemonExitAction,
                             streams_db.clone(),
                             std::sync::Arc::new(token_db),
                             telemetry_handle.clone(),
-                            shutdown_notify.clone(),
+                            token_usage_shutdown_notify.clone(),
                         ))
                     }
                     Err(e) => {
@@ -9284,6 +9294,9 @@ pub(crate) async fn run_daemon(config: DaemonConfig) -> Result<DaemonExitAction,
                 let _ = coordinator_inner
                     .transcript_shutdown_notify
                     .set(shutdown_notify);
+                let _ = coordinator_inner
+                    .token_usage_shutdown_notify
+                    .set(token_usage_shutdown_notify);
                 tracing::info!("transcript worker spawned");
             }
             Err(e) => {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -73,6 +73,7 @@ pub mod sweep_coordinator;
 pub mod telemetry_handle;
 pub mod telemetry_worker;
 pub mod test_sync;
+pub mod token_usage_worker;
 pub mod trace_normalizer;
 pub mod transcript_redaction;
 
@@ -2783,6 +2784,7 @@ pub struct ActorDaemonCoordinator {
     trace_ingest_tx: std::sync::OnceLock<mpsc::Sender<Value>>,
     telemetry_worker: Option<crate::daemon::telemetry_worker::DaemonTelemetryWorkerHandle>,
     stream_worker: Option<crate::daemon::stream_worker::StreamWorkerHandle>,
+    token_usage_worker: Option<crate::daemon::token_usage_worker::TokenUsageWorkerHandle>,
     transcript_shutdown_notify: std::sync::OnceLock<Arc<tokio::sync::Notify>>,
     streams_db: Option<Arc<crate::streams::db::StreamsDatabase>>,
     next_trace_ingest_seq: AtomicUsize,
@@ -2913,6 +2915,7 @@ impl ActorDaemonCoordinator {
             trace_ingest_tx: std::sync::OnceLock::new(),
             telemetry_worker: None,
             stream_worker: None,
+            token_usage_worker: None,
             transcript_shutdown_notify: std::sync::OnceLock::new(),
             streams_db: None,
             next_trace_ingest_seq: AtomicUsize::new(0),
@@ -7070,6 +7073,29 @@ impl ActorDaemonCoordinator {
             }
         }
 
+        // Phase 2b: drain the token-usage worker. It is fed by stream-worker
+        // completions, so this must run after the transcript drain above.
+        if !result.timed_out
+            && let Some(worker) = &self.token_usage_worker
+        {
+            let now = Instant::now();
+            if now < deadline {
+                let remaining = deadline - now;
+                maybe_log("token-usage processing");
+                match timeout(remaining, worker.drain()).await {
+                    Ok(Ok(())) => {}
+                    Ok(Err(e)) => {
+                        tracing::warn!(error = %e, "await: token-usage drain failed");
+                    }
+                    Err(_) => {
+                        result.timed_out = true;
+                    }
+                }
+            } else {
+                result.timed_out = true;
+            }
+        }
+
         // Phase 3: flush telemetry and wait for the worker to finish.
         if !result.timed_out
             && let Some(worker) = &self.telemetry_worker
@@ -9227,13 +9253,34 @@ pub(crate) async fn run_daemon(config: DaemonConfig) -> Result<DaemonExitAction,
             Ok(streams_db) => {
                 let streams_db = std::sync::Arc::new(streams_db);
                 let shutdown_notify = Arc::new(tokio::sync::Notify::new());
+                // The token-usage worker is fed by stream-worker completions,
+                // so it lives inside the transcript_streaming gate. Its own
+                // token_usage_metrics flag is re-read per trigger.
+                let token_usage_handle = match crate::token_usage::db::TokenUsageDatabase::open(
+                    config.internal_dir.join("token-usage-db"),
+                ) {
+                    Ok(token_db) => {
+                        Some(crate::daemon::token_usage_worker::spawn_token_usage_worker(
+                            streams_db.clone(),
+                            std::sync::Arc::new(token_db),
+                            telemetry_handle.clone(),
+                            shutdown_notify.clone(),
+                        ))
+                    }
+                    Err(e) => {
+                        tracing::error!(error = %e, "failed to open token-usage database, token-usage worker not started");
+                        None
+                    }
+                };
                 let transcript_handle = crate::daemon::stream_worker::spawn_stream_worker(
                     streams_db.clone(),
                     telemetry_handle.clone(),
                     shutdown_notify.clone(),
+                    token_usage_handle.clone(),
                 );
                 coordinator_inner.streams_db = Some(streams_db);
                 coordinator_inner.stream_worker = Some(transcript_handle);
+                coordinator_inner.token_usage_worker = token_usage_handle;
                 let _ = coordinator_inner
                     .transcript_shutdown_notify
                     .set(shutdown_notify);

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -9264,23 +9264,34 @@ pub(crate) async fn run_daemon(config: DaemonConfig) -> Result<DaemonExitAction,
                 // uses notify_one, which wakes exactly one waiter.
                 let token_usage_shutdown_notify = Arc::new(tokio::sync::Notify::new());
                 // The token-usage worker is fed by stream-worker completions,
-                // so it lives inside the transcript_streaming gate. Its own
-                // token_usage_metrics flag is re-read per trigger.
-                let token_usage_handle = match crate::token_usage::db::TokenUsageDatabase::open(
-                    config.internal_dir.join("token-usage-db"),
-                ) {
-                    Ok(token_db) => {
-                        Some(crate::daemon::token_usage_worker::spawn_token_usage_worker(
-                            streams_db.clone(),
-                            std::sync::Arc::new(token_db),
-                            telemetry_handle.clone(),
-                            token_usage_shutdown_notify.clone(),
-                        ))
+                // so it lives inside the transcript_streaming gate, behind
+                // its own startup flag (like transcript_streaming itself).
+                // When the flag is off, nothing runs, no database is created,
+                // and any previously collected data is deleted.
+                let token_usage_db_path = config.internal_dir.join("token-usage-db");
+                let token_usage_handle = if config::Config::get()
+                    .get_feature_flags()
+                    .token_usage_metrics
+                {
+                    match crate::token_usage::db::TokenUsageDatabase::open(&token_usage_db_path) {
+                        Ok(token_db) => {
+                            Some(crate::daemon::token_usage_worker::spawn_token_usage_worker(
+                                streams_db.clone(),
+                                std::sync::Arc::new(token_db),
+                                telemetry_handle.clone(),
+                                token_usage_shutdown_notify.clone(),
+                            ))
+                        }
+                        Err(e) => {
+                            tracing::error!(error = %e, "failed to open token-usage database, token-usage worker not started");
+                            None
+                        }
                     }
-                    Err(e) => {
-                        tracing::error!(error = %e, "failed to open token-usage database, token-usage worker not started");
-                        None
-                    }
+                } else {
+                    crate::token_usage::db::TokenUsageDatabase::remove_database_files(
+                        &token_usage_db_path,
+                    );
+                    None
                 };
                 let transcript_handle = crate::daemon::stream_worker::spawn_stream_worker(
                     streams_db.clone(),

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -9248,6 +9248,17 @@ pub(crate) async fn run_daemon(config: DaemonConfig) -> Result<DaemonExitAction,
     crate::daemon::telemetry_worker::set_daemon_internal_telemetry(telemetry_handle.clone());
     coordinator_inner.telemetry_worker = Some(telemetry_handle.clone());
 
+    // With the token-usage flag off, previously collected data is deleted
+    // regardless of the streaming gate below (the spec's "no collected data
+    // is retained" holds even when transcript_streaming is also off).
+    let token_usage_db_path = config.internal_dir.join("token-usage-db");
+    let token_usage_enabled = config::Config::get()
+        .get_feature_flags()
+        .token_usage_metrics;
+    if !token_usage_enabled {
+        crate::token_usage::db::TokenUsageDatabase::remove_database_files(&token_usage_db_path);
+    }
+
     // Spawn the transcript worker BEFORE wrapping coordinator in Arc
     if config::Config::get()
         .get_feature_flags()
@@ -9266,13 +9277,10 @@ pub(crate) async fn run_daemon(config: DaemonConfig) -> Result<DaemonExitAction,
                 // The token-usage worker is fed by stream-worker completions,
                 // so it lives inside the transcript_streaming gate, behind
                 // its own startup flag (like transcript_streaming itself).
-                // When the flag is off, nothing runs, no database is created,
-                // and any previously collected data is deleted.
-                let token_usage_db_path = config.internal_dir.join("token-usage-db");
-                let token_usage_handle = if config::Config::get()
-                    .get_feature_flags()
-                    .token_usage_metrics
-                {
+                // When the flag is off, nothing runs and no database is
+                // created (deletion of old data happens above, outside this
+                // gate).
+                let token_usage_handle = if token_usage_enabled {
                     match crate::token_usage::db::TokenUsageDatabase::open(&token_usage_db_path) {
                         Ok(token_db) => {
                             Some(crate::daemon::token_usage_worker::spawn_token_usage_worker(
@@ -9288,9 +9296,6 @@ pub(crate) async fn run_daemon(config: DaemonConfig) -> Result<DaemonExitAction,
                         }
                     }
                 } else {
-                    crate::token_usage::db::TokenUsageDatabase::remove_database_files(
-                        &token_usage_db_path,
-                    );
                     None
                 };
                 let transcript_handle = crate::daemon::stream_worker::spawn_stream_worker(

--- a/src/daemon/stream_worker.rs
+++ b/src/daemon/stream_worker.rs
@@ -312,6 +312,9 @@ struct StreamWorker {
     sweep_rx: tokio::sync::mpsc::UnboundedReceiver<SweepRequest>,
     drain_rx: tokio::sync::mpsc::UnboundedReceiver<DrainRequest>,
     sweep_trigger_gate: SweepTriggerGate,
+    /// Pinged after a transcript task succeeds so token usage can be
+    /// recomputed for that session (cheap non-blocking send).
+    token_usage_worker: Option<crate::daemon::token_usage_worker::TokenUsageWorkerHandle>,
 }
 
 impl StreamWorker {
@@ -326,6 +329,7 @@ impl StreamWorker {
         sweep_rx: tokio::sync::mpsc::UnboundedReceiver<SweepRequest>,
         drain_rx: tokio::sync::mpsc::UnboundedReceiver<DrainRequest>,
         sweep_trigger_gate: SweepTriggerGate,
+        token_usage_worker: Option<crate::daemon::token_usage_worker::TokenUsageWorkerHandle>,
     ) -> Self {
         let sweep_coordinator =
             crate::daemon::sweep_coordinator::SweepCoordinator::new(streams_db.clone());
@@ -343,6 +347,7 @@ impl StreamWorker {
             sweep_rx,
             drain_rx,
             sweep_trigger_gate,
+            token_usage_worker,
         }
     }
 
@@ -984,7 +989,17 @@ impl StreamWorker {
         // Handle result
         match result {
             Ok(Ok(())) => {
-                // Success - task is done
+                // Success - task is done. Let the token-usage worker pick up
+                // the freshly ingested transcript bytes.
+                if task.stream_kind == "transcript"
+                    && let Some(token_usage) = &self.token_usage_worker
+                {
+                    token_usage.notify_stream_processed(
+                        &task.session_id,
+                        &task.tool,
+                        &task.canonical_path,
+                    );
+                }
             }
             Ok(Err(e)) => {
                 // Error - handle retry logic
@@ -1379,6 +1394,7 @@ pub fn spawn_stream_worker(
     streams_db: Arc<StreamsDatabase>,
     telemetry_handle: DaemonTelemetryWorkerHandle,
     shutdown_notify: Arc<Notify>,
+    token_usage_worker: Option<crate::daemon::token_usage_worker::TokenUsageWorkerHandle>,
 ) -> StreamWorkerHandle {
     let (checkpoint_tx, checkpoint_rx) = tokio::sync::mpsc::unbounded_channel();
     let (sweep_tx, sweep_rx) = tokio::sync::mpsc::unbounded_channel();
@@ -1395,6 +1411,7 @@ pub fn spawn_stream_worker(
         sweep_rx,
         drain_rx,
         sweep_trigger_gate.clone(),
+        token_usage_worker,
     );
 
     tokio::spawn(async move {
@@ -1492,6 +1509,7 @@ mod scheduling_tests {
             sweep_rx,
             drain_rx,
             sweep_trigger_gate,
+            None,
         );
         (temp, worker, shutdown, checkpoint_tx)
     }
@@ -1669,6 +1687,7 @@ mod subagent_sweep_tests {
             sweep_rx,
             drain_rx,
             SweepTriggerGate::new(),
+            None,
         )
     }
 

--- a/src/daemon/stream_worker.rs
+++ b/src/daemon/stream_worker.rs
@@ -989,17 +989,8 @@ impl StreamWorker {
         // Handle result
         match result {
             Ok(Ok(())) => {
-                // Success - task is done. Let the token-usage worker pick up
-                // the freshly ingested transcript bytes.
-                if task.stream_kind == "transcript"
-                    && let Some(token_usage) = &self.token_usage_worker
-                {
-                    token_usage.notify_stream_processed(
-                        &task.session_id,
-                        &task.tool,
-                        &task.canonical_path,
-                    );
-                }
+                // Success - task is done.
+                self.notify_token_usage(&task);
             }
             Ok(Err(e)) => {
                 // Error - handle retry logic
@@ -1357,8 +1348,22 @@ impl StreamWorker {
                 Ok(Err(e)) => {
                     tracing::error!(error = %e, session_id = %task.session_id, "drain task processing error");
                 }
-                Ok(Ok(())) => {}
+                Ok(Ok(())) => {
+                    self.notify_token_usage(&task);
+                }
             }
+        }
+    }
+
+    /// On transcript success, let the token-usage worker pick up the freshly
+    /// ingested bytes (cheap non-blocking send). Called from every task
+    /// success arm — including the drain path — so the await barrier, which
+    /// drains token usage right after transcripts, always sees the ping.
+    fn notify_token_usage(&self, task: &ProcessingTask) {
+        if task.stream_kind == "transcript"
+            && let Some(token_usage) = &self.token_usage_worker
+        {
+            token_usage.notify_stream_processed(&task.session_id, &task.tool, &task.canonical_path);
         }
     }
 

--- a/src/daemon/token_usage_worker.rs
+++ b/src/daemon/token_usage_worker.rs
@@ -48,9 +48,34 @@ use crate::daemon::telemetry_worker::DaemonTelemetryWorkerHandle;
 use crate::error::GitAiError;
 use crate::metrics::{EventAttributes, MetricEvent, PosEncoded, TokenUsageValues};
 use crate::streams::db::{StreamRecord, StreamsDatabase};
-use crate::streams::types::{JsonlLineState, read_jsonl_line};
 use crate::token_usage::db::{BatchCommit, TokenUsageDatabase, TrackedFile};
 use crate::token_usage::extractor_for_tool;
+
+/// One raw JSONL line read as bytes: unlike UTF-8-strict `read_line`, a
+/// single invalid byte cannot wedge the cursor forever (the line decodes
+/// lossily, fails JSON parsing, is skipped, and the cursor advances —
+/// matching upstream ccusage's byte-level reads).
+enum LineRead {
+    Eof,
+    /// No trailing newline: the writer may still be appending.
+    Partial(usize),
+    Complete(usize),
+}
+
+fn read_line_bytes(
+    reader: &mut impl std::io::BufRead,
+    buf: &mut Vec<u8>,
+) -> std::io::Result<LineRead> {
+    buf.clear();
+    let bytes = reader.read_until(b'\n', buf)?;
+    if bytes == 0 {
+        return Ok(LineRead::Eof);
+    }
+    if buf.last() != Some(&b'\n') {
+        return Ok(LineRead::Partial(bytes));
+    }
+    Ok(LineRead::Complete(bytes))
+}
 
 /// Entry/byte bounds of one atomic batch commit.
 const BATCH_MAX_ENTRIES: usize = 1_000;
@@ -513,11 +538,7 @@ fn process_task_blocking(
             repo_url
         },
         &sink,
-    )
-    // Cross-session replacements flagged other sessions during the batch
-    // commits: reconcile them now, DB-only (their files are not needed and
-    // may no longer exist).
-    .and_then(|_| reconcile_flagged_sessions(token_db, &sink));
+    );
     if let Err(e) = &result {
         // Keyed by the rollup session id (subagent transcripts track under
         // their parent), matching the row ensure_file created.
@@ -527,6 +548,16 @@ fn process_task_blocking(
             &e.to_string(),
             now_secs(),
         );
+    }
+    // Cross-session replacements flagged other sessions during the batch
+    // commits: reconcile them now, DB-only. Failures here belong to the
+    // flagged sessions (the durable flag retries them), NOT to this task's
+    // transcript — charging them here would put a healthy file into error
+    // backoff and point diagnostics at the wrong session.
+    if result.is_ok()
+        && let Err(e) = reconcile_flagged_sessions(token_db, &sink)
+    {
+        tracing::warn!(error = %e, "token-usage cross-session reconcile failed; flags retained for retry");
     }
     result
 }
@@ -606,13 +637,19 @@ fn process_file(
     let Some(mut extractor) = extractor_for_tool(&identity.tool) else {
         return Ok(());
     };
-    // A shrunken file was rewritten: restart from scratch. Entry-level dedup
-    // keeps re-extraction idempotent.
+    // A shrunken file was rewritten, and unreadable persisted state (corrupt
+    // or cross-version) means the cursor position is meaningless for the
+    // fresh extractor: both restart from scratch. Entry-level dedup keeps
+    // re-extraction idempotent, whereas continuing mid-file on default state
+    // would book the session's whole cumulative history as one delta.
     let mut offset = tracked.byte_offset;
     if offset > size {
         offset = 0;
-    } else if let Some(state) = tracked.state_json.as_deref() {
-        extractor.restore_state(state);
+    } else if let Some(state) = tracked.state_json.as_deref()
+        && !extractor.restore_state(state)
+    {
+        tracing::warn!(session_id = %identity.session_id, "unreadable extractor state; re-reading from the start");
+        offset = 0;
     }
 
     // Quiet skip: nothing changed since the last completed pass and the
@@ -629,7 +666,7 @@ fn process_file(
     reader.seek(SeekFrom::Start(offset))?;
 
     let cutoff = retention_cutoff_bucket(now);
-    let mut line = String::new();
+    let mut line: Vec<u8> = Vec::new();
     let mut reached_end = false;
     let mut interrupted = false;
     while !reached_end && !interrupted {
@@ -640,21 +677,36 @@ fn process_file(
                 interrupted = true;
                 break;
             }
-            match read_jsonl_line(&mut reader, &mut line)? {
-                JsonlLineState::Eof => {
+            match read_line_bytes(&mut reader, &mut line)? {
+                LineRead::Eof => {
                     reached_end = true;
                     break;
                 }
-                // A partial trailing line is still being appended; re-read it
-                // next pass (the cursor stays before it).
-                JsonlLineState::Partial => {
+                // A trailing line without a newline is usually a write in
+                // progress: leave the cursor before it. But if it already
+                // parses as complete JSON it will never grow a newline once
+                // the writer is gone, and the size/mtime snapshot would
+                // suppress every later pass — count it now (upstream counts
+                // unterminated final segments too).
+                LineRead::Partial(bytes) => {
+                    let text = String::from_utf8_lossy(&line);
+                    let trimmed = text.trim();
+                    if !trimmed.is_empty()
+                        && serde_json::from_str::<serde_json::Value>(trimmed).is_ok()
+                    {
+                        offset += bytes as u64;
+                        if extractor.wants_line(trimmed) {
+                            entries.extend(extractor.extract_line(trimmed));
+                        }
+                    }
                     reached_end = true;
                     break;
                 }
-                JsonlLineState::Complete(bytes) => {
+                LineRead::Complete(bytes) => {
                     offset += bytes as u64;
                     consumed += bytes;
-                    let trimmed = line.trim_end();
+                    let text = String::from_utf8_lossy(&line);
+                    let trimmed = text.trim_end();
                     if extractor.wants_line(trimmed) {
                         entries.extend(extractor.extract_line(trimmed));
                     }
@@ -712,14 +764,27 @@ fn emit_changed_buckets(
     // N+1 may exist in the metrics queue, that revision must never be
     // reused, or a crash before the fingerprint write would re-open the
     // equal-revision tie. A failed sink merely wastes a revision number.
+    // The revision is floored to wall-clock seconds so that losing the
+    // local revision state (flag off deletes the DB; the DB is rebuilt)
+    // cannot restart below revisions the server has already seen — a
+    // re-enabled backfill would otherwise re-emit at revision 1 and lose to
+    // every previously uploaded value under the highest-revision upsert.
+    let seq_floor = now_secs().max(0) as u64;
+    let changed: Vec<(crate::token_usage::db::ChangedBucket, u64)> = changed
+        .into_iter()
+        .map(|bucket| {
+            let next_seq = (bucket.emit_seq + 1).max(seq_floor);
+            (bucket, next_seq)
+        })
+        .collect();
     let reservations: Vec<(String, u32, u64)> = changed
         .iter()
-        .map(|bucket| (bucket.model.clone(), bucket.bucket_ts, bucket.emit_seq + 1))
+        .map(|(bucket, next_seq)| (bucket.model.clone(), bucket.bucket_ts, *next_seq))
         .collect();
     token_db.reserve_emit_seqs(&identity.session_id, &reservations)?;
     let repo_url = resolve_repo_url();
     let mut events = Vec::with_capacity(changed.len());
-    for bucket in &changed {
+    for (bucket, next_seq) in &changed {
         let aggregate = &bucket.aggregate;
         let values = TokenUsageValues::new()
             .bucket_ts(bucket.bucket_ts as u64)
@@ -733,7 +798,7 @@ fn emit_changed_buckets(
             .message_count(aggregate.message_count)
             // Strictly increasing per bucket: the server keeps the highest
             // revision, so same-second re-emissions cannot tie.
-            .emitted_seq(bucket.emit_seq + 1);
+            .emitted_seq(*next_seq);
         let mut attrs = EventAttributes::with_version(env!("CARGO_PKG_VERSION"))
             .session_id(identity.session_id.clone())
             .external_session_id(identity.external_session_id.clone())
@@ -746,13 +811,13 @@ fn emit_changed_buckets(
     }
     sink(&events)?;
     let now_ts = now_secs();
-    for bucket in changed {
+    for (bucket, next_seq) in changed {
         token_db.mark_emitted(
             &identity.session_id,
             &bucket.model,
             bucket.bucket_ts,
             &bucket.aggregate.fingerprint(),
-            bucket.emit_seq + 1,
+            next_seq,
             now_ts,
         )?;
     }
@@ -866,7 +931,11 @@ mod tests {
             assert_eq!(event.event_id, 9);
             assert_eq!(value_u64(event, token_usage_pos::INPUT_TOKENS), Some(100));
             assert_eq!(value_u64(event, token_usage_pos::MESSAGE_COUNT), Some(1));
-            assert_eq!(value_u64(event, token_usage_pos::EMITTED_SEQ), Some(1));
+            // Revisions are floored to wall-clock seconds so a rebuilt DB
+            // can never restart below previously uploaded revisions.
+            assert!(
+                value_u64(event, token_usage_pos::EMITTED_SEQ).unwrap() >= now_secs() as u64 - 60
+            );
             assert!(value_u64(event, token_usage_pos::EST_COST_MICRO_USD).unwrap() > 0);
             let attrs = EventAttributes::from_sparse(&event.attrs);
             assert_eq!(attrs.session_id, Some(Some("s_test".to_string())));
@@ -908,7 +977,7 @@ mod tests {
             value_u64(&first[0], token_usage_pos::OUTPUT_TOKENS),
             Some(50)
         );
-        assert_eq!(value_u64(&first[0], token_usage_pos::EMITTED_SEQ), Some(1));
+        let first_seq = value_u64(&first[0], token_usage_pos::EMITTED_SEQ).unwrap();
 
         let mut content = fs::read_to_string(&transcript).unwrap();
         content.push_str(&claude_line("m2", "r2", &recent_ts(2, 0), 30));
@@ -925,7 +994,7 @@ mod tests {
             value_u64(&second[0], token_usage_pos::MESSAGE_COUNT),
             Some(2)
         );
-        assert_eq!(value_u64(&second[0], token_usage_pos::EMITTED_SEQ), Some(2));
+        assert!(value_u64(&second[0], token_usage_pos::EMITTED_SEQ).unwrap() > first_seq);
     }
 
     #[test]
@@ -967,7 +1036,9 @@ mod tests {
             value_u64(zero_event, token_usage_pos::MESSAGE_COUNT),
             Some(0)
         );
-        assert_eq!(value_u64(zero_event, token_usage_pos::EMITTED_SEQ), Some(2));
+        assert!(
+            value_u64(zero_event, token_usage_pos::EMITTED_SEQ).unwrap() >= now_secs() as u64 - 60
+        );
     }
 
     #[test]
@@ -993,6 +1064,145 @@ mod tests {
             value_u64(&events[0], token_usage_pos::MESSAGE_COUNT),
             Some(2)
         );
+    }
+
+    #[test]
+    fn invalid_utf8_lines_are_skipped_and_the_cursor_advances() {
+        // A single invalid byte must not wedge the cursor forever (UTF-8
+        // strict reads would error at the same offset on every pass and lose
+        // all usage after that point).
+        let (_dir, db, transcript) = setup();
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(claude_line("m1", "r1", &recent_ts(1, 0), 50).as_bytes());
+        bytes.push(b'\n');
+        bytes.extend_from_slice(b"{\"garbage\": \"\xff\xfe broken\"}\n");
+        bytes.extend_from_slice(claude_line("m2", "r2", &recent_ts(2, 0), 30).as_bytes());
+        bytes.push(b'\n');
+        fs::write(&transcript, bytes).unwrap();
+
+        let events = run(&db, &transcript).unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            value_u64(&events[0], token_usage_pos::MESSAGE_COUNT),
+            Some(2),
+            "usage after the invalid-UTF-8 line must still count"
+        );
+        // The cursor advanced past everything: the next pass is quiet.
+        assert!(run(&db, &transcript).unwrap().is_empty());
+    }
+
+    #[test]
+    fn complete_final_line_without_newline_is_counted() {
+        // Agent killed between writing the JSON object and its newline: the
+        // file never grows again, so the entry must be counted now instead
+        // of being suppressed forever by the size/mtime snapshot.
+        let (_dir, db, transcript) = setup();
+        fs::write(
+            &transcript,
+            claude_line("m1", "r1", &recent_ts(1, 0), 50), // no trailing \n
+        )
+        .unwrap();
+        let events = run(&db, &transcript).unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            value_u64(&events[0], token_usage_pos::MESSAGE_COUNT),
+            Some(1)
+        );
+        assert!(run(&db, &transcript).unwrap().is_empty());
+    }
+
+    #[test]
+    fn truncated_final_json_stays_pending_until_completed() {
+        // A half-written JSON object (not yet valid) is a write in progress:
+        // the cursor stays before it and the completed line counts later.
+        let (_dir, db, transcript) = setup();
+        let full = claude_line("m1", "r1", &recent_ts(1, 0), 50);
+        fs::write(&transcript, &full[..full.len() - 5]).unwrap();
+        assert!(run(&db, &transcript).unwrap().is_empty());
+        fs::write(&transcript, format!("{full}\n")).unwrap();
+        assert_eq!(run(&db, &transcript).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn unreadable_state_resets_the_cursor_and_recounts_idempotently() {
+        // Continuing mid-file on default codex state would book the whole
+        // cumulative history as one fresh delta; a full re-read dedups by
+        // entry identity instead.
+        let (_dir, db, transcript) = setup();
+        let identity = SessionIdentity {
+            tool: "codex".to_string(),
+            ..identity()
+        };
+        let token_count = |ts: String, total: u64| {
+            format!(
+                r#"{{"timestamp":"{ts}","type":"event_msg","payload":{{"type":"token_count","info":{{"total_token_usage":{{"input_tokens":{total},"cached_input_tokens":0,"output_tokens":10,"reasoning_output_tokens":0,"total_tokens":{}}}}}}}}}"#,
+                total + 10
+            )
+        };
+        fs::write(
+            &transcript,
+            format!(
+                "{}\n{}\n",
+                token_count(recent_ts(1, 0), 100),
+                token_count(recent_ts(6, 0), 300),
+            ),
+        )
+        .unwrap();
+        let events = run_as(&db, &identity, &transcript).unwrap();
+        assert_eq!(events.len(), 2);
+
+        // Corrupt the persisted state (e.g. a cross-version enum change) and
+        // grow the file so the pass runs.
+        let path = transcript.display().to_string();
+        db.commit_batch(&BatchCommit {
+            session_id: &identity.session_id,
+            stream_path: &path,
+            entries: &[],
+            new_offset: fs::metadata(&transcript).unwrap().len(),
+            state_json: Some("{\"kind\": \"from-the-future\""),
+            pending_flush: false,
+            min_bucket_ts: 0,
+        })
+        .unwrap();
+        let mut content = fs::read_to_string(&transcript).unwrap();
+        content.push_str(&token_count(recent_ts(11, 0), 350));
+        content.push('\n');
+        fs::write(&transcript, content).unwrap();
+
+        // The re-read from offset 0 rebuilds identical entries (deduped) and
+        // only the genuinely new turn emits; nothing double counts.
+        let events = run_as(&db, &identity, &transcript).unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            value_u64(&events[0], token_usage_pos::INPUT_TOKENS),
+            Some(50)
+        );
+        let first_bucket = db
+            .aggregate_bucket(&identity.session_id, "gpt-5", bucket_of(1, 0) as u32)
+            .unwrap();
+        assert_eq!(first_bucket.message_count, 1, "no double count");
+    }
+
+    #[test]
+    fn shrunken_file_re_reads_idempotently_from_scratch() {
+        let (_dir, db, transcript) = setup();
+        let l1 = claude_line("m1", "r1", &recent_ts(1, 0), 50);
+        let l2 = claude_line("m2", "r2", &recent_ts(2, 0), 30);
+        fs::write(&transcript, format!("{l1}\n{l2}\n")).unwrap();
+        assert_eq!(run(&db, &transcript).unwrap().len(), 1);
+
+        // The file is truncated back to one line (rewrite/rotation): the
+        // cursor resets and the surviving entry re-extracts idempotently
+        // (no aggregate change, no re-emission). The truncated-away entry
+        // remains counted - a documented residual: entries have no per-file
+        // ownership, and rollouts/transcripts are append-only in practice.
+        fs::write(&transcript, format!("{l1}\n")).unwrap();
+        let events = run(&db, &transcript).unwrap();
+        assert!(events.is_empty(), "no aggregate change from the re-read");
+        let agg = db
+            .aggregate_bucket("s_test", "claude-sonnet-4-20250514", bucket_of(1, 0) as u32)
+            .unwrap();
+        assert_eq!(agg.message_count, 2);
     }
 
     #[test]

--- a/src/daemon/token_usage_worker.rs
+++ b/src/daemon/token_usage_worker.rs
@@ -168,6 +168,7 @@ impl TokenUsageWorker {
         sweep_ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
         sweep_ticker.tick().await; // skip the immediate tick
 
+        self.prune_old_entries().await;
         self.enqueue_sweep_tasks().await;
         self.reconcile_flagged().await;
 
@@ -196,6 +197,7 @@ impl TokenUsageWorker {
                     }
                 }
                 _ = sweep_ticker.tick() => {
+                    self.prune_old_entries().await;
                     self.enqueue_sweep_tasks().await;
                     // Crash recovery: reconcile flags left by a pass that
                     // died between its batch commit and its reconcile step,
@@ -279,6 +281,18 @@ impl TokenUsageWorker {
         for task in tasks {
             self.enqueue_sweep(task);
         }
+    }
+
+    /// Retention prune, run once per sweep off the async loop.
+    async fn prune_old_entries(&self) {
+        let token_db = self.token_db.clone();
+        let _ = tokio::task::spawn_blocking(move || {
+            let cutoff = retention_cutoff_bucket(now_secs());
+            if let Err(e) = token_db.prune_buckets_before(cutoff) {
+                tracing::warn!(error = %e, "token-usage retention prune failed");
+            }
+        })
+        .await;
     }
 
     /// Reconcile cross-session flags off the async loop (used by sweeps for

--- a/src/daemon/token_usage_worker.rs
+++ b/src/daemon/token_usage_worker.rs
@@ -159,6 +159,9 @@ pub fn spawn_token_usage_worker(
         notify_queue: VecDeque::new(),
         sweep_queue: VecDeque::new(),
         queued: HashSet::new(),
+        sweep_interval: Duration::from_secs(30 * 60),
+        #[cfg(test)]
+        test_sink: None,
     };
     tokio::spawn(async move {
         worker.run().await;
@@ -182,12 +185,37 @@ struct TokenUsageWorker {
     /// Sweep/backfill work: processed only in the background loop.
     sweep_queue: VecDeque<TokenUsageTask>,
     queued: HashSet<TokenUsageTask>,
+    /// 30 minutes in production; injectable so tests can drive the ticker.
+    sweep_interval: Duration,
+    /// Test-only event capture: the metrics DB is a process-lifetime
+    /// singleton, so run()-level tests inject a sink instead of a real
+    /// telemetry handle.
+    #[cfg(test)]
+    test_sink: Option<TestSink>,
 }
 
+#[cfg(test)]
+type TestSink = Arc<dyn Fn(&[MetricEvent]) -> Result<(), GitAiError> + Send + Sync>;
+
 impl TokenUsageWorker {
+    /// The sink every task/reconcile pass hands emitted events to.
+    fn make_sink(&self) -> impl Fn(&[MetricEvent]) -> Result<(), GitAiError> + Send + use<> {
+        let telemetry = self.telemetry.clone();
+        let shutdown_flag = self.shutdown_flag.clone();
+        #[cfg(test)]
+        let test_sink = self.test_sink.clone();
+        move |events: &[MetricEvent]| {
+            #[cfg(test)]
+            if let Some(sink) = &test_sink {
+                return sink(events);
+            }
+            persist_events(&telemetry, &shutdown_flag, events)
+        }
+    }
+
     async fn run(mut self) {
         tracing::info!("token-usage worker started");
-        let mut sweep_ticker = interval(Duration::from_secs(30 * 60));
+        let mut sweep_ticker = interval(self.sweep_interval);
         // After suspend/resume, one sweep covers everything; do not replay
         // every missed tick.
         sweep_ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
@@ -324,10 +352,8 @@ impl TokenUsageWorker {
     /// crash recovery; the per-task path reconciles inline).
     async fn reconcile_flagged(&self) {
         let token_db = self.token_db.clone();
-        let telemetry = self.telemetry.clone();
-        let shutdown_flag = self.shutdown_flag.clone();
+        let sink = self.make_sink();
         let _ = tokio::task::spawn_blocking(move || {
-            let sink = |events: &[MetricEvent]| persist_events(&telemetry, &shutdown_flag, events);
             if let Err(e) = reconcile_flagged_sessions(&token_db, &sink) {
                 tracing::warn!(error = %e, "token-usage cross-session reconcile failed");
             }
@@ -338,17 +364,11 @@ impl TokenUsageWorker {
     async fn process_task(&mut self, task: TokenUsageTask) {
         let streams_db = self.streams_db.clone();
         let token_db = self.token_db.clone();
-        let telemetry = self.telemetry.clone();
+        let sink = self.make_sink();
         let shutdown_flag = self.shutdown_flag.clone();
         let task_clone = task.clone();
         let mut handle = tokio::task::spawn_blocking(move || {
-            process_task_blocking(
-                &streams_db,
-                &token_db,
-                &telemetry,
-                &task_clone,
-                &shutdown_flag,
-            )
+            process_task_blocking(&streams_db, &token_db, &sink, &task_clone, &shutdown_flag)
         });
         // Keep watching for shutdown while the blocking pass runs: setting
         // the flag makes the pass stop at its next line/batch boundary.
@@ -510,7 +530,7 @@ fn retention_cutoff_bucket(now: i64) -> u32 {
 fn process_task_blocking(
     streams_db: &StreamsDatabase,
     token_db: &TokenUsageDatabase,
-    telemetry: &DaemonTelemetryWorkerHandle,
+    sink: &impl Fn(&[MetricEvent]) -> Result<(), GitAiError>,
     task: &TokenUsageTask,
     shutdown_flag: &AtomicBool,
 ) -> Result<(), GitAiError> {
@@ -521,7 +541,6 @@ fn process_task_blocking(
         return Ok(());
     };
     let identity = SessionIdentity::from_stream(&stream);
-    let sink = |events: &[MetricEvent]| persist_events(telemetry, shutdown_flag, events);
     let result = process_file(
         token_db,
         &identity,
@@ -537,7 +556,7 @@ fn process_task_blocking(
             }
             repo_url
         },
-        &sink,
+        sink,
     );
     if let Err(e) = &result {
         // Keyed by the rollup session id (subagent transcripts track under
@@ -555,7 +574,7 @@ fn process_task_blocking(
     // transcript — charging them here would put a healthy file into error
     // backoff and point diagnostics at the wrong session.
     if result.is_ok()
-        && let Err(e) = reconcile_flagged_sessions(token_db, &sink)
+        && let Err(e) = reconcile_flagged_sessions(token_db, sink)
     {
         tracing::warn!(error = %e, "token-usage cross-session reconcile failed; flags retained for retry");
     }
@@ -1547,6 +1566,8 @@ mod tests {
             notify_queue: VecDeque::new(),
             sweep_queue: VecDeque::new(),
             queued: HashSet::new(),
+            sweep_interval: Duration::from_secs(30 * 60),
+            test_sink: None,
         }
     }
 
@@ -1668,7 +1689,7 @@ mod tests {
         let result = process_task_blocking(
             &streams_db,
             &token_db,
-            &DaemonTelemetryWorkerHandle::new_noop(),
+            &|_: &[MetricEvent]| Ok(()),
             &task,
             &AtomicBool::new(false),
         );
@@ -1709,5 +1730,227 @@ mod tests {
         assert_eq!(error_backoff_secs(3), 300);
         assert_eq!(error_backoff_secs(4), 1800);
         assert_eq!(error_backoff_secs(100), 1800);
+    }
+
+    fn collecting_sink() -> (Arc<Mutex<Vec<MetricEvent>>>, TestSink) {
+        let collected: Arc<Mutex<Vec<MetricEvent>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink_events = collected.clone();
+        let sink: TestSink = Arc::new(move |events: &[MetricEvent]| {
+            sink_events.lock().unwrap().extend(events.to_vec());
+            Ok(())
+        });
+        (collected, sink)
+    }
+
+    #[test]
+    fn parked_fork_stays_pending_and_a_later_sweep_pass_releases_it() {
+        // A fork whose transcript ends with its first usage event still
+        // parked must survive the full worker chain across two passes:
+        // pending_flush persists, the unchanged file stays a sweep candidate,
+        // and the re-sweep pass releases the turn once the burst window has
+        // passed in wall clock.
+        let dir = tempfile::tempdir().unwrap();
+        let streams_db =
+            Arc::new(StreamsDatabase::open(dir.path().join("transcripts-db")).unwrap());
+        let token_db =
+            Arc::new(TokenUsageDatabase::open(dir.path().join("token-usage-db")).unwrap());
+        let path = dir.path().join("rollout.jsonl");
+        let now = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+        let fork_meta = r#"{"timestamp":"2026-01-01T00:00:00Z","type":"session_meta","payload":{"id":"child","forked_from_id":"parent"}}"#;
+        let token_count = format!(
+            r#"{{"timestamp":"{now}","type":"event_msg","payload":{{"type":"token_count","info":{{"total_token_usage":{{"input_tokens":10,"cached_input_tokens":0,"output_tokens":5,"reasoning_output_tokens":0,"total_tokens":15}}}}}}}}"#
+        );
+        fs::write(&path, format!("{fork_meta}\n{token_count}\n")).unwrap();
+        let path_str = path.display().to_string();
+        streams_db
+            .insert_stream(&stream_record("s_fork", "codex", &path_str))
+            .unwrap();
+        let task = TokenUsageTask {
+            session_id: "s_fork".to_string(),
+            tool: "codex".to_string(),
+            stream_path: path_str.clone(),
+        };
+        let (collected, sink) = collecting_sink();
+
+        // Pass 1: the usage event is written moments ago, so the EOF flush
+        // must not release it (a burst partner may still be coming).
+        process_task_blocking(&streams_db, &token_db, &|e| sink(e), &task, &flag_off()).unwrap();
+        assert!(collected.lock().unwrap().is_empty(), "turn stays parked");
+        let tracked = token_db
+            .ensure_file("s_fork", &path_str, "codex", "s_fork-ext")
+            .unwrap();
+        assert!(tracked.pending_flush);
+        // The bytes have not changed, but the pending flush alone keeps the
+        // file a sweep candidate.
+        assert_eq!(sweep_candidates(&streams_db, &token_db).len(), 1);
+
+        // Pass 2, after the burst window: the parked turn is the session's
+        // own first turn and is released and emitted. (The flush clock has
+        // second granularity, so sleep past the window plus one second.)
+        std::thread::sleep(Duration::from_millis(2100));
+        process_task_blocking(&streams_db, &token_db, &|e| sink(e), &task, &flag_off()).unwrap();
+        let events = collected.lock().unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            value_u64(&events[0], token_usage_pos::TOTAL_TOKENS),
+            Some(15)
+        );
+        let tracked = token_db
+            .ensure_file("s_fork", &path_str, "codex", "s_fork-ext")
+            .unwrap();
+        assert!(!tracked.pending_flush);
+        assert!(sweep_candidates(&streams_db, &token_db).is_empty());
+    }
+
+    fn flag_off() -> AtomicBool {
+        AtomicBool::new(false)
+    }
+
+    fn spawn_run_loop(
+        streams_db: Arc<StreamsDatabase>,
+        token_db: Arc<TokenUsageDatabase>,
+        sink: TestSink,
+        sweep_interval: Duration,
+    ) -> (TokenUsageWorkerHandle, Arc<Notify>) {
+        let (notify_tx, notify_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (drain_tx, drain_rx) = tokio::sync::mpsc::unbounded_channel();
+        let shutdown_notify = Arc::new(Notify::new());
+        let worker = TokenUsageWorker {
+            streams_db,
+            token_db,
+            telemetry: DaemonTelemetryWorkerHandle::new_noop(),
+            shutdown_notify: shutdown_notify.clone(),
+            shutdown_flag: Arc::new(AtomicBool::new(false)),
+            notify_rx,
+            drain_rx,
+            notify_queue: VecDeque::new(),
+            sweep_queue: VecDeque::new(),
+            queued: HashSet::new(),
+            sweep_interval,
+            test_sink: Some(sink),
+        };
+        tokio::spawn(worker.run());
+        (
+            TokenUsageWorkerHandle {
+                notify_tx,
+                drain_tx,
+            },
+            shutdown_notify,
+        )
+    }
+
+    /// Poll until the collected events contain the given bucket, or panic.
+    async fn wait_for_bucket(collected: &Arc<Mutex<Vec<MetricEvent>>>, bucket: u64) {
+        for _ in 0..600 {
+            if collected
+                .lock()
+                .unwrap()
+                .iter()
+                .any(|e| value_u64(e, token_usage_pos::BUCKET_TS) == Some(bucket))
+            {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        panic!("bucket {bucket} was never emitted");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn run_loop_startup_sweep_backfills_and_ticker_picks_up_appends() {
+        // The real run() loop, end to end: the startup sweep backfills a
+        // tracked transcript with no notification ever sent, and the sweep
+        // ticker later picks up appended lines on its own.
+        let dir = tempfile::tempdir().unwrap();
+        let streams_db =
+            Arc::new(StreamsDatabase::open(dir.path().join("transcripts-db")).unwrap());
+        let token_db =
+            Arc::new(TokenUsageDatabase::open(dir.path().join("token-usage-db")).unwrap());
+        let path = dir.path().join("transcript.jsonl");
+        fs::write(
+            &path,
+            format!("{}\n", claude_line("m1", "r1", &recent_ts(1, 0), 50)),
+        )
+        .unwrap();
+        streams_db
+            .insert_stream(&stream_record(
+                "s_run",
+                "claude",
+                &path.display().to_string(),
+            ))
+            .unwrap();
+        let (collected, sink) = collecting_sink();
+        let (_handle, shutdown) =
+            spawn_run_loop(streams_db, token_db, sink, Duration::from_millis(200));
+
+        wait_for_bucket(&collected, bucket_of(1, 0)).await;
+
+        // Append into a new bucket without notifying: only the ticker sweep
+        // can find it.
+        let mut content = fs::read_to_string(&path).unwrap();
+        content.push_str(&format!(
+            "{}\n",
+            claude_line("m2", "r2", &recent_ts(6, 0), 70)
+        ));
+        fs::write(&path, content).unwrap();
+        wait_for_bucket(&collected, bucket_of(6, 0)).await;
+
+        shutdown.notify_one();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn run_loop_restart_backfills_from_the_committed_cursor() {
+        // Daemon restart: a fresh worker over the same databases picks up
+        // lines appended while no worker ran, via its startup sweep alone,
+        // without re-emitting history the previous worker already handled.
+        let dir = tempfile::tempdir().unwrap();
+        let streams_db =
+            Arc::new(StreamsDatabase::open(dir.path().join("transcripts-db")).unwrap());
+        let token_db =
+            Arc::new(TokenUsageDatabase::open(dir.path().join("token-usage-db")).unwrap());
+        let path = dir.path().join("transcript.jsonl");
+        fs::write(
+            &path,
+            format!("{}\n", claude_line("m1", "r1", &recent_ts(1, 0), 50)),
+        )
+        .unwrap();
+        streams_db
+            .insert_stream(&stream_record(
+                "s_restart",
+                "claude",
+                &path.display().to_string(),
+            ))
+            .unwrap();
+        let (collected, sink) = collecting_sink();
+
+        // Worker A: 30-minute interval, so only its startup sweep runs.
+        let (_handle_a, shutdown_a) = spawn_run_loop(
+            streams_db.clone(),
+            token_db.clone(),
+            sink.clone(),
+            Duration::from_secs(30 * 60),
+        );
+        wait_for_bucket(&collected, bucket_of(1, 0)).await;
+        shutdown_a.notify_one();
+
+        // While no worker runs, the agent keeps writing.
+        let mut content = fs::read_to_string(&path).unwrap();
+        content.push_str(&format!(
+            "{}\n",
+            claude_line("m2", "r2", &recent_ts(6, 0), 70)
+        ));
+        fs::write(&path, content).unwrap();
+
+        // Worker B (the restarted daemon) backfills the gap at startup.
+        let (_handle_b, shutdown_b) =
+            spawn_run_loop(streams_db, token_db, sink, Duration::from_secs(30 * 60));
+        wait_for_bucket(&collected, bucket_of(6, 0)).await;
+        shutdown_b.notify_one();
+
+        let events = collected.lock().unwrap();
+        let first_bucket_emissions = events
+            .iter()
+            .filter(|e| value_u64(e, token_usage_pos::BUCKET_TS) == Some(bucket_of(1, 0)))
+            .count();
+        assert_eq!(first_bucket_emissions, 1, "restart must not re-emit");
     }
 }

--- a/src/daemon/token_usage_worker.rs
+++ b/src/daemon/token_usage_worker.rs
@@ -171,21 +171,28 @@ impl TokenUsageWorker {
         self.enqueue_sweep_tasks();
 
         loop {
-            // Promote notifications that arrived while processing.
-            while let Ok(task) = self.notify_rx.try_recv() {
-                self.enqueue_notify(task);
-            }
             if self.shutdown_flag.load(Ordering::Relaxed) {
                 break;
             }
-            if let Some(task) = self.pop_next() {
-                self.process_task(task).await;
-                continue;
-            }
+            // Ready work is one select arm (the stream worker's pattern), so
+            // drain requests, notifications, and shutdown are still serviced
+            // between tasks while a long backfill queue is being worked off.
+            let has_ready_task = !self.notify_queue.is_empty() || !self.sweep_queue.is_empty();
             tokio::select! {
                 _ = self.shutdown_notify.notified() => {
                     self.shutdown_flag.store(true, Ordering::Relaxed);
                     break;
+                }
+                _ = async {}, if has_ready_task => {
+                    // Ingest pending notifications first so fresh work is
+                    // picked (and promoted over backfill) before the next
+                    // task is chosen.
+                    while let Ok(task) = self.notify_rx.try_recv() {
+                        self.enqueue_notify(task);
+                    }
+                    if let Some(task) = self.pop_next() {
+                        self.process_task(task).await;
+                    }
                 }
                 _ = sweep_ticker.tick() => {
                     self.enqueue_sweep_tasks();

--- a/src/daemon/token_usage_worker.rs
+++ b/src/daemon/token_usage_worker.rs
@@ -1,0 +1,872 @@
+//! Token-usage worker: reads agent transcripts incrementally, aggregates
+//! deduplicated token usage into 5-minute UTC buckets, and emits `TokenUsage`
+//! metric events for buckets whose aggregate changed.
+//!
+//! Design notes:
+//! - Everything runs off the trace2 ingestion path: work arrives as
+//!   non-blocking notifications from the stream worker (after it processed a
+//!   transcript), a 30-minute sweep ticker, and a startup sweep.
+//! - Sweeps enumerate the streams database's `transcript` rows, so every
+//!   session git-ai knows about is backfilled: a newly tracked file starts at
+//!   byte offset 0 and its full history is bucketed on first processing.
+//! - The read cursor, extractor state, entries, and emission fingerprints all
+//!   live in [`TokenUsageDatabase`]; each batch commits atomically, so there
+//!   is no retry machinery here - a failed file is retried on the next
+//!   notification or sweep, and unchanged files are skipped by size/mtime.
+//! - Claude subagent transcripts roll up to their parent session (matching
+//!   ccusage), which also lets sidechain replays dedup against the parent's
+//!   entries.
+//! - The `token_usage_metrics` feature flag is read fresh on every trigger,
+//!   so the worker can be disabled without a daemon restart (enabling it
+//!   only requires the daemon to be running with the worker spawned).
+
+use std::collections::HashSet;
+use std::collections::VecDeque;
+use std::io::{BufReader, Seek, SeekFrom};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use tokio::sync::Notify;
+use tokio::time::interval;
+
+use crate::authorship::authorship_log_serialization::generate_session_id;
+use crate::daemon::telemetry_worker::DaemonTelemetryWorkerHandle;
+use crate::error::GitAiError;
+use crate::metrics::{EventAttributes, MetricEvent, PosEncoded, TokenUsageValues};
+use crate::streams::db::{StreamRecord, StreamsDatabase};
+use crate::streams::types::{JsonlLineState, read_jsonl_line};
+use crate::token_usage::db::{DirtyBuckets, TokenUsageDatabase};
+use crate::token_usage::extractor_for_tool;
+
+/// Entry/byte bounds of one atomic batch commit.
+const BATCH_MAX_ENTRIES: usize = 1_000;
+const BATCH_MAX_BYTES: usize = 4 * 1024 * 1024;
+
+/// Same telemetry-buffer backpressure as the stream worker.
+const BACKPRESSURE_THRESHOLD: usize = 5_000;
+const BACKPRESSURE_MAX_WAITS: usize = 40;
+
+/// A transcript file to (re)process, identified by its streams-db row.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct TokenUsageTask {
+    session_id: String,
+    tool: String,
+    stream_path: String,
+}
+
+struct DrainRequest {
+    completion: tokio::sync::oneshot::Sender<()>,
+}
+
+/// Handle for feeding the worker.
+#[derive(Clone)]
+pub struct TokenUsageWorkerHandle {
+    notify_tx: tokio::sync::mpsc::UnboundedSender<TokenUsageTask>,
+    drain_tx: tokio::sync::mpsc::UnboundedSender<DrainRequest>,
+}
+
+impl TokenUsageWorkerHandle {
+    /// Notify the worker that the stream worker finished processing a
+    /// transcript (cheap, non-blocking; unsupported tools are dropped here).
+    pub fn notify_stream_processed(&self, session_id: &str, tool: &str, stream_path: &Path) {
+        if extractor_for_tool(tool).is_none() {
+            return;
+        }
+        let _ = self.notify_tx.send(TokenUsageTask {
+            session_id: session_id.to_string(),
+            tool: tool.to_string(),
+            stream_path: stream_path.display().to_string(),
+        });
+    }
+
+    /// Wait until all currently queued work has been processed.
+    pub async fn drain(&self) -> Result<(), String> {
+        let (completion_tx, completion_rx) = tokio::sync::oneshot::channel();
+        self.drain_tx
+            .send(DrainRequest {
+                completion: completion_tx,
+            })
+            .map_err(|_| "token-usage worker has stopped".to_string())?;
+        completion_rx
+            .await
+            .map_err(|_| "token-usage worker drain was cancelled".to_string())
+    }
+}
+
+/// Spawn the worker on the current tokio runtime.
+pub fn spawn_token_usage_worker(
+    streams_db: Arc<StreamsDatabase>,
+    token_db: Arc<TokenUsageDatabase>,
+    telemetry: DaemonTelemetryWorkerHandle,
+    shutdown_notify: Arc<Notify>,
+) -> TokenUsageWorkerHandle {
+    let (notify_tx, notify_rx) = tokio::sync::mpsc::unbounded_channel();
+    let (drain_tx, drain_rx) = tokio::sync::mpsc::unbounded_channel();
+    let worker = TokenUsageWorker {
+        streams_db,
+        token_db,
+        telemetry,
+        shutdown_notify,
+        shutdown_flag: Arc::new(AtomicBool::new(false)),
+        notify_rx,
+        drain_rx,
+        queue: VecDeque::new(),
+        queued: HashSet::new(),
+    };
+    tokio::spawn(async move {
+        worker.run().await;
+    });
+    TokenUsageWorkerHandle {
+        notify_tx,
+        drain_tx,
+    }
+}
+
+struct TokenUsageWorker {
+    streams_db: Arc<StreamsDatabase>,
+    token_db: Arc<TokenUsageDatabase>,
+    telemetry: DaemonTelemetryWorkerHandle,
+    shutdown_notify: Arc<Notify>,
+    shutdown_flag: Arc<AtomicBool>,
+    notify_rx: tokio::sync::mpsc::UnboundedReceiver<TokenUsageTask>,
+    drain_rx: tokio::sync::mpsc::UnboundedReceiver<DrainRequest>,
+    queue: VecDeque<TokenUsageTask>,
+    queued: HashSet<TokenUsageTask>,
+}
+
+/// Read the flag fresh so config changes apply without a daemon restart.
+fn token_usage_enabled() -> bool {
+    crate::config::Config::fresh()
+        .get_feature_flags()
+        .token_usage_metrics
+}
+
+impl TokenUsageWorker {
+    async fn run(mut self) {
+        tracing::info!("token-usage worker started");
+        let mut sweep_ticker = interval(Duration::from_secs(30 * 60));
+        sweep_ticker.tick().await; // skip the immediate tick
+
+        if token_usage_enabled() {
+            self.enqueue_sweep_tasks();
+        }
+
+        loop {
+            self.process_queued().await;
+            if self.shutdown_flag.load(Ordering::Relaxed) {
+                break;
+            }
+            tokio::select! {
+                _ = self.shutdown_notify.notified() => {
+                    self.shutdown_flag.store(true, Ordering::Relaxed);
+                    break;
+                }
+                _ = sweep_ticker.tick() => {
+                    if token_usage_enabled() {
+                        self.enqueue_sweep_tasks();
+                    }
+                }
+                Some(task) = self.notify_rx.recv() => {
+                    if token_usage_enabled() {
+                        self.enqueue(task);
+                    }
+                }
+                Some(request) = self.drain_rx.recv() => {
+                    self.handle_drain(request).await;
+                }
+            }
+        }
+        tracing::info!("token-usage worker shutdown complete");
+    }
+
+    async fn handle_drain(&mut self, request: DrainRequest) {
+        // Consume notifications that were queued before the barrier.
+        while let Ok(task) = self.notify_rx.try_recv() {
+            if token_usage_enabled() {
+                self.enqueue(task);
+            }
+        }
+        self.process_queued().await;
+        let _ = request.completion.send(());
+    }
+
+    fn enqueue(&mut self, task: TokenUsageTask) {
+        if self.queued.insert(task.clone()) {
+            self.queue.push_back(task);
+        }
+    }
+
+    /// Enqueue every supported transcript the streams database knows about.
+    /// New files get a zero cursor in the token-usage database, which is what
+    /// backfills history for sessions tracked before this feature ran.
+    fn enqueue_sweep_tasks(&mut self) {
+        let streams = match self.streams_db.all_streams() {
+            Ok(streams) => streams,
+            Err(e) => {
+                tracing::warn!(error = %e, "token-usage sweep: failed to list streams");
+                return;
+            }
+        };
+        for stream in streams {
+            if stream.stream_kind != "transcript" || extractor_for_tool(&stream.tool).is_none() {
+                continue;
+            }
+            // Sessions whose transcript is gone can't be backfilled; skip
+            // them without recording errors so sweeps stay quiet.
+            if !std::path::Path::new(&stream.stream_path).exists() {
+                continue;
+            }
+            self.enqueue(TokenUsageTask {
+                session_id: stream.session_id,
+                tool: stream.tool,
+                stream_path: stream.stream_path,
+            });
+        }
+    }
+
+    async fn process_queued(&mut self) {
+        while let Some(task) = self.queue.pop_front() {
+            self.queued.remove(&task);
+            if self.shutdown_flag.load(Ordering::Relaxed) {
+                return;
+            }
+            let streams_db = self.streams_db.clone();
+            let token_db = self.token_db.clone();
+            let telemetry = self.telemetry.clone();
+            let shutdown_flag = self.shutdown_flag.clone();
+            let task_clone = task.clone();
+            let result = tokio::task::spawn_blocking(move || {
+                process_task_blocking(
+                    &streams_db,
+                    &token_db,
+                    &telemetry,
+                    &task_clone,
+                    &shutdown_flag,
+                )
+            })
+            .await;
+            match result {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => {
+                    tracing::warn!(error = %e, session_id = %task.session_id, "token-usage processing failed");
+                    let _ = self.token_db.record_error(
+                        &task.session_id,
+                        &task.stream_path,
+                        &e.to_string(),
+                    );
+                }
+                Err(e) => {
+                    tracing::error!(error = %e, session_id = %task.session_id, "token-usage task panicked");
+                }
+            }
+        }
+    }
+}
+
+/// Per-file emission context derived from the streams-db row.
+struct EmissionContext {
+    /// Rollup session: subagent transcripts attribute to their parent session
+    /// (matching ccusage), which also dedups sidechain replays.
+    session_id: String,
+    external_session_id: String,
+    tool: String,
+    repo_url: Option<String>,
+}
+
+impl EmissionContext {
+    fn from_stream(stream: &StreamRecord) -> Self {
+        let (session_id, external_session_id) = match &stream.external_parent_session_id {
+            Some(parent_ext) => (
+                generate_session_id(parent_ext, &stream.tool),
+                parent_ext.clone(),
+            ),
+            None => (
+                stream.session_id.clone(),
+                stream.external_session_id.clone(),
+            ),
+        };
+        let repo_url = stream
+            .repo_work_dir
+            .as_ref()
+            .and_then(|dir| crate::repo_url::resolve_repo_url_from_path(&PathBuf::from(dir)));
+        Self {
+            session_id,
+            external_session_id,
+            tool: stream.tool.clone(),
+            repo_url,
+        }
+    }
+}
+
+fn process_task_blocking(
+    streams_db: &StreamsDatabase,
+    token_db: &TokenUsageDatabase,
+    telemetry: &DaemonTelemetryWorkerHandle,
+    task: &TokenUsageTask,
+    shutdown_flag: &AtomicBool,
+) -> Result<(), GitAiError> {
+    let Some(stream) = streams_db
+        .get_stream(&task.session_id, "transcript", &task.stream_path)
+        .map_err(|e| GitAiError::Generic(format!("streams db read failed: {e}")))?
+    else {
+        return Ok(());
+    };
+    let ctx = EmissionContext::from_stream(&stream);
+    process_file(token_db, &ctx, &task.stream_path, shutdown_flag, |events| {
+        // Backpressure before handing a batch to the telemetry queue.
+        for _ in 0..BACKPRESSURE_MAX_WAITS {
+            if telemetry.metrics_buffer_len() < BACKPRESSURE_THRESHOLD
+                || shutdown_flag.load(Ordering::Relaxed)
+            {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        }
+        telemetry.persist_metrics_blocking(events).map(|_| ())
+    })
+}
+
+/// Incrementally read one transcript file, persist deduplicated entries, and
+/// emit changed buckets through `sink`. Split out (with an injectable sink)
+/// for direct testing without a daemon.
+fn process_file(
+    token_db: &TokenUsageDatabase,
+    ctx: &EmissionContext,
+    stream_path: &str,
+    shutdown_flag: &AtomicBool,
+    sink: impl Fn(&[MetricEvent]) -> Result<(), GitAiError>,
+) -> Result<(), GitAiError> {
+    let tracked = token_db.ensure_file(&ctx.session_id, stream_path, &ctx.tool)?;
+    let metadata = std::fs::metadata(stream_path)?;
+    let size = metadata.len();
+    let modified = metadata
+        .modified()
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_secs() as i64);
+
+    // Quiet skip: nothing changed since the last completed pass.
+    if size == tracked.last_known_size as u64
+        && modified == tracked.last_modified
+        && tracked.byte_offset <= size
+    {
+        return Ok(());
+    }
+
+    let Some(mut extractor) = extractor_for_tool(&ctx.tool) else {
+        return Ok(());
+    };
+    // A shrunken file was rewritten: restart from scratch. Entry-level dedup
+    // keeps re-extraction idempotent.
+    let mut offset = tracked.byte_offset;
+    if offset > size {
+        offset = 0;
+    } else if let Some(state) = tracked.state_json.as_deref() {
+        extractor.restore_state(state);
+    }
+
+    let file = std::fs::File::open(stream_path)?;
+    let mut reader = BufReader::with_capacity(128 * 1024, file);
+    reader.seek(SeekFrom::Start(offset))?;
+
+    let mut dirty = DirtyBuckets::new();
+    let mut line = String::new();
+    let mut reached_end = false;
+    let mut interrupted = false;
+    while !reached_end && !interrupted {
+        let mut entries = Vec::new();
+        let mut consumed = 0usize;
+        loop {
+            if shutdown_flag.load(Ordering::Relaxed) {
+                interrupted = true;
+                break;
+            }
+            match read_jsonl_line(&mut reader, &mut line)? {
+                JsonlLineState::Eof => {
+                    reached_end = true;
+                    break;
+                }
+                // A partial trailing line is still being appended; re-read it
+                // next pass (the cursor stays before it).
+                JsonlLineState::Partial => {
+                    reached_end = true;
+                    break;
+                }
+                JsonlLineState::Complete(bytes) => {
+                    offset += bytes as u64;
+                    consumed += bytes;
+                    let trimmed = line.trim_end();
+                    if extractor.wants_line(trimmed) {
+                        entries.extend(extractor.extract_line(trimmed));
+                    }
+                    if entries.len() >= BATCH_MAX_ENTRIES || consumed >= BATCH_MAX_BYTES {
+                        break;
+                    }
+                }
+            }
+        }
+        dirty.extend(token_db.commit_batch(
+            &ctx.session_id,
+            stream_path,
+            &entries,
+            offset,
+            extractor.state_json().as_deref(),
+        )?);
+    }
+
+    if reached_end && !interrupted {
+        token_db.update_file_metadata(&ctx.session_id, stream_path, size, modified)?;
+    }
+
+    emit_changed_buckets(token_db, ctx, &dirty, sink)
+}
+
+/// Re-aggregate each dirty bucket and emit those whose fingerprint differs
+/// from the last emitted one, marking them emitted only after the sink
+/// accepted the events.
+fn emit_changed_buckets(
+    token_db: &TokenUsageDatabase,
+    ctx: &EmissionContext,
+    dirty: &DirtyBuckets,
+    sink: impl Fn(&[MetricEvent]) -> Result<(), GitAiError>,
+) -> Result<(), GitAiError> {
+    let mut events = Vec::new();
+    let mut emitted = Vec::new();
+    for (model, bucket) in dirty {
+        let aggregate = token_db.aggregate_bucket(&ctx.session_id, model, *bucket)?;
+        let fingerprint = aggregate.fingerprint();
+        if token_db
+            .emitted_fingerprint(&ctx.session_id, model, *bucket)?
+            .as_deref()
+            == Some(fingerprint.as_str())
+        {
+            continue;
+        }
+        let values = TokenUsageValues::new()
+            .bucket_ts(*bucket as u64)
+            .input_tokens(aggregate.input)
+            .output_tokens(aggregate.output)
+            .cache_read_tokens(aggregate.cache_read)
+            .cache_write_tokens(aggregate.cache_write)
+            .total_tokens(aggregate.total)
+            .reasoning_output_tokens_opt(aggregate.reasoning_output)
+            .est_cost_micro_usd(aggregate.cost_micro_usd)
+            .message_count(aggregate.message_count);
+        let mut attrs = EventAttributes::with_version(env!("CARGO_PKG_VERSION"))
+            .session_id(ctx.session_id.clone())
+            .external_session_id(ctx.external_session_id.clone())
+            .tool(&ctx.tool)
+            .model(model);
+        if let Some(url) = &ctx.repo_url {
+            attrs = attrs.repo_url(url.clone());
+        }
+        events.push(MetricEvent::new(&values, attrs.to_sparse()));
+        emitted.push((model.clone(), *bucket, fingerprint));
+    }
+    if events.is_empty() {
+        return Ok(());
+    }
+    sink(&events)?;
+    let now_ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+    for (model, bucket, fingerprint) in emitted {
+        token_db.mark_emitted(&ctx.session_id, &model, bucket, &fingerprint, now_ts)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::metrics::PosEncoded;
+    use crate::metrics::events::token_usage_pos;
+    use std::fs;
+    use std::sync::Mutex;
+
+    fn ctx() -> EmissionContext {
+        EmissionContext {
+            session_id: "s_test".to_string(),
+            external_session_id: "ext-test".to_string(),
+            tool: "claude".to_string(),
+            repo_url: Some("https://github.com/acme/repo".to_string()),
+        }
+    }
+
+    fn setup() -> (tempfile::TempDir, TokenUsageDatabase, PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let db = TokenUsageDatabase::open(dir.path().join("token-usage-db")).unwrap();
+        let transcript = dir.path().join("transcript.jsonl");
+        (dir, db, transcript)
+    }
+
+    fn claude_line(msg: &str, req: &str, ts: &str, output: u64) -> String {
+        format!(
+            r#"{{"timestamp":"{ts}","sessionId":"ext-test","requestId":"{req}","message":{{"id":"{msg}","model":"claude-sonnet-4-20250514","usage":{{"input_tokens":100,"output_tokens":{output},"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}}}}"#
+        )
+    }
+
+    fn run(
+        db: &TokenUsageDatabase,
+        transcript: &std::path::Path,
+    ) -> Result<Vec<MetricEvent>, GitAiError> {
+        let collected = Mutex::new(Vec::new());
+        let flag = AtomicBool::new(false);
+        process_file(
+            db,
+            &ctx(),
+            &transcript.display().to_string(),
+            &flag,
+            |events| {
+                collected.lock().unwrap().extend(events.to_vec());
+                Ok(())
+            },
+        )?;
+        Ok(collected.into_inner().unwrap())
+    }
+
+    fn value_u64(event: &MetricEvent, pos: usize) -> Option<u64> {
+        event.values.get(&pos.to_string()).and_then(|v| v.as_u64())
+    }
+
+    #[test]
+    fn processes_a_transcript_and_emits_bucket_events() {
+        let (_dir, db, transcript) = setup();
+        fs::write(
+            &transcript,
+            format!(
+                "{}\n{}\n",
+                claude_line("m1", "r1", "2026-01-01T00:01:00Z", 50),
+                claude_line("m2", "r2", "2026-01-01T00:06:00Z", 70),
+            ),
+        )
+        .unwrap();
+
+        let events = run(&db, &transcript).unwrap();
+        assert_eq!(events.len(), 2);
+        let mut buckets: Vec<u64> = events
+            .iter()
+            .map(|e| value_u64(e, token_usage_pos::BUCKET_TS).unwrap())
+            .collect();
+        buckets.sort_unstable();
+        // 2026-01-01T00:00:00Z = 1767225600.
+        assert_eq!(buckets, vec![1_767_225_600, 1_767_225_900]);
+        for event in &events {
+            assert_eq!(event.event_id, 9);
+            assert_eq!(value_u64(event, token_usage_pos::INPUT_TOKENS), Some(100));
+            assert_eq!(value_u64(event, token_usage_pos::MESSAGE_COUNT), Some(1));
+            assert!(value_u64(event, token_usage_pos::EST_COST_MICRO_USD).unwrap() > 0);
+            let attrs = EventAttributes::from_sparse(&event.attrs);
+            assert_eq!(attrs.session_id, Some(Some("s_test".to_string())));
+            assert_eq!(attrs.tool, Some(Some("claude".to_string())));
+            assert_eq!(
+                attrs.model,
+                Some(Some("claude-sonnet-4-20250514".to_string()))
+            );
+            assert_eq!(
+                attrs.repo_url,
+                Some(Some("https://github.com/acme/repo".to_string()))
+            );
+        }
+    }
+
+    #[test]
+    fn unchanged_file_emits_nothing_on_reprocess() {
+        let (_dir, db, transcript) = setup();
+        fs::write(
+            &transcript,
+            format!("{}\n", claude_line("m1", "r1", "2026-01-01T00:01:00Z", 50)),
+        )
+        .unwrap();
+        assert_eq!(run(&db, &transcript).unwrap().len(), 1);
+        // Size/mtime unchanged: skipped entirely.
+        assert!(run(&db, &transcript).unwrap().is_empty());
+    }
+
+    #[test]
+    fn appended_usage_reemits_the_bucket_with_higher_totals() {
+        let (_dir, db, transcript) = setup();
+        fs::write(
+            &transcript,
+            format!("{}\n", claude_line("m1", "r1", "2026-01-01T00:01:00Z", 50)),
+        )
+        .unwrap();
+        let first = run(&db, &transcript).unwrap();
+        assert_eq!(
+            value_u64(&first[0], token_usage_pos::OUTPUT_TOKENS),
+            Some(50)
+        );
+
+        let mut content = fs::read_to_string(&transcript).unwrap();
+        content.push_str(&claude_line("m2", "r2", "2026-01-01T00:02:00Z", 30));
+        content.push('\n');
+        fs::write(&transcript, content).unwrap();
+
+        let second = run(&db, &transcript).unwrap();
+        assert_eq!(second.len(), 1);
+        assert_eq!(
+            value_u64(&second[0], token_usage_pos::OUTPUT_TOKENS),
+            Some(80)
+        );
+        assert_eq!(
+            value_u64(&second[0], token_usage_pos::MESSAGE_COUNT),
+            Some(2)
+        );
+    }
+
+    #[test]
+    fn streaming_replacement_moving_buckets_reemits_zeroed_bucket() {
+        let (_dir, db, transcript) = setup();
+        fs::write(
+            &transcript,
+            format!("{}\n", claude_line("m1", "r1", "2026-01-01T00:01:00Z", 50)),
+        )
+        .unwrap();
+        assert_eq!(run(&db, &transcript).unwrap().len(), 1);
+
+        // The same message re-emits with larger totals in the next bucket:
+        // the old bucket empties and must re-emit as zero exactly once.
+        let mut content = fs::read_to_string(&transcript).unwrap();
+        content.push_str(&claude_line("m1", "r1", "2026-01-01T00:06:00Z", 90));
+        content.push('\n');
+        fs::write(&transcript, content).unwrap();
+
+        let events = run(&db, &transcript).unwrap();
+        assert_eq!(events.len(), 2);
+        let mut by_bucket: Vec<(u64, u64)> = events
+            .iter()
+            .map(|e| {
+                (
+                    value_u64(e, token_usage_pos::BUCKET_TS).unwrap(),
+                    value_u64(e, token_usage_pos::TOTAL_TOKENS).unwrap(),
+                )
+            })
+            .collect();
+        by_bucket.sort_unstable();
+        assert_eq!(by_bucket[0], (1_767_225_600, 0));
+        assert_eq!(by_bucket[1], (1_767_225_900, 190));
+        let zero_event = events
+            .iter()
+            .find(|e| value_u64(e, token_usage_pos::TOTAL_TOKENS) == Some(0))
+            .unwrap();
+        assert_eq!(
+            value_u64(zero_event, token_usage_pos::MESSAGE_COUNT),
+            Some(0)
+        );
+    }
+
+    #[test]
+    fn partial_trailing_line_is_left_for_the_next_pass() {
+        let (_dir, db, transcript) = setup();
+        let complete = claude_line("m1", "r1", "2026-01-01T00:01:00Z", 50);
+        let partial = claude_line("m2", "r2", "2026-01-01T00:02:00Z", 70);
+        let partial_prefix = &partial[..partial.len() - 10];
+        fs::write(&transcript, format!("{complete}\n{partial_prefix}")).unwrap();
+
+        let events = run(&db, &transcript).unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            value_u64(&events[0], token_usage_pos::MESSAGE_COUNT),
+            Some(1)
+        );
+
+        // Writer finishes the line.
+        fs::write(&transcript, format!("{complete}\n{partial}\n")).unwrap();
+        let events = run(&db, &transcript).unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            value_u64(&events[0], token_usage_pos::MESSAGE_COUNT),
+            Some(2)
+        );
+    }
+
+    #[test]
+    fn missing_file_is_an_error() {
+        let (_dir, db, transcript) = setup();
+        assert!(run(&db, &transcript).is_err());
+    }
+
+    #[test]
+    fn codex_reasoning_tokens_flow_through() {
+        let (_dir, db, transcript) = setup();
+        let ctx = EmissionContext {
+            tool: "codex".to_string(),
+            ..ctx()
+        };
+        fs::write(
+            &transcript,
+            concat!(
+                r#"{"timestamp":"2026-01-01T00:00:00Z","type":"turn_context","payload":{"model":"gpt-5.1"}}"#,
+                "\n",
+                r#"{"timestamp":"2026-01-01T00:01:00Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":100,"cached_input_tokens":40,"output_tokens":50,"reasoning_output_tokens":10,"total_tokens":150}}}}"#,
+                "\n",
+            ),
+        )
+        .unwrap();
+
+        let collected = Mutex::new(Vec::new());
+        let flag = AtomicBool::new(false);
+        process_file(
+            &db,
+            &ctx,
+            &transcript.display().to_string(),
+            &flag,
+            |events| {
+                collected.lock().unwrap().extend(events.to_vec());
+                Ok(())
+            },
+        )
+        .unwrap();
+        let events = collected.into_inner().unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            value_u64(&events[0], token_usage_pos::INPUT_TOKENS),
+            Some(60)
+        );
+        assert_eq!(
+            value_u64(&events[0], token_usage_pos::CACHE_READ_TOKENS),
+            Some(40)
+        );
+        assert_eq!(
+            value_u64(&events[0], token_usage_pos::REASONING_OUTPUT_TOKENS),
+            Some(10)
+        );
+        let attrs = EventAttributes::from_sparse(&events[0].attrs);
+        assert_eq!(attrs.model, Some(Some("gpt-5.1".to_string())));
+    }
+
+    #[test]
+    fn failed_sink_leaves_bucket_unmarked_for_retry() {
+        let (_dir, db, transcript) = setup();
+        fs::write(
+            &transcript,
+            format!("{}\n", claude_line("m1", "r1", "2026-01-01T00:01:00Z", 50)),
+        )
+        .unwrap();
+        let flag = AtomicBool::new(false);
+        let result = process_file(
+            &db,
+            &ctx(),
+            &transcript.display().to_string(),
+            &flag,
+            |_| Err(GitAiError::Generic("sink down".to_string())),
+        );
+        assert!(result.is_err());
+
+        // Entries and cursor were committed, but the bucket was not marked
+        // emitted: the next pass over a changed file re-emits it. Touch the
+        // file so the size/mtime skip doesn't apply.
+        let mut content = fs::read_to_string(&transcript).unwrap();
+        content.push_str(&claude_line("m2", "r2", "2026-01-01T00:02:00Z", 5));
+        content.push('\n');
+        fs::write(&transcript, content).unwrap();
+        let events = run(&db, &transcript).unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            value_u64(&events[0], token_usage_pos::MESSAGE_COUNT),
+            Some(2)
+        );
+    }
+
+    fn stream_record(session_id: &str, tool: &str, path: &str) -> StreamRecord {
+        StreamRecord {
+            session_id: session_id.to_string(),
+            stream_kind: "transcript".to_string(),
+            tool: tool.to_string(),
+            stream_path: path.to_string(),
+            stream_format: "ClaudeJsonl".to_string(),
+            watermark_type: "ByteOffset".to_string(),
+            watermark_value: "0".to_string(),
+            external_session_id: format!("{session_id}-ext"),
+            external_parent_session_id: None,
+            first_seen_at: 0,
+            last_processed_at: 0,
+            last_known_size: 0,
+            last_modified: None,
+            processing_errors: 0,
+            last_error: None,
+            repo_work_dir: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn sweep_enqueues_supported_existing_transcripts_once() {
+        let dir = tempfile::tempdir().unwrap();
+        let streams_db =
+            Arc::new(StreamsDatabase::open(dir.path().join("transcripts-db")).unwrap());
+        let token_db =
+            Arc::new(TokenUsageDatabase::open(dir.path().join("token-usage-db")).unwrap());
+        let claude_path = dir.path().join("claude.jsonl");
+        fs::write(&claude_path, "{}\n").unwrap();
+        let claude_path = claude_path.display().to_string();
+
+        streams_db
+            .insert_stream(&stream_record("s_claude", "claude", &claude_path))
+            .unwrap();
+        // Unsupported tool and missing file are both skipped.
+        streams_db
+            .insert_stream(&stream_record("s_gem", "gemini", &claude_path))
+            .unwrap();
+        streams_db
+            .insert_stream(&stream_record("s_gone", "claude", "/definitely/gone.jsonl"))
+            .unwrap();
+        // Non-transcript stream kinds are skipped.
+        let mut otel = stream_record("s_otel", "claude", &claude_path);
+        otel.stream_kind = "otel_traces".to_string();
+        streams_db.insert_stream(&otel).unwrap();
+
+        let (_notify_tx, notify_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (_drain_tx, drain_rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut worker = TokenUsageWorker {
+            streams_db,
+            token_db,
+            telemetry: DaemonTelemetryWorkerHandle::new_noop(),
+            shutdown_notify: Arc::new(Notify::new()),
+            shutdown_flag: Arc::new(AtomicBool::new(false)),
+            notify_rx,
+            drain_rx,
+            queue: VecDeque::new(),
+            queued: HashSet::new(),
+        };
+
+        worker.enqueue_sweep_tasks();
+        worker.enqueue_sweep_tasks(); // dedup: repeated sweeps don't re-add
+        assert_eq!(worker.queue.len(), 1);
+        assert_eq!(worker.queue[0].session_id, "s_claude");
+        assert_eq!(worker.queue[0].tool, "claude");
+    }
+
+    #[test]
+    fn subagent_stream_rolls_up_to_parent_session() {
+        let stream = StreamRecord {
+            session_id: "s_child".to_string(),
+            stream_kind: "transcript".to_string(),
+            tool: "claude".to_string(),
+            stream_path: "/tmp/child.jsonl".to_string(),
+            stream_format: "ClaudeJsonl".to_string(),
+            watermark_type: "ByteOffset".to_string(),
+            watermark_value: "0".to_string(),
+            external_session_id: "child-ext".to_string(),
+            external_parent_session_id: Some("parent-ext".to_string()),
+            first_seen_at: 0,
+            last_processed_at: 0,
+            last_known_size: 0,
+            last_modified: None,
+            processing_errors: 0,
+            last_error: None,
+            repo_work_dir: None,
+        };
+        let ctx = EmissionContext::from_stream(&stream);
+        assert_eq!(ctx.session_id, generate_session_id("parent-ext", "claude"));
+        assert_eq!(ctx.external_session_id, "parent-ext");
+
+        let mut top_level = stream;
+        top_level.external_parent_session_id = None;
+        let ctx = EmissionContext::from_stream(&top_level);
+        assert_eq!(ctx.session_id, "s_child");
+        assert_eq!(ctx.external_session_id, "child-ext");
+    }
+}

--- a/src/daemon/token_usage_worker.rs
+++ b/src/daemon/token_usage_worker.rs
@@ -9,22 +9,31 @@
 //! - Sweeps enumerate the streams database's `transcript` rows, so every
 //!   session git-ai knows about is backfilled: a newly tracked file starts at
 //!   byte offset 0 and its full history is bucketed on first processing.
+//!   Sweep enumeration is cheap per session (one stat compared against the
+//!   token database's size/mtime snapshot); per-file work — extractor state,
+//!   repo discovery, reading — only happens for files that actually changed.
+//! - Notifications and sweep backfill run on separate queues: the await
+//!   drain barrier waits only for notification-driven work, so a first-start
+//!   historical backfill can never starve `git-ai await`.
 //! - The read cursor, extractor state, entries, and emission fingerprints all
 //!   live in [`TokenUsageDatabase`]; each batch commits atomically, and
 //!   emission reconciles fingerprints across all of the session's buckets, so
 //!   there is no retry machinery here - a failed pass (or a crash at any
-//!   point) is healed by the next notification or sweep, and unchanged files
-//!   are skipped by a size/mtime snapshot written only after a fully
-//!   successful pass.
+//!   point) is healed by the next notification or sweep, with a per-file
+//!   error backoff so a permanently failing transcript is not re-read on
+//!   every trigger. The size/mtime quiet-skip snapshot is written only after
+//!   a fully successful pass.
 //! - Claude subagent transcripts roll up to their parent session (matching
 //!   ccusage), which also lets sidechain replays dedup against the parent's
-//!   entries.
-//! - The `token_usage_metrics` feature flag is read fresh on every trigger,
-//!   so the worker can be disabled without a daemon restart (enabling it
-//!   only requires the daemon to be running with the worker spawned).
+//!   entries. Entry dedup itself is global across sessions (resume/fork
+//!   copies); when a replacement moves an entry between sessions, the
+//!   previous owner's files are invalidated so its buckets re-reconcile on
+//!   the next pass with their own attributes.
+//! - The `token_usage_metrics` feature flag gates the worker at daemon
+//!   startup (like `transcript_streaming`); when it is off, the token-usage
+//!   database is deleted so no collected data is retained.
 
-use std::collections::HashSet;
-use std::collections::VecDeque;
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::io::{BufReader, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -32,7 +41,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use tokio::sync::Notify;
-use tokio::time::interval;
+use tokio::time::{MissedTickBehavior, interval};
 
 use crate::authorship::authorship_log_serialization::generate_session_id;
 use crate::daemon::telemetry_worker::DaemonTelemetryWorkerHandle;
@@ -40,7 +49,7 @@ use crate::error::GitAiError;
 use crate::metrics::{EventAttributes, MetricEvent, PosEncoded, TokenUsageValues};
 use crate::streams::db::{StreamRecord, StreamsDatabase};
 use crate::streams::types::{JsonlLineState, read_jsonl_line};
-use crate::token_usage::db::TokenUsageDatabase;
+use crate::token_usage::db::{BatchCommit, TokenUsageDatabase, TrackedFile};
 use crate::token_usage::extractor_for_tool;
 
 /// Entry/byte bounds of one atomic batch commit.
@@ -50,6 +59,11 @@ const BATCH_MAX_BYTES: usize = 4 * 1024 * 1024;
 /// Same telemetry-buffer backpressure as the stream worker.
 const BACKPRESSURE_THRESHOLD: usize = 5_000;
 const BACKPRESSURE_MAX_WAITS: usize = 40;
+
+/// Entries older than this are neither stored nor emitted, and stored ones
+/// are pruned on sweep: backfill must not upload history that the retention
+/// prune would immediately delete.
+pub(crate) const ENTRY_RETENTION_DAYS: u64 = 90;
 
 /// A transcript file to (re)process, identified by its streams-db row.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -84,7 +98,9 @@ impl TokenUsageWorkerHandle {
         });
     }
 
-    /// Wait until all currently queued work has been processed.
+    /// Wait until all notification-driven work has been processed. Sweep
+    /// backfill intentionally continues in the background so a historical
+    /// backfill cannot starve the await barrier.
     pub async fn drain(&self) -> Result<(), String> {
         let (completion_tx, completion_rx) = tokio::sync::oneshot::channel();
         self.drain_tx
@@ -115,7 +131,8 @@ pub fn spawn_token_usage_worker(
         shutdown_flag: Arc::new(AtomicBool::new(false)),
         notify_rx,
         drain_rx,
-        queue: VecDeque::new(),
+        notify_queue: VecDeque::new(),
+        sweep_queue: VecDeque::new(),
         queued: HashSet::new(),
     };
     tokio::spawn(async move {
@@ -135,31 +152,35 @@ struct TokenUsageWorker {
     shutdown_flag: Arc<AtomicBool>,
     notify_rx: tokio::sync::mpsc::UnboundedReceiver<TokenUsageTask>,
     drain_rx: tokio::sync::mpsc::UnboundedReceiver<DrainRequest>,
-    queue: VecDeque<TokenUsageTask>,
+    /// Notification-driven work: drained by the await barrier.
+    notify_queue: VecDeque<TokenUsageTask>,
+    /// Sweep/backfill work: processed only in the background loop.
+    sweep_queue: VecDeque<TokenUsageTask>,
     queued: HashSet<TokenUsageTask>,
-}
-
-/// Read the flag fresh so config changes apply without a daemon restart.
-fn token_usage_enabled() -> bool {
-    crate::config::Config::fresh()
-        .get_feature_flags()
-        .token_usage_metrics
 }
 
 impl TokenUsageWorker {
     async fn run(mut self) {
         tracing::info!("token-usage worker started");
         let mut sweep_ticker = interval(Duration::from_secs(30 * 60));
+        // After suspend/resume, one sweep covers everything; do not replay
+        // every missed tick.
+        sweep_ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
         sweep_ticker.tick().await; // skip the immediate tick
 
-        if token_usage_enabled() {
-            self.enqueue_sweep_tasks();
-        }
+        self.enqueue_sweep_tasks();
 
         loop {
-            self.process_queued().await;
+            // Promote notifications that arrived while processing.
+            while let Ok(task) = self.notify_rx.try_recv() {
+                self.enqueue_notify(task);
+            }
             if self.shutdown_flag.load(Ordering::Relaxed) {
                 break;
+            }
+            if let Some(task) = self.pop_next() {
+                self.process_task(task).await;
+                continue;
             }
             tokio::select! {
                 _ = self.shutdown_notify.notified() => {
@@ -167,14 +188,10 @@ impl TokenUsageWorker {
                     break;
                 }
                 _ = sweep_ticker.tick() => {
-                    if token_usage_enabled() {
-                        self.enqueue_sweep_tasks();
-                    }
+                    self.enqueue_sweep_tasks();
                 }
                 Some(task) = self.notify_rx.recv() => {
-                    if token_usage_enabled() {
-                        self.enqueue(task);
-                    }
+                    self.enqueue_notify(task);
                 }
                 Some(request) = self.drain_rx.recv() => {
                     self.handle_drain(request).await;
@@ -185,26 +202,57 @@ impl TokenUsageWorker {
     }
 
     async fn handle_drain(&mut self, request: DrainRequest) {
-        // Consume notifications that were queued before the barrier.
-        let enabled = token_usage_enabled();
+        // Consume notifications that were queued before the barrier, then
+        // process only notification-driven work (not sweep backfill).
         while let Ok(task) = self.notify_rx.try_recv() {
-            if enabled {
-                self.enqueue(task);
+            self.enqueue_notify(task);
+        }
+        while let Some(task) = self.pop_queue(true) {
+            self.process_task(task).await;
+            if self.shutdown_flag.load(Ordering::Relaxed) {
+                break;
             }
         }
-        self.process_queued().await;
         let _ = request.completion.send(());
     }
 
-    fn enqueue(&mut self, task: TokenUsageTask) {
+    fn enqueue_notify(&mut self, task: TokenUsageTask) {
         if self.queued.insert(task.clone()) {
-            self.queue.push_back(task);
+            self.notify_queue.push_back(task);
+        } else if let Some(pos) = self.sweep_queue.iter().position(|t| *t == task) {
+            // Promote: fresh data trumps pending backfill of the same file.
+            self.sweep_queue.remove(pos);
+            self.notify_queue.push_back(task);
         }
     }
 
-    /// Enqueue every supported transcript the streams database knows about.
-    /// New files get a zero cursor in the token-usage database, which is what
-    /// backfills history for sessions tracked before this feature ran.
+    fn enqueue_sweep(&mut self, task: TokenUsageTask) {
+        if self.queued.insert(task.clone()) {
+            self.sweep_queue.push_back(task);
+        }
+    }
+
+    fn pop_queue(&mut self, notify_only: bool) -> Option<TokenUsageTask> {
+        let task = self.notify_queue.pop_front().or_else(|| {
+            if notify_only {
+                None
+            } else {
+                self.sweep_queue.pop_front()
+            }
+        })?;
+        self.queued.remove(&task);
+        Some(task)
+    }
+
+    fn pop_next(&mut self) -> Option<TokenUsageTask> {
+        self.pop_queue(false)
+    }
+
+    /// Enqueue supported transcripts the streams database knows about whose
+    /// files changed since the last completed pass. New files have no
+    /// snapshot yet and are always enqueued, which is what backfills history
+    /// for sessions tracked before this feature ran; missing files are
+    /// skipped quietly.
     fn enqueue_sweep_tasks(&mut self) {
         let streams = match self.streams_db.all_streams() {
             Ok(streams) => streams,
@@ -213,16 +261,31 @@ impl TokenUsageWorker {
                 return;
             }
         };
+        let tracked: HashMap<String, TrackedFile> = match self.token_db.all_files() {
+            Ok(files) => files
+                .into_iter()
+                .map(|file| (file.stream_path.clone(), file))
+                .collect(),
+            Err(e) => {
+                tracing::warn!(error = %e, "token-usage sweep: failed to list tracked files");
+                return;
+            }
+        };
         for stream in streams {
             if stream.stream_kind != "transcript" || extractor_for_tool(&stream.tool).is_none() {
                 continue;
             }
-            // Sessions whose transcript is gone can't be backfilled; skip
-            // them without recording errors so sweeps stay quiet.
-            if !std::path::Path::new(&stream.stream_path).exists() {
+            let Ok(metadata) = std::fs::metadata(&stream.stream_path) else {
+                continue;
+            };
+            if let Some(file) = tracked.get(&stream.stream_path)
+                && file.last_known_size as u64 == metadata.len()
+                && file.last_modified == modified_secs(&metadata)
+                && !file.pending_flush
+            {
                 continue;
             }
-            self.enqueue(TokenUsageTask {
+            self.enqueue_sweep(TokenUsageTask {
                 session_id: stream.session_id,
                 tool: stream.tool,
                 stream_path: stream.stream_path,
@@ -230,51 +293,51 @@ impl TokenUsageWorker {
         }
     }
 
-    async fn process_queued(&mut self) {
-        while let Some(task) = self.queue.pop_front() {
-            self.queued.remove(&task);
-            if self.shutdown_flag.load(Ordering::Relaxed) {
-                return;
+    async fn process_task(&mut self, task: TokenUsageTask) {
+        let streams_db = self.streams_db.clone();
+        let token_db = self.token_db.clone();
+        let telemetry = self.telemetry.clone();
+        let shutdown_flag = self.shutdown_flag.clone();
+        let task_clone = task.clone();
+        let mut handle = tokio::task::spawn_blocking(move || {
+            process_task_blocking(
+                &streams_db,
+                &token_db,
+                &telemetry,
+                &task_clone,
+                &shutdown_flag,
+            )
+        });
+        // Keep watching for shutdown while the blocking pass runs: setting
+        // the flag makes the pass stop at its next line/batch boundary.
+        let result = tokio::select! {
+            result = &mut handle => result,
+            _ = self.shutdown_notify.notified() => {
+                self.shutdown_flag.store(true, Ordering::Relaxed);
+                (&mut handle).await
             }
-            let streams_db = self.streams_db.clone();
-            let token_db = self.token_db.clone();
-            let telemetry = self.telemetry.clone();
-            let shutdown_flag = self.shutdown_flag.clone();
-            let task_clone = task.clone();
-            let result = tokio::task::spawn_blocking(move || {
-                process_task_blocking(
-                    &streams_db,
-                    &token_db,
-                    &telemetry,
-                    &task_clone,
-                    &shutdown_flag,
-                )
-            })
-            .await;
-            match result {
-                Ok(Ok(())) => {}
-                Ok(Err(e)) => {
-                    tracing::warn!(error = %e, session_id = %task.session_id, "token-usage processing failed");
-                }
-                Err(e) => {
-                    tracing::error!(error = %e, session_id = %task.session_id, "token-usage task panicked");
-                }
+        };
+        match result {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => {
+                tracing::warn!(error = %e, session_id = %task.session_id, "token-usage processing failed");
+            }
+            Err(e) => {
+                tracing::error!(error = %e, session_id = %task.session_id, "token-usage task panicked");
             }
         }
     }
 }
 
-/// Per-file emission context derived from the streams-db row.
-struct EmissionContext {
-    /// Rollup session: subagent transcripts attribute to their parent session
-    /// (matching ccusage), which also dedups sidechain replays.
+/// Rollup identity of the session a transcript belongs to: subagent
+/// transcripts attribute to their parent session (matching ccusage).
+struct SessionIdentity {
     session_id: String,
     external_session_id: String,
     tool: String,
-    repo_url: Option<String>,
 }
 
-impl EmissionContext {
+impl SessionIdentity {
     fn from_stream(stream: &StreamRecord) -> Self {
         let (session_id, external_session_id) = match &stream.external_parent_session_id {
             Some(parent_ext) => (
@@ -286,17 +349,71 @@ impl EmissionContext {
                 stream.external_session_id.clone(),
             ),
         };
-        let repo_url = stream
-            .repo_work_dir
-            .as_ref()
-            .and_then(|dir| crate::repo_url::resolve_repo_url_from_path(&PathBuf::from(dir)));
         Self {
             session_id,
             external_session_id,
             tool: stream.tool.clone(),
-            repo_url,
         }
     }
+}
+
+/// Resolve the repo_url for emission attributes: the stream's stored working
+/// directory, falling back to the agent's cwd inference (persisted back like
+/// the SessionEvent path does) so the repo exclude gate sees a repo_url
+/// whenever one is resolvable.
+fn resolve_repo_url_for_stream(
+    streams_db: &StreamsDatabase,
+    stream: &StreamRecord,
+) -> Option<String> {
+    let work_dir = stream
+        .repo_work_dir
+        .as_ref()
+        .map(PathBuf::from)
+        .or_else(|| {
+            let inferred = crate::streams::agent::get_agent(&stream.tool)?
+                .infer_cwd(Path::new(&stream.stream_path))?;
+            let _ = streams_db.update_repo_work_dir(
+                &stream.session_id,
+                &stream.stream_kind,
+                &stream.stream_path,
+                &inferred.display().to_string(),
+            );
+            Some(inferred)
+        })?;
+    crate::repo_url::resolve_repo_url_from_path(&work_dir)
+}
+
+/// Backoff between attempts for a file whose last pass failed, indexed by
+/// consecutive error count.
+fn error_backoff_secs(errors: i64) -> i64 {
+    match errors {
+        ..=0 => 0,
+        1 => 5,
+        2 => 30,
+        3 => 300,
+        _ => 1800,
+    }
+}
+
+fn now_secs() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+fn modified_secs(metadata: &std::fs::Metadata) -> Option<i64> {
+    metadata
+        .modified()
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_secs() as i64)
+}
+
+/// Bucket cutoff below which entries are dropped instead of stored.
+fn retention_cutoff_bucket(now: i64) -> u32 {
+    now.saturating_sub((ENTRY_RETENTION_DAYS * 24 * 60 * 60) as i64)
+        .clamp(0, u32::MAX as i64) as u32
 }
 
 fn process_task_blocking(
@@ -312,55 +429,68 @@ fn process_task_blocking(
     else {
         return Ok(());
     };
-    let ctx = EmissionContext::from_stream(&stream);
-    let result = process_file(token_db, &ctx, &task.stream_path, shutdown_flag, |events| {
-        // Backpressure before handing a batch to the telemetry queue.
-        for _ in 0..BACKPRESSURE_MAX_WAITS {
-            if telemetry.metrics_buffer_len() < BACKPRESSURE_THRESHOLD
-                || shutdown_flag.load(Ordering::Relaxed)
-            {
-                break;
+    let identity = SessionIdentity::from_stream(&stream);
+    let result = process_file(
+        token_db,
+        &identity,
+        &task.stream_path,
+        shutdown_flag,
+        // Repo discovery is deferred until events are actually emitted.
+        || resolve_repo_url_for_stream(streams_db, &stream),
+        |events| {
+            // Backpressure before handing a batch to the telemetry queue.
+            for _ in 0..BACKPRESSURE_MAX_WAITS {
+                if telemetry.metrics_buffer_len() < BACKPRESSURE_THRESHOLD
+                    || shutdown_flag.load(Ordering::Relaxed)
+                {
+                    break;
+                }
+                std::thread::sleep(Duration::from_millis(100));
             }
-            std::thread::sleep(Duration::from_millis(100));
-        }
-        telemetry.persist_metrics_blocking(events).map(|_| ())
-    });
+            telemetry.persist_metrics_blocking(events).map(|_| ())
+        },
+    );
     if let Err(e) = &result {
         // Keyed by the rollup session id (subagent transcripts track under
         // their parent), matching the row ensure_file created.
-        let _ = token_db.record_error(&ctx.session_id, &task.stream_path, &e.to_string());
+        let _ = token_db.record_error(
+            &identity.session_id,
+            &task.stream_path,
+            &e.to_string(),
+            now_secs(),
+        );
     }
     result
 }
 
 /// Incrementally read one transcript file, persist deduplicated entries, and
-/// emit changed buckets through `sink`. Split out (with an injectable sink)
-/// for direct testing without a daemon.
+/// emit changed buckets through `sink`. Split out (with injectable repo
+/// resolution and sink) for direct testing without a daemon.
 fn process_file(
     token_db: &TokenUsageDatabase,
-    ctx: &EmissionContext,
+    identity: &SessionIdentity,
     stream_path: &str,
     shutdown_flag: &AtomicBool,
+    resolve_repo_url: impl FnOnce() -> Option<String>,
     sink: impl Fn(&[MetricEvent]) -> Result<(), GitAiError>,
 ) -> Result<(), GitAiError> {
-    let tracked = token_db.ensure_file(&ctx.session_id, stream_path, &ctx.tool)?;
-    let metadata = std::fs::metadata(stream_path)?;
-    let size = metadata.len();
-    let modified = metadata
-        .modified()
-        .ok()
-        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-        .map(|d| d.as_secs() as i64);
+    let tracked = token_db.ensure_file(&identity.session_id, stream_path, &identity.tool)?;
+    let now = now_secs();
 
-    // Quiet skip: nothing changed since the last completed pass.
-    if size == tracked.last_known_size as u64
-        && modified == tracked.last_modified
-        && tracked.byte_offset <= size
+    // Error backoff: a file whose last pass failed is not retried on every
+    // trigger.
+    if tracked.processing_errors > 0
+        && let Some(last_error_at) = tracked.last_error_at
+        && now < last_error_at.saturating_add(error_backoff_secs(tracked.processing_errors))
     {
         return Ok(());
     }
 
-    let Some(mut extractor) = extractor_for_tool(&ctx.tool) else {
+    let metadata = std::fs::metadata(stream_path)?;
+    let size = metadata.len();
+    let modified = modified_secs(&metadata);
+
+    let Some(mut extractor) = extractor_for_tool(&identity.tool) else {
         return Ok(());
     };
     // A shrunken file was rewritten: restart from scratch. Entry-level dedup
@@ -372,10 +502,21 @@ fn process_file(
         extractor.restore_state(state);
     }
 
+    // Quiet skip: nothing changed since the last completed pass and the
+    // extractor holds nothing to flush.
+    if size == tracked.last_known_size as u64
+        && modified == tracked.last_modified
+        && !extractor.has_pending()
+    {
+        return Ok(());
+    }
+
     let file = std::fs::File::open(stream_path)?;
     let mut reader = BufReader::with_capacity(128 * 1024, file);
     reader.seek(SeekFrom::Start(offset))?;
 
+    let cutoff = retention_cutoff_bucket(now);
+    let mut foreign_sessions: Vec<String> = Vec::new();
     let mut line = String::new();
     let mut reached_end = false;
     let mut interrupted = false;
@@ -411,13 +552,25 @@ fn process_file(
                 }
             }
         }
-        token_db.commit_batch(
-            &ctx.session_id,
+        if reached_end {
+            // End of the file: release buffered entries whose deferral
+            // window has passed (e.g. a forked codex session's parked first
+            // turn).
+            entries.extend(extractor.flush(now.saturating_mul(1000)));
+        }
+        for session in token_db.commit_batch(&BatchCommit {
+            session_id: &identity.session_id,
             stream_path,
-            &entries,
-            offset,
-            extractor.state_json().as_deref(),
-        )?;
+            entries: &entries,
+            new_offset: offset,
+            state_json: extractor.state_json().as_deref(),
+            pending_flush: extractor.has_pending(),
+            min_bucket_ts: cutoff,
+        })? {
+            if !foreign_sessions.contains(&session) {
+                foreign_sessions.push(session);
+            }
+        }
     }
 
     if interrupted {
@@ -426,35 +579,39 @@ fn process_file(
         // reconciles emission.
         return Ok(());
     }
-    emit_changed_buckets(token_db, ctx, sink)?;
+    // Cross-session replacements changed other sessions' buckets: invalidate
+    // their snapshots so their next pass re-reconciles with their own
+    // attributes.
+    for session in &foreign_sessions {
+        token_db.invalidate_session_files(session)?;
+    }
+    emit_changed_buckets(token_db, identity, resolve_repo_url, sink)?;
     // The quiet-skip snapshot is written only after emission succeeded, so a
     // failed hand-off (or a crash anywhere in this pass) leaves the file
     // "changed" and the next pass re-runs reconciliation.
-    token_db.update_file_metadata(&ctx.session_id, stream_path, size, modified)
+    token_db.update_file_metadata(&identity.session_id, stream_path, size, modified)
 }
 
-/// Reconcile every bucket the session has entries or emission state for, and
-/// emit those whose aggregate fingerprint differs from the last emitted one,
-/// marking them emitted only after the sink accepted the events.
+/// Reconcile the session's buckets in one pass and emit those whose
+/// fingerprint differs from the last emitted one, marking them emitted only
+/// after the sink accepted the events. Repo discovery runs only when there
+/// is something to emit.
 fn emit_changed_buckets(
     token_db: &TokenUsageDatabase,
-    ctx: &EmissionContext,
+    identity: &SessionIdentity,
+    resolve_repo_url: impl FnOnce() -> Option<String>,
     sink: impl Fn(&[MetricEvent]) -> Result<(), GitAiError>,
 ) -> Result<(), GitAiError> {
-    let mut events = Vec::new();
-    let mut emitted = Vec::new();
-    for (model, bucket) in &token_db.session_buckets(&ctx.session_id)? {
-        let aggregate = token_db.aggregate_bucket(&ctx.session_id, model, *bucket)?;
-        let fingerprint = aggregate.fingerprint();
-        if token_db
-            .emitted_fingerprint(&ctx.session_id, model, *bucket)?
-            .as_deref()
-            == Some(fingerprint.as_str())
-        {
-            continue;
-        }
+    let changed = token_db.changed_buckets(&identity.session_id)?;
+    if changed.is_empty() {
+        return Ok(());
+    }
+    let repo_url = resolve_repo_url();
+    let mut events = Vec::with_capacity(changed.len());
+    for bucket in &changed {
+        let aggregate = &bucket.aggregate;
         let values = TokenUsageValues::new()
-            .bucket_ts(*bucket as u64)
+            .bucket_ts(bucket.bucket_ts as u64)
             .input_tokens(aggregate.input)
             .output_tokens(aggregate.output)
             .cache_read_tokens(aggregate.cache_read)
@@ -462,28 +619,31 @@ fn emit_changed_buckets(
             .total_tokens(aggregate.total)
             .reasoning_output_tokens_opt(aggregate.reasoning_output)
             .est_cost_micro_usd(aggregate.cost_micro_usd)
-            .message_count(aggregate.message_count);
+            .message_count(aggregate.message_count)
+            // Strictly increasing per bucket: the server keeps the highest
+            // revision, so same-second re-emissions cannot tie.
+            .emitted_seq(bucket.emit_seq + 1);
         let mut attrs = EventAttributes::with_version(env!("CARGO_PKG_VERSION"))
-            .session_id(ctx.session_id.clone())
-            .external_session_id(ctx.external_session_id.clone())
-            .tool(&ctx.tool)
-            .model(model);
-        if let Some(url) = &ctx.repo_url {
+            .session_id(identity.session_id.clone())
+            .external_session_id(identity.external_session_id.clone())
+            .tool(&identity.tool)
+            .model(&bucket.model);
+        if let Some(url) = &repo_url {
             attrs = attrs.repo_url(url.clone());
         }
         events.push(MetricEvent::new(&values, attrs.to_sparse()));
-        emitted.push((model.clone(), *bucket, fingerprint));
-    }
-    if events.is_empty() {
-        return Ok(());
     }
     sink(&events)?;
-    let now_ts = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs() as i64)
-        .unwrap_or(0);
-    for (model, bucket, fingerprint) in emitted {
-        token_db.mark_emitted(&ctx.session_id, &model, bucket, &fingerprint, now_ts)?;
+    let now_ts = now_secs();
+    for bucket in changed {
+        token_db.mark_emitted(
+            &identity.session_id,
+            &bucket.model,
+            bucket.bucket_ts,
+            &bucket.aggregate.fingerprint(),
+            bucket.emit_seq + 1,
+            now_ts,
+        )?;
     }
     Ok(())
 }
@@ -491,17 +651,15 @@ fn emit_changed_buckets(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::metrics::PosEncoded;
     use crate::metrics::events::token_usage_pos;
     use std::fs;
     use std::sync::Mutex;
 
-    fn ctx() -> EmissionContext {
-        EmissionContext {
+    fn identity() -> SessionIdentity {
+        SessionIdentity {
             session_id: "s_test".to_string(),
             external_session_id: "ext-test".to_string(),
             tool: "claude".to_string(),
-            repo_url: Some("https://github.com/acme/repo".to_string()),
         }
     }
 
@@ -512,29 +670,52 @@ mod tests {
         (dir, db, transcript)
     }
 
+    /// Recent RFC3339 timestamps so entries fall inside the retention window.
+    fn recent_ts(minute: u32, second: u32) -> String {
+        let base = now_secs() - (now_secs() % 86_400);
+        chrono::DateTime::from_timestamp(base + (minute * 60 + second) as i64, 0)
+            .unwrap()
+            .to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+    }
+
+    fn bucket_of(minute: u32, second: u32) -> u64 {
+        let base = now_secs() - (now_secs() % 86_400);
+        let ts = base as u64 + (minute * 60 + second) as u64;
+        ts - ts % 300
+    }
+
     fn claude_line(msg: &str, req: &str, ts: &str, output: u64) -> String {
         format!(
             r#"{{"timestamp":"{ts}","sessionId":"ext-test","requestId":"{req}","message":{{"id":"{msg}","model":"claude-sonnet-4-20250514","usage":{{"input_tokens":100,"output_tokens":{output},"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}}}}"#
         )
     }
 
-    fn run(
+    fn run_as(
         db: &TokenUsageDatabase,
+        identity: &SessionIdentity,
         transcript: &std::path::Path,
     ) -> Result<Vec<MetricEvent>, GitAiError> {
         let collected = Mutex::new(Vec::new());
         let flag = AtomicBool::new(false);
         process_file(
             db,
-            &ctx(),
+            identity,
             &transcript.display().to_string(),
             &flag,
+            || Some("https://github.com/acme/repo".to_string()),
             |events| {
                 collected.lock().unwrap().extend(events.to_vec());
                 Ok(())
             },
         )?;
         Ok(collected.into_inner().unwrap())
+    }
+
+    fn run(
+        db: &TokenUsageDatabase,
+        transcript: &std::path::Path,
+    ) -> Result<Vec<MetricEvent>, GitAiError> {
+        run_as(db, &identity(), transcript)
     }
 
     fn value_u64(event: &MetricEvent, pos: usize) -> Option<u64> {
@@ -548,8 +729,8 @@ mod tests {
             &transcript,
             format!(
                 "{}\n{}\n",
-                claude_line("m1", "r1", "2026-01-01T00:01:00Z", 50),
-                claude_line("m2", "r2", "2026-01-01T00:06:00Z", 70),
+                claude_line("m1", "r1", &recent_ts(1, 0), 50),
+                claude_line("m2", "r2", &recent_ts(6, 0), 70),
             ),
         )
         .unwrap();
@@ -561,12 +742,12 @@ mod tests {
             .map(|e| value_u64(e, token_usage_pos::BUCKET_TS).unwrap())
             .collect();
         buckets.sort_unstable();
-        // 2026-01-01T00:00:00Z = 1767225600.
-        assert_eq!(buckets, vec![1_767_225_600, 1_767_225_900]);
+        assert_eq!(buckets, vec![bucket_of(1, 0), bucket_of(6, 0)]);
         for event in &events {
             assert_eq!(event.event_id, 9);
             assert_eq!(value_u64(event, token_usage_pos::INPUT_TOKENS), Some(100));
             assert_eq!(value_u64(event, token_usage_pos::MESSAGE_COUNT), Some(1));
+            assert_eq!(value_u64(event, token_usage_pos::EMITTED_SEQ), Some(1));
             assert!(value_u64(event, token_usage_pos::EST_COST_MICRO_USD).unwrap() > 0);
             let attrs = EventAttributes::from_sparse(&event.attrs);
             assert_eq!(attrs.session_id, Some(Some("s_test".to_string())));
@@ -587,7 +768,7 @@ mod tests {
         let (_dir, db, transcript) = setup();
         fs::write(
             &transcript,
-            format!("{}\n", claude_line("m1", "r1", "2026-01-01T00:01:00Z", 50)),
+            format!("{}\n", claude_line("m1", "r1", &recent_ts(1, 0), 50)),
         )
         .unwrap();
         assert_eq!(run(&db, &transcript).unwrap().len(), 1);
@@ -596,11 +777,11 @@ mod tests {
     }
 
     #[test]
-    fn appended_usage_reemits_the_bucket_with_higher_totals() {
+    fn appended_usage_reemits_the_bucket_with_bumped_revision() {
         let (_dir, db, transcript) = setup();
         fs::write(
             &transcript,
-            format!("{}\n", claude_line("m1", "r1", "2026-01-01T00:01:00Z", 50)),
+            format!("{}\n", claude_line("m1", "r1", &recent_ts(1, 0), 50)),
         )
         .unwrap();
         let first = run(&db, &transcript).unwrap();
@@ -608,9 +789,10 @@ mod tests {
             value_u64(&first[0], token_usage_pos::OUTPUT_TOKENS),
             Some(50)
         );
+        assert_eq!(value_u64(&first[0], token_usage_pos::EMITTED_SEQ), Some(1));
 
         let mut content = fs::read_to_string(&transcript).unwrap();
-        content.push_str(&claude_line("m2", "r2", "2026-01-01T00:02:00Z", 30));
+        content.push_str(&claude_line("m2", "r2", &recent_ts(2, 0), 30));
         content.push('\n');
         fs::write(&transcript, content).unwrap();
 
@@ -624,6 +806,7 @@ mod tests {
             value_u64(&second[0], token_usage_pos::MESSAGE_COUNT),
             Some(2)
         );
+        assert_eq!(value_u64(&second[0], token_usage_pos::EMITTED_SEQ), Some(2));
     }
 
     #[test]
@@ -631,7 +814,7 @@ mod tests {
         let (_dir, db, transcript) = setup();
         fs::write(
             &transcript,
-            format!("{}\n", claude_line("m1", "r1", "2026-01-01T00:01:00Z", 50)),
+            format!("{}\n", claude_line("m1", "r1", &recent_ts(1, 0), 50)),
         )
         .unwrap();
         assert_eq!(run(&db, &transcript).unwrap().len(), 1);
@@ -639,7 +822,7 @@ mod tests {
         // The same message re-emits with larger totals in the next bucket:
         // the old bucket empties and must re-emit as zero exactly once.
         let mut content = fs::read_to_string(&transcript).unwrap();
-        content.push_str(&claude_line("m1", "r1", "2026-01-01T00:06:00Z", 90));
+        content.push_str(&claude_line("m1", "r1", &recent_ts(6, 0), 90));
         content.push('\n');
         fs::write(&transcript, content).unwrap();
 
@@ -655,8 +838,8 @@ mod tests {
             })
             .collect();
         by_bucket.sort_unstable();
-        assert_eq!(by_bucket[0], (1_767_225_600, 0));
-        assert_eq!(by_bucket[1], (1_767_225_900, 190));
+        assert_eq!(by_bucket[0], (bucket_of(1, 0), 0));
+        assert_eq!(by_bucket[1], (bucket_of(6, 0), 190));
         let zero_event = events
             .iter()
             .find(|e| value_u64(e, token_usage_pos::TOTAL_TOKENS) == Some(0))
@@ -665,13 +848,14 @@ mod tests {
             value_u64(zero_event, token_usage_pos::MESSAGE_COUNT),
             Some(0)
         );
+        assert_eq!(value_u64(zero_event, token_usage_pos::EMITTED_SEQ), Some(2));
     }
 
     #[test]
     fn partial_trailing_line_is_left_for_the_next_pass() {
         let (_dir, db, transcript) = setup();
-        let complete = claude_line("m1", "r1", "2026-01-01T00:01:00Z", 50);
-        let partial = claude_line("m2", "r2", "2026-01-01T00:02:00Z", 70);
+        let complete = claude_line("m1", "r1", &recent_ts(1, 0), 50);
+        let partial = claude_line("m2", "r2", &recent_ts(2, 0), 70);
         let partial_prefix = &partial[..partial.len() - 10];
         fs::write(&transcript, format!("{complete}\n{partial_prefix}")).unwrap();
 
@@ -699,37 +883,81 @@ mod tests {
     }
 
     #[test]
-    fn codex_reasoning_tokens_flow_through() {
+    fn entries_older_than_retention_are_not_emitted() {
         let (_dir, db, transcript) = setup();
-        let ctx = EmissionContext {
-            tool: "codex".to_string(),
-            ..ctx()
-        };
         fs::write(
             &transcript,
-            concat!(
+            format!(
+                "{}\n{}\n",
+                // 2020: far past the retention cutoff.
+                claude_line("m1", "r1", "2020-01-01T00:01:00Z", 50),
+                claude_line("m2", "r2", &recent_ts(1, 0), 70),
+            ),
+        )
+        .unwrap();
+        let events = run(&db, &transcript).unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            value_u64(&events[0], token_usage_pos::BUCKET_TS),
+            Some(bucket_of(1, 0))
+        );
+    }
+
+    #[test]
+    fn error_backoff_suppresses_immediate_retries() {
+        let (_dir, db, transcript) = setup();
+        let identity = identity();
+        let path = transcript.display().to_string();
+        // File is missing: the pass errors and the error is recorded (as the
+        // task wrapper does).
+        assert!(run_as(&db, &identity, &transcript).is_err());
+        db.record_error(&identity.session_id, &path, "boom", now_secs())
+            .unwrap();
+
+        // The file now exists with real usage, but the backoff window makes
+        // the next pass a quiet no-op instead of a retry.
+        fs::write(
+            &transcript,
+            format!("{}\n", claude_line("m1", "r1", &recent_ts(1, 0), 50)),
+        )
+        .unwrap();
+        assert!(run_as(&db, &identity, &transcript).unwrap().is_empty());
+
+        // Once the window has passed (simulated by backdating the error),
+        // processing resumes and a successful pass clears the error state.
+        db.record_error(&identity.session_id, &path, "boom", now_secs() - 60)
+            .unwrap();
+        let events = run_as(&db, &identity, &transcript).unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            db.ensure_file(&identity.session_id, &path, "claude")
+                .unwrap()
+                .processing_errors,
+            0
+        );
+    }
+
+    #[test]
+    fn codex_reasoning_tokens_flow_through() {
+        let (_dir, db, transcript) = setup();
+        let identity = SessionIdentity {
+            tool: "codex".to_string(),
+            ..identity()
+        };
+        let token_count_line = format!(
+            r#"{{"timestamp":"{}","type":"event_msg","payload":{{"type":"token_count","info":{{"total_token_usage":{{"input_tokens":100,"cached_input_tokens":40,"output_tokens":50,"reasoning_output_tokens":10,"total_tokens":150}}}}}}}}"#,
+            recent_ts(1, 0)
+        );
+        fs::write(
+            &transcript,
+            format!(
+                "{}\n{token_count_line}\n",
                 r#"{"timestamp":"2026-01-01T00:00:00Z","type":"turn_context","payload":{"model":"gpt-5.1"}}"#,
-                "\n",
-                r#"{"timestamp":"2026-01-01T00:01:00Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":100,"cached_input_tokens":40,"output_tokens":50,"reasoning_output_tokens":10,"total_tokens":150}}}}"#,
-                "\n",
             ),
         )
         .unwrap();
 
-        let collected = Mutex::new(Vec::new());
-        let flag = AtomicBool::new(false);
-        process_file(
-            &db,
-            &ctx,
-            &transcript.display().to_string(),
-            &flag,
-            |events| {
-                collected.lock().unwrap().extend(events.to_vec());
-                Ok(())
-            },
-        )
-        .unwrap();
-        let events = collected.into_inner().unwrap();
+        let events = run_as(&db, &identity, &transcript).unwrap();
         assert_eq!(events.len(), 1);
         assert_eq!(
             value_u64(&events[0], token_usage_pos::INPUT_TOKENS),
@@ -748,19 +976,125 @@ mod tests {
     }
 
     #[test]
+    fn forked_codex_single_turn_is_flushed_at_end_of_file() {
+        // The lone parked turn of a forked session is released by the
+        // end-of-file flush once the burst window has passed in wall-clock
+        // time, instead of being undercounted forever.
+        let (_dir, db, transcript) = setup();
+        let identity = SessionIdentity {
+            tool: "codex".to_string(),
+            ..identity()
+        };
+        let token_count_line = format!(
+            r#"{{"timestamp":"{}","type":"event_msg","payload":{{"type":"token_count","info":{{"total_token_usage":{{"input_tokens":10,"cached_input_tokens":0,"output_tokens":5,"reasoning_output_tokens":0,"total_tokens":15}}}}}}}}"#,
+            recent_ts(1, 0)
+        );
+        fs::write(
+            &transcript,
+            format!(
+                "{}\n{token_count_line}\n",
+                r#"{"timestamp":"2026-01-01T00:00:00Z","type":"session_meta","payload":{"id":"child","forked_from_id":"parent"}}"#,
+            ),
+        )
+        .unwrap();
+        // recent_ts is in the past (>1s), so the flush releases the turn in
+        // the same pass.
+        let events = run_as(&db, &identity, &transcript).unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            value_u64(&events[0], token_usage_pos::INPUT_TOKENS),
+            Some(10)
+        );
+    }
+
+    #[test]
+    fn cross_session_replacement_invalidates_the_previous_owner() {
+        let (dir, db, transcript_a) = setup();
+        let identity_a = identity();
+        fs::write(
+            &transcript_a,
+            format!("{}\n", claude_line("m1", "r1", &recent_ts(1, 0), 50)),
+        )
+        .unwrap();
+        assert_eq!(run_as(&db, &identity_a, &transcript_a).unwrap().len(), 1);
+
+        // A resumed session copies the message with larger totals: the entry
+        // moves to the new session, and the previous owner's file snapshot
+        // is invalidated so its zeroed bucket re-reconciles on its next pass.
+        let identity_b = SessionIdentity {
+            session_id: "s_resumed".to_string(),
+            external_session_id: "ext-resumed".to_string(),
+            tool: "claude".to_string(),
+        };
+        let transcript_b = dir.path().join("resumed.jsonl");
+        fs::write(
+            &transcript_b,
+            format!("{}\n", claude_line("m1", "r1", &recent_ts(1, 30), 90)),
+        )
+        .unwrap();
+        let events = run_as(&db, &identity_b, &transcript_b).unwrap();
+        assert_eq!(events.len(), 1);
+        let attrs = EventAttributes::from_sparse(&events[0].attrs);
+        assert_eq!(attrs.session_id, Some(Some("s_resumed".to_string())));
+
+        let file_a = db
+            .ensure_file(
+                &identity_a.session_id,
+                &transcript_a.display().to_string(),
+                "claude",
+            )
+            .unwrap();
+        assert_eq!(file_a.last_known_size, -1, "snapshot invalidated");
+        // Session A's next pass re-emits its emptied bucket as zero.
+        let events = run_as(&db, &identity_a, &transcript_a).unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            value_u64(&events[0], token_usage_pos::TOTAL_TOKENS),
+            Some(0)
+        );
+    }
+
+    #[test]
+    fn resumed_session_copy_is_not_double_counted() {
+        let (dir, db, transcript_a) = setup();
+        let identity_a = identity();
+        fs::write(
+            &transcript_a,
+            format!("{}\n", claude_line("m1", "r1", &recent_ts(1, 0), 50)),
+        )
+        .unwrap();
+        assert_eq!(run_as(&db, &identity_a, &transcript_a).unwrap().len(), 1);
+
+        // The resumed file carries an identical copy: nothing new to emit.
+        let identity_b = SessionIdentity {
+            session_id: "s_resumed".to_string(),
+            external_session_id: "ext-resumed".to_string(),
+            tool: "claude".to_string(),
+        };
+        let transcript_b = dir.path().join("resumed.jsonl");
+        fs::write(
+            &transcript_b,
+            format!("{}\n", claude_line("m1", "r1", &recent_ts(1, 0), 50)),
+        )
+        .unwrap();
+        assert!(run_as(&db, &identity_b, &transcript_b).unwrap().is_empty());
+    }
+
+    #[test]
     fn failed_sink_leaves_bucket_unmarked_for_retry() {
         let (_dir, db, transcript) = setup();
         fs::write(
             &transcript,
-            format!("{}\n", claude_line("m1", "r1", "2026-01-01T00:01:00Z", 50)),
+            format!("{}\n", claude_line("m1", "r1", &recent_ts(1, 0), 50)),
         )
         .unwrap();
         let flag = AtomicBool::new(false);
         let result = process_file(
             &db,
-            &ctx(),
+            &identity(),
             &transcript.display().to_string(),
             &flag,
+            || None,
             |_| Err(GitAiError::Generic("sink down".to_string())),
         );
         assert!(result.is_err());
@@ -799,35 +1133,13 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn sweep_enqueues_supported_existing_transcripts_once() {
-        let dir = tempfile::tempdir().unwrap();
-        let streams_db =
-            Arc::new(StreamsDatabase::open(dir.path().join("transcripts-db")).unwrap());
-        let token_db =
-            Arc::new(TokenUsageDatabase::open(dir.path().join("token-usage-db")).unwrap());
-        let claude_path = dir.path().join("claude.jsonl");
-        fs::write(&claude_path, "{}\n").unwrap();
-        let claude_path = claude_path.display().to_string();
-
-        streams_db
-            .insert_stream(&stream_record("s_claude", "claude", &claude_path))
-            .unwrap();
-        // Unsupported tool and missing file are both skipped.
-        streams_db
-            .insert_stream(&stream_record("s_gem", "gemini", &claude_path))
-            .unwrap();
-        streams_db
-            .insert_stream(&stream_record("s_gone", "claude", "/definitely/gone.jsonl"))
-            .unwrap();
-        // Non-transcript stream kinds are skipped.
-        let mut otel = stream_record("s_otel", "claude", &claude_path);
-        otel.stream_kind = "otel_traces".to_string();
-        streams_db.insert_stream(&otel).unwrap();
-
+    fn test_worker(
+        streams_db: Arc<StreamsDatabase>,
+        token_db: Arc<TokenUsageDatabase>,
+    ) -> TokenUsageWorker {
         let (_notify_tx, notify_rx) = tokio::sync::mpsc::unbounded_channel();
         let (_drain_tx, drain_rx) = tokio::sync::mpsc::unbounded_channel();
-        let mut worker = TokenUsageWorker {
+        TokenUsageWorker {
             streams_db,
             token_db,
             telemetry: DaemonTelemetryWorkerHandle::new_noop(),
@@ -835,15 +1147,98 @@ mod tests {
             shutdown_flag: Arc::new(AtomicBool::new(false)),
             notify_rx,
             drain_rx,
-            queue: VecDeque::new(),
+            notify_queue: VecDeque::new(),
+            sweep_queue: VecDeque::new(),
             queued: HashSet::new(),
-        };
+        }
+    }
 
+    #[tokio::test]
+    async fn sweep_enqueues_only_changed_supported_transcripts() {
+        let dir = tempfile::tempdir().unwrap();
+        let streams_db =
+            Arc::new(StreamsDatabase::open(dir.path().join("transcripts-db")).unwrap());
+        let token_db =
+            Arc::new(TokenUsageDatabase::open(dir.path().join("token-usage-db")).unwrap());
+        let changed_path = dir.path().join("changed.jsonl");
+        fs::write(&changed_path, "{}\n").unwrap();
+        let changed_path = changed_path.display().to_string();
+        let settled_path = dir.path().join("settled.jsonl");
+        fs::write(&settled_path, "{}\n").unwrap();
+        let settled_path = settled_path.display().to_string();
+
+        streams_db
+            .insert_stream(&stream_record("s_changed", "claude", &changed_path))
+            .unwrap();
+        streams_db
+            .insert_stream(&stream_record("s_settled", "claude", &settled_path))
+            .unwrap();
+        // Unsupported tool, missing file, and non-transcript kinds skipped.
+        streams_db
+            .insert_stream(&stream_record("s_gem", "gemini", &changed_path))
+            .unwrap();
+        streams_db
+            .insert_stream(&stream_record("s_gone", "claude", "/definitely/gone.jsonl"))
+            .unwrap();
+        let mut otel = stream_record("s_otel", "claude", &changed_path);
+        otel.stream_kind = "otel_traces".to_string();
+        streams_db.insert_stream(&otel).unwrap();
+
+        // The settled file's snapshot matches its current metadata.
+        let metadata = fs::metadata(&settled_path).unwrap();
+        token_db
+            .ensure_file("s_settled", &settled_path, "claude")
+            .unwrap();
+        token_db
+            .update_file_metadata(
+                "s_settled",
+                &settled_path,
+                metadata.len(),
+                modified_secs(&metadata),
+            )
+            .unwrap();
+
+        let mut worker = test_worker(streams_db, token_db);
         worker.enqueue_sweep_tasks();
         worker.enqueue_sweep_tasks(); // dedup: repeated sweeps don't re-add
-        assert_eq!(worker.queue.len(), 1);
-        assert_eq!(worker.queue[0].session_id, "s_claude");
-        assert_eq!(worker.queue[0].tool, "claude");
+        assert_eq!(worker.sweep_queue.len(), 1);
+        assert_eq!(worker.sweep_queue[0].session_id, "s_changed");
+        assert!(worker.notify_queue.is_empty());
+    }
+
+    #[tokio::test]
+    async fn notifications_promote_queued_sweep_tasks_and_drain_skips_backfill() {
+        let dir = tempfile::tempdir().unwrap();
+        let streams_db =
+            Arc::new(StreamsDatabase::open(dir.path().join("transcripts-db")).unwrap());
+        let token_db =
+            Arc::new(TokenUsageDatabase::open(dir.path().join("token-usage-db")).unwrap());
+        let mut worker = test_worker(streams_db, token_db);
+
+        let backfill = TokenUsageTask {
+            session_id: "s_backfill".to_string(),
+            tool: "claude".to_string(),
+            stream_path: "/a.jsonl".to_string(),
+        };
+        let fresh = TokenUsageTask {
+            session_id: "s_fresh".to_string(),
+            tool: "claude".to_string(),
+            stream_path: "/b.jsonl".to_string(),
+        };
+        worker.enqueue_sweep(backfill.clone());
+        worker.enqueue_sweep(fresh.clone());
+        // A notification for a file already queued for backfill promotes it.
+        worker.enqueue_notify(fresh.clone());
+        assert_eq!(worker.sweep_queue.len(), 1);
+        assert_eq!(worker.notify_queue.len(), 1);
+
+        // The drain barrier only sees notification-driven work.
+        assert_eq!(worker.pop_queue(true), Some(fresh));
+        assert_eq!(worker.pop_queue(true), None);
+        // The background loop still gets the backfill.
+        assert_eq!(worker.pop_next(), Some(backfill));
+        assert_eq!(worker.pop_next(), None);
+        assert!(worker.queued.is_empty());
     }
 
     #[tokio::test]
@@ -879,37 +1274,35 @@ mod tests {
             .ensure_file(&parent_session, &missing, "claude")
             .unwrap();
         assert_eq!(tracked.processing_errors, 1);
+        assert!(tracked.last_error_at.is_some());
         assert_eq!(token_db.all_files().unwrap().len(), 1);
     }
 
     #[test]
     fn subagent_stream_rolls_up_to_parent_session() {
-        let stream = StreamRecord {
-            session_id: "s_child".to_string(),
-            stream_kind: "transcript".to_string(),
-            tool: "claude".to_string(),
-            stream_path: "/tmp/child.jsonl".to_string(),
-            stream_format: "ClaudeJsonl".to_string(),
-            watermark_type: "ByteOffset".to_string(),
-            watermark_value: "0".to_string(),
-            external_session_id: "child-ext".to_string(),
-            external_parent_session_id: Some("parent-ext".to_string()),
-            first_seen_at: 0,
-            last_processed_at: 0,
-            last_known_size: 0,
-            last_modified: None,
-            processing_errors: 0,
-            last_error: None,
-            repo_work_dir: None,
-        };
-        let ctx = EmissionContext::from_stream(&stream);
-        assert_eq!(ctx.session_id, generate_session_id("parent-ext", "claude"));
-        assert_eq!(ctx.external_session_id, "parent-ext");
+        let mut stream = stream_record("s_child", "claude", "/tmp/child.jsonl");
+        stream.external_session_id = "child-ext".to_string();
+        stream.external_parent_session_id = Some("parent-ext".to_string());
+        let identity = SessionIdentity::from_stream(&stream);
+        assert_eq!(
+            identity.session_id,
+            generate_session_id("parent-ext", "claude")
+        );
+        assert_eq!(identity.external_session_id, "parent-ext");
 
-        let mut top_level = stream;
-        top_level.external_parent_session_id = None;
-        let ctx = EmissionContext::from_stream(&top_level);
-        assert_eq!(ctx.session_id, "s_child");
-        assert_eq!(ctx.external_session_id, "child-ext");
+        stream.external_parent_session_id = None;
+        let identity = SessionIdentity::from_stream(&stream);
+        assert_eq!(identity.session_id, "s_child");
+        assert_eq!(identity.external_session_id, "child-ext");
+    }
+
+    #[test]
+    fn error_backoff_schedule_is_bounded() {
+        assert_eq!(error_backoff_secs(0), 0);
+        assert_eq!(error_backoff_secs(1), 5);
+        assert_eq!(error_backoff_secs(2), 30);
+        assert_eq!(error_backoff_secs(3), 300);
+        assert_eq!(error_backoff_secs(4), 1800);
+        assert_eq!(error_backoff_secs(100), 1800);
     }
 }

--- a/src/daemon/token_usage_worker.rs
+++ b/src/daemon/token_usage_worker.rs
@@ -502,8 +502,16 @@ fn process_task_blocking(
         &identity,
         &task.stream_path,
         shutdown_flag,
-        // Repo discovery is deferred until events are actually emitted.
-        || resolve_repo_url_for_stream(streams_db, &stream),
+        // Repo discovery is deferred until events are actually emitted; the
+        // result is persisted so later DB-only corrections carry the same
+        // repo gate attribute.
+        || {
+            let repo_url = resolve_repo_url_for_stream(streams_db, &stream);
+            if let Some(url) = &repo_url {
+                let _ = token_db.update_session_repo_url(&identity.session_id, url);
+            }
+            repo_url
+        },
         &sink,
     )
     // Cross-session replacements flagged other sessions during the batch
@@ -541,23 +549,24 @@ fn persist_events(
     telemetry.persist_metrics_blocking(events).map(|_| ())
 }
 
-/// Reconcile sessions flagged by cross-session replacements. Emission is
-/// DB-only (aggregate + fingerprint compare), so this works even after the
-/// flagged session's transcripts were deleted; corrections re-emitted here
-/// carry the stored session identity but no repo_url (the server updates the
-/// bucket's values by its key).
+/// Reconcile sessions flagged by cross-session replacements or the
+/// migration purge. Emission is DB-only (aggregate + fingerprint compare),
+/// so this works even after the flagged session's transcripts were deleted;
+/// corrections carry the stored session identity and the repo_url the
+/// session's events were last emitted with, so they face the same repo
+/// exclude gate as the originals.
 fn reconcile_flagged_sessions(
     token_db: &TokenUsageDatabase,
     sink: &impl Fn(&[MetricEvent]) -> Result<(), GitAiError>,
 ) -> Result<(), GitAiError> {
-    for (session_id, external_session_id, tool) in token_db.sessions_needing_reconcile()? {
+    for session in token_db.sessions_needing_reconcile()? {
         let identity = SessionIdentity {
-            session_id: session_id.clone(),
-            external_session_id,
-            tool,
+            session_id: session.session_id.clone(),
+            external_session_id: session.external_session_id,
+            tool: session.tool,
         };
-        emit_changed_buckets(token_db, &identity, || None, sink)?;
-        token_db.clear_needs_reconcile(&session_id)?;
+        emit_changed_buckets(token_db, &identity, || session.repo_url, sink)?;
+        token_db.clear_needs_reconcile(&session.session_id)?;
     }
     Ok(())
 }
@@ -1127,6 +1136,10 @@ mod tests {
         )
         .unwrap();
         assert_eq!(run_as(&db, &identity_a, &transcript_a).unwrap().len(), 1);
+        // Production persists the emission repo_url per session; corrections
+        // must carry it so they face the same repo exclude gate.
+        db.update_session_repo_url(&identity_a.session_id, "https://github.com/acme/repo")
+            .unwrap();
         // Session A's transcript disappears (e.g. Claude Code pruned it):
         // reconciliation of A must not depend on the file.
         fs::remove_file(&transcript_a).unwrap();
@@ -1170,6 +1183,11 @@ mod tests {
         assert_eq!(
             attrs.external_session_id,
             Some(Some("ext-test".to_string()))
+        );
+        assert_eq!(
+            attrs.repo_url,
+            Some(Some("https://github.com/acme/repo".to_string())),
+            "corrections must carry the stored repo_url for the exclude gate"
         );
         assert!(db.sessions_needing_reconcile().unwrap().is_empty());
     }

--- a/src/daemon/token_usage_worker.rs
+++ b/src/daemon/token_usage_worker.rs
@@ -255,11 +255,6 @@ impl TokenUsageWorker {
                 Ok(Ok(())) => {}
                 Ok(Err(e)) => {
                     tracing::warn!(error = %e, session_id = %task.session_id, "token-usage processing failed");
-                    let _ = self.token_db.record_error(
-                        &task.session_id,
-                        &task.stream_path,
-                        &e.to_string(),
-                    );
                 }
                 Err(e) => {
                     tracing::error!(error = %e, session_id = %task.session_id, "token-usage task panicked");
@@ -318,7 +313,7 @@ fn process_task_blocking(
         return Ok(());
     };
     let ctx = EmissionContext::from_stream(&stream);
-    process_file(token_db, &ctx, &task.stream_path, shutdown_flag, |events| {
+    let result = process_file(token_db, &ctx, &task.stream_path, shutdown_flag, |events| {
         // Backpressure before handing a batch to the telemetry queue.
         for _ in 0..BACKPRESSURE_MAX_WAITS {
             if telemetry.metrics_buffer_len() < BACKPRESSURE_THRESHOLD
@@ -329,7 +324,13 @@ fn process_task_blocking(
             std::thread::sleep(Duration::from_millis(100));
         }
         telemetry.persist_metrics_blocking(events).map(|_| ())
-    })
+    });
+    if let Err(e) = &result {
+        // Keyed by the rollup session id (subagent transcripts track under
+        // their parent), matching the row ensure_file created.
+        let _ = token_db.record_error(&ctx.session_id, &task.stream_path, &e.to_string());
+    }
+    result
 }
 
 /// Incrementally read one transcript file, persist deduplicated entries, and
@@ -843,6 +844,42 @@ mod tests {
         assert_eq!(worker.queue.len(), 1);
         assert_eq!(worker.queue[0].session_id, "s_claude");
         assert_eq!(worker.queue[0].tool, "claude");
+    }
+
+    #[tokio::test]
+    async fn processing_errors_are_recorded_under_the_rollup_session() {
+        // Subagent transcripts track under their parent session id, so error
+        // recording must use the same key or the UPDATE matches no row.
+        let dir = tempfile::tempdir().unwrap();
+        let streams_db =
+            Arc::new(StreamsDatabase::open(dir.path().join("transcripts-db")).unwrap());
+        let token_db =
+            Arc::new(TokenUsageDatabase::open(dir.path().join("token-usage-db")).unwrap());
+        let missing = dir.path().join("gone.jsonl").display().to_string();
+        let mut record = stream_record("s_child", "claude", &missing);
+        record.external_parent_session_id = Some("parent-ext".to_string());
+        streams_db.insert_stream(&record).unwrap();
+
+        let task = TokenUsageTask {
+            session_id: "s_child".to_string(),
+            tool: "claude".to_string(),
+            stream_path: missing.clone(),
+        };
+        let result = process_task_blocking(
+            &streams_db,
+            &token_db,
+            &DaemonTelemetryWorkerHandle::new_noop(),
+            &task,
+            &AtomicBool::new(false),
+        );
+        assert!(result.is_err());
+
+        let parent_session = generate_session_id("parent-ext", "claude");
+        let tracked = token_db
+            .ensure_file(&parent_session, &missing, "claude")
+            .unwrap();
+        assert_eq!(tracked.processing_errors, 1);
+        assert_eq!(token_db.all_files().unwrap().len(), 1);
     }
 
     #[test]

--- a/src/daemon/token_usage_worker.rs
+++ b/src/daemon/token_usage_worker.rs
@@ -801,9 +801,13 @@ fn emit_changed_buckets(
             .emitted_seq(*next_seq);
         let mut attrs = EventAttributes::with_version(env!("CARGO_PKG_VERSION"))
             .session_id(identity.session_id.clone())
-            .external_session_id(identity.external_session_id.clone())
             .tool(&identity.tool)
             .model(&bucket.model);
+        // Rows migrated from schema v1 have no recorded external id ('');
+        // omit the attribute rather than emitting an empty string.
+        if !identity.external_session_id.is_empty() {
+            attrs = attrs.external_session_id(identity.external_session_id.clone());
+        }
         if let Some(url) = &repo_url {
             attrs = attrs.repo_url(url.clone());
         }

--- a/src/daemon/token_usage_worker.rs
+++ b/src/daemon/token_usage_worker.rs
@@ -169,6 +169,7 @@ impl TokenUsageWorker {
         sweep_ticker.tick().await; // skip the immediate tick
 
         self.enqueue_sweep_tasks().await;
+        self.reconcile_flagged().await;
 
         loop {
             if self.shutdown_flag.load(Ordering::Relaxed) {
@@ -196,6 +197,10 @@ impl TokenUsageWorker {
                 }
                 _ = sweep_ticker.tick() => {
                     self.enqueue_sweep_tasks().await;
+                    // Crash recovery: reconcile flags left by a pass that
+                    // died between its batch commit and its reconcile step,
+                    // even when no file traffic ever triggers a task again.
+                    self.reconcile_flagged().await;
                 }
                 Some(task) = self.notify_rx.recv() => {
                     self.enqueue_notify(task);
@@ -274,6 +279,21 @@ impl TokenUsageWorker {
         for task in tasks {
             self.enqueue_sweep(task);
         }
+    }
+
+    /// Reconcile cross-session flags off the async loop (used by sweeps for
+    /// crash recovery; the per-task path reconciles inline).
+    async fn reconcile_flagged(&self) {
+        let token_db = self.token_db.clone();
+        let telemetry = self.telemetry.clone();
+        let shutdown_flag = self.shutdown_flag.clone();
+        let _ = tokio::task::spawn_blocking(move || {
+            let sink = |events: &[MetricEvent]| persist_events(&telemetry, &shutdown_flag, events);
+            if let Err(e) = reconcile_flagged_sessions(&token_db, &sink) {
+                tracing::warn!(error = %e, "token-usage cross-session reconcile failed");
+            }
+        })
+        .await;
     }
 
     async fn process_task(&mut self, task: TokenUsageTask) {
@@ -462,6 +482,7 @@ fn process_task_blocking(
         return Ok(());
     };
     let identity = SessionIdentity::from_stream(&stream);
+    let sink = |events: &[MetricEvent]| persist_events(telemetry, shutdown_flag, events);
     let result = process_file(
         token_db,
         &identity,
@@ -469,19 +490,12 @@ fn process_task_blocking(
         shutdown_flag,
         // Repo discovery is deferred until events are actually emitted.
         || resolve_repo_url_for_stream(streams_db, &stream),
-        |events| {
-            // Backpressure before handing a batch to the telemetry queue.
-            for _ in 0..BACKPRESSURE_MAX_WAITS {
-                if telemetry.metrics_buffer_len() < BACKPRESSURE_THRESHOLD
-                    || shutdown_flag.load(Ordering::Relaxed)
-                {
-                    break;
-                }
-                std::thread::sleep(Duration::from_millis(100));
-            }
-            telemetry.persist_metrics_blocking(events).map(|_| ())
-        },
-    );
+        &sink,
+    )
+    // Cross-session replacements flagged other sessions during the batch
+    // commits: reconcile them now, DB-only (their files are not needed and
+    // may no longer exist).
+    .and_then(|_| reconcile_flagged_sessions(token_db, &sink));
     if let Err(e) = &result {
         // Keyed by the rollup session id (subagent transcripts track under
         // their parent), matching the row ensure_file created.
@@ -495,6 +509,45 @@ fn process_task_blocking(
     result
 }
 
+/// Hand events to the telemetry queue, waiting out buffer backpressure
+/// (same thresholds as the stream worker).
+fn persist_events(
+    telemetry: &DaemonTelemetryWorkerHandle,
+    shutdown_flag: &AtomicBool,
+    events: &[MetricEvent],
+) -> Result<(), GitAiError> {
+    for _ in 0..BACKPRESSURE_MAX_WAITS {
+        if telemetry.metrics_buffer_len() < BACKPRESSURE_THRESHOLD
+            || shutdown_flag.load(Ordering::Relaxed)
+        {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    telemetry.persist_metrics_blocking(events).map(|_| ())
+}
+
+/// Reconcile sessions flagged by cross-session replacements. Emission is
+/// DB-only (aggregate + fingerprint compare), so this works even after the
+/// flagged session's transcripts were deleted; corrections re-emitted here
+/// carry the stored session identity but no repo_url (the server updates the
+/// bucket's values by its key).
+fn reconcile_flagged_sessions(
+    token_db: &TokenUsageDatabase,
+    sink: &impl Fn(&[MetricEvent]) -> Result<(), GitAiError>,
+) -> Result<(), GitAiError> {
+    for (session_id, external_session_id, tool) in token_db.sessions_needing_reconcile()? {
+        let identity = SessionIdentity {
+            session_id: session_id.clone(),
+            external_session_id,
+            tool,
+        };
+        emit_changed_buckets(token_db, &identity, || None, sink)?;
+        token_db.clear_needs_reconcile(&session_id)?;
+    }
+    Ok(())
+}
+
 /// Incrementally read one transcript file, persist deduplicated entries, and
 /// emit changed buckets through `sink`. Split out (with injectable repo
 /// resolution and sink) for direct testing without a daemon.
@@ -504,9 +557,14 @@ fn process_file(
     stream_path: &str,
     shutdown_flag: &AtomicBool,
     resolve_repo_url: impl FnOnce() -> Option<String>,
-    sink: impl Fn(&[MetricEvent]) -> Result<(), GitAiError>,
+    sink: &impl Fn(&[MetricEvent]) -> Result<(), GitAiError>,
 ) -> Result<(), GitAiError> {
-    let tracked = token_db.ensure_file(&identity.session_id, stream_path, &identity.tool)?;
+    let tracked = token_db.ensure_file(
+        &identity.session_id,
+        stream_path,
+        &identity.tool,
+        &identity.external_session_id,
+    )?;
     let now = now_secs();
 
     // Error backoff: a file whose last pass failed is not retried on every
@@ -548,7 +606,6 @@ fn process_file(
     reader.seek(SeekFrom::Start(offset))?;
 
     let cutoff = retention_cutoff_bucket(now);
-    let mut foreign_sessions: Vec<String> = Vec::new();
     let mut line = String::new();
     let mut reached_end = false;
     let mut interrupted = false;
@@ -590,7 +647,7 @@ fn process_file(
             // turn).
             entries.extend(extractor.flush(now.saturating_mul(1000)));
         }
-        for session in token_db.commit_batch(&BatchCommit {
+        token_db.commit_batch(&BatchCommit {
             session_id: &identity.session_id,
             stream_path,
             entries: &entries,
@@ -598,11 +655,7 @@ fn process_file(
             state_json: extractor.state_json().as_deref(),
             pending_flush: extractor.has_pending(),
             min_bucket_ts: cutoff,
-        })? {
-            if !foreign_sessions.contains(&session) {
-                foreign_sessions.push(session);
-            }
-        }
+        })?;
     }
 
     if interrupted {
@@ -610,12 +663,6 @@ fn process_file(
         // size/mtime snapshot stays stale, so the next pass resumes and
         // reconciles emission.
         return Ok(());
-    }
-    // Cross-session replacements changed other sessions' buckets: invalidate
-    // their snapshots so their next pass re-reconciles with their own
-    // attributes.
-    for session in &foreign_sessions {
-        token_db.invalidate_session_files(session)?;
     }
     emit_changed_buckets(token_db, identity, resolve_repo_url, sink)?;
     // The quiet-skip snapshot is written only after emission succeeded, so a
@@ -632,12 +679,21 @@ fn emit_changed_buckets(
     token_db: &TokenUsageDatabase,
     identity: &SessionIdentity,
     resolve_repo_url: impl FnOnce() -> Option<String>,
-    sink: impl Fn(&[MetricEvent]) -> Result<(), GitAiError>,
+    sink: &impl Fn(&[MetricEvent]) -> Result<(), GitAiError>,
 ) -> Result<(), GitAiError> {
     let changed = token_db.changed_buckets(&identity.session_id)?;
     if changed.is_empty() {
         return Ok(());
     }
+    // Reserve the revisions BEFORE the sink: once a payload with revision
+    // N+1 may exist in the metrics queue, that revision must never be
+    // reused, or a crash before the fingerprint write would re-open the
+    // equal-revision tie. A failed sink merely wastes a revision number.
+    let reservations: Vec<(String, u32, u64)> = changed
+        .iter()
+        .map(|bucket| (bucket.model.clone(), bucket.bucket_ts, bucket.emit_seq + 1))
+        .collect();
+    token_db.reserve_emit_seqs(&identity.session_id, &reservations)?;
     let repo_url = resolve_repo_url();
     let mut events = Vec::with_capacity(changed.len());
     for bucket in &changed {
@@ -702,17 +758,25 @@ mod tests {
         (dir, db, transcript)
     }
 
+    /// Stable anchor for fixture timestamps: yesterday's UTC midnight,
+    /// computed once per process. Always in the past (no future-dated
+    /// fixtures right after midnight), always inside the retention window,
+    /// and never shifting between fixture creation and assertion when a test
+    /// straddles a UTC midnight.
+    fn fixture_base() -> i64 {
+        static BASE: std::sync::OnceLock<i64> = std::sync::OnceLock::new();
+        *BASE.get_or_init(|| now_secs() - now_secs() % 86_400 - 86_400)
+    }
+
     /// Recent RFC3339 timestamps so entries fall inside the retention window.
     fn recent_ts(minute: u32, second: u32) -> String {
-        let base = now_secs() - (now_secs() % 86_400);
-        chrono::DateTime::from_timestamp(base + (minute * 60 + second) as i64, 0)
+        chrono::DateTime::from_timestamp(fixture_base() + (minute * 60 + second) as i64, 0)
             .unwrap()
             .to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
     }
 
     fn bucket_of(minute: u32, second: u32) -> u64 {
-        let base = now_secs() - (now_secs() % 86_400);
-        let ts = base as u64 + (minute * 60 + second) as u64;
+        let ts = fixture_base() as u64 + (minute * 60 + second) as u64;
         ts - ts % 300
     }
 
@@ -735,7 +799,7 @@ mod tests {
             &transcript.display().to_string(),
             &flag,
             || Some("https://github.com/acme/repo".to_string()),
-            |events| {
+            &|events| {
                 collected.lock().unwrap().extend(events.to_vec());
                 Ok(())
             },
@@ -962,7 +1026,7 @@ mod tests {
         let events = run_as(&db, &identity, &transcript).unwrap();
         assert_eq!(events.len(), 1);
         assert_eq!(
-            db.ensure_file(&identity.session_id, &path, "claude")
+            db.ensure_file(&identity.session_id, &path, "claude", "ext-test")
                 .unwrap()
                 .processing_errors,
             0
@@ -1040,7 +1104,7 @@ mod tests {
     }
 
     #[test]
-    fn cross_session_replacement_invalidates_the_previous_owner() {
+    fn cross_session_replacement_reconciles_the_previous_owner_without_its_file() {
         let (dir, db, transcript_a) = setup();
         let identity_a = identity();
         fs::write(
@@ -1049,10 +1113,13 @@ mod tests {
         )
         .unwrap();
         assert_eq!(run_as(&db, &identity_a, &transcript_a).unwrap().len(), 1);
+        // Session A's transcript disappears (e.g. Claude Code pruned it):
+        // reconciliation of A must not depend on the file.
+        fs::remove_file(&transcript_a).unwrap();
 
         // A resumed session copies the message with larger totals: the entry
-        // moves to the new session, and the previous owner's file snapshot
-        // is invalidated so its zeroed bucket re-reconciles on its next pass.
+        // moves to the new session, and the previous owner is durably
+        // flagged for reconciliation.
         let identity_b = SessionIdentity {
             session_id: "s_resumed".to_string(),
             external_session_id: "ext-resumed".to_string(),
@@ -1068,22 +1135,74 @@ mod tests {
         assert_eq!(events.len(), 1);
         let attrs = EventAttributes::from_sparse(&events[0].attrs);
         assert_eq!(attrs.session_id, Some(Some("s_resumed".to_string())));
+        assert_eq!(db.sessions_needing_reconcile().unwrap().len(), 1);
 
-        let file_a = db
-            .ensure_file(
-                &identity_a.session_id,
-                &transcript_a.display().to_string(),
-                "claude",
-            )
-            .unwrap();
-        assert_eq!(file_a.last_known_size, -1, "snapshot invalidated");
-        // Session A's next pass re-emits its emptied bucket as zero.
-        let events = run_as(&db, &identity_a, &transcript_a).unwrap();
+        // The DB-only reconcile pass emits A's emptied bucket as zero with
+        // A's stored identity, no file read required, and clears the flag.
+        let collected = Mutex::new(Vec::new());
+        reconcile_flagged_sessions(&db, &|events: &[MetricEvent]| {
+            collected.lock().unwrap().extend(events.to_vec());
+            Ok(())
+        })
+        .unwrap();
+        let events = collected.into_inner().unwrap();
         assert_eq!(events.len(), 1);
         assert_eq!(
             value_u64(&events[0], token_usage_pos::TOTAL_TOKENS),
             Some(0)
         );
+        let attrs = EventAttributes::from_sparse(&events[0].attrs);
+        assert_eq!(attrs.session_id, Some(Some("s_test".to_string())));
+        assert_eq!(
+            attrs.external_session_id,
+            Some(Some("ext-test".to_string()))
+        );
+        assert!(db.sessions_needing_reconcile().unwrap().is_empty());
+    }
+
+    #[test]
+    fn failed_reconcile_sink_keeps_the_flag_for_retry() {
+        let (dir, db, transcript_a) = setup();
+        let identity_a = identity();
+        fs::write(
+            &transcript_a,
+            format!("{}\n", claude_line("m1", "r1", &recent_ts(1, 0), 50)),
+        )
+        .unwrap();
+        assert_eq!(run_as(&db, &identity_a, &transcript_a).unwrap().len(), 1);
+
+        let identity_b = SessionIdentity {
+            session_id: "s_resumed".to_string(),
+            external_session_id: "ext-resumed".to_string(),
+            tool: "claude".to_string(),
+        };
+        let transcript_b = dir.path().join("resumed.jsonl");
+        fs::write(
+            &transcript_b,
+            format!("{}\n", claude_line("m1", "r1", &recent_ts(1, 30), 90)),
+        )
+        .unwrap();
+        run_as(&db, &identity_b, &transcript_b).unwrap();
+        assert_eq!(db.sessions_needing_reconcile().unwrap().len(), 1);
+
+        // The flag survives a failed reconcile sink...
+        assert!(
+            reconcile_flagged_sessions(&db, &|_: &[MetricEvent]| {
+                Err(GitAiError::Generic("sink down".to_string()))
+            })
+            .is_err()
+        );
+        assert_eq!(db.sessions_needing_reconcile().unwrap().len(), 1);
+
+        // ...and the retry emits the correction and clears it.
+        let collected = Mutex::new(Vec::new());
+        reconcile_flagged_sessions(&db, &|events: &[MetricEvent]| {
+            collected.lock().unwrap().extend(events.to_vec());
+            Ok(())
+        })
+        .unwrap();
+        assert_eq!(collected.into_inner().unwrap().len(), 1);
+        assert!(db.sessions_needing_reconcile().unwrap().is_empty());
     }
 
     #[test]
@@ -1127,7 +1246,7 @@ mod tests {
             &transcript.display().to_string(),
             &flag,
             || None,
-            |_| Err(GitAiError::Generic("sink down".to_string())),
+            &|_| Err(GitAiError::Generic("sink down".to_string())),
         );
         assert!(result.is_err());
 
@@ -1219,7 +1338,7 @@ mod tests {
         // The settled file's snapshot matches its current metadata.
         let metadata = fs::metadata(&settled_path).unwrap();
         token_db
-            .ensure_file("s_settled", &settled_path, "claude")
+            .ensure_file("s_settled", &settled_path, "claude", "s_settled-ext")
             .unwrap();
         token_db
             .update_file_metadata(
@@ -1311,7 +1430,7 @@ mod tests {
 
         let parent_session = generate_session_id("parent-ext", "claude");
         let tracked = token_db
-            .ensure_file(&parent_session, &missing, "claude")
+            .ensure_file(&parent_session, &missing, "claude", "parent-ext")
             .unwrap();
         assert_eq!(tracked.processing_errors, 1);
         assert!(tracked.last_error_at.is_some());

--- a/src/daemon/token_usage_worker.rs
+++ b/src/daemon/token_usage_worker.rs
@@ -1755,7 +1755,10 @@ mod tests {
         let token_db =
             Arc::new(TokenUsageDatabase::open(dir.path().join("token-usage-db")).unwrap());
         let path = dir.path().join("rollout.jsonl");
-        let now = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+        // Stamped slightly in the future so pass 1 cannot release early on a
+        // loaded CI box (release needs >1s of wall clock past this stamp).
+        let now = (chrono::Utc::now() + chrono::Duration::seconds(2))
+            .to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
         let fork_meta = r#"{"timestamp":"2026-01-01T00:00:00Z","type":"session_meta","payload":{"id":"child","forked_from_id":"parent"}}"#;
         let token_count = format!(
             r#"{{"timestamp":"{now}","type":"event_msg","payload":{{"type":"token_count","info":{{"total_token_usage":{{"input_tokens":10,"cached_input_tokens":0,"output_tokens":5,"reasoning_output_tokens":0,"total_tokens":15}}}}}}}}"#
@@ -1785,9 +1788,10 @@ mod tests {
         assert_eq!(sweep_candidates(&streams_db, &token_db).len(), 1);
 
         // Pass 2, after the burst window: the parked turn is the session's
-        // own first turn and is released and emitted. (The flush clock has
-        // second granularity, so sleep past the window plus one second.)
-        std::thread::sleep(Duration::from_millis(2100));
+        // own first turn and is released and emitted. Sleep past the future
+        // stamp plus the window plus one second (the flush clock has second
+        // granularity).
+        std::thread::sleep(Duration::from_millis(4100));
         process_task_blocking(&streams_db, &token_db, &|e| sink(e), &task, &flag_off()).unwrap();
         let events = collected.lock().unwrap();
         assert_eq!(events.len(), 1);

--- a/src/daemon/token_usage_worker.rs
+++ b/src/daemon/token_usage_worker.rs
@@ -10,9 +10,12 @@
 //!   session git-ai knows about is backfilled: a newly tracked file starts at
 //!   byte offset 0 and its full history is bucketed on first processing.
 //! - The read cursor, extractor state, entries, and emission fingerprints all
-//!   live in [`TokenUsageDatabase`]; each batch commits atomically, so there
-//!   is no retry machinery here - a failed file is retried on the next
-//!   notification or sweep, and unchanged files are skipped by size/mtime.
+//!   live in [`TokenUsageDatabase`]; each batch commits atomically, and
+//!   emission reconciles fingerprints across all of the session's buckets, so
+//!   there is no retry machinery here - a failed pass (or a crash at any
+//!   point) is healed by the next notification or sweep, and unchanged files
+//!   are skipped by a size/mtime snapshot written only after a fully
+//!   successful pass.
 //! - Claude subagent transcripts roll up to their parent session (matching
 //!   ccusage), which also lets sidechain replays dedup against the parent's
 //!   entries.
@@ -37,7 +40,7 @@ use crate::error::GitAiError;
 use crate::metrics::{EventAttributes, MetricEvent, PosEncoded, TokenUsageValues};
 use crate::streams::db::{StreamRecord, StreamsDatabase};
 use crate::streams::types::{JsonlLineState, read_jsonl_line};
-use crate::token_usage::db::{DirtyBuckets, TokenUsageDatabase};
+use crate::token_usage::db::TokenUsageDatabase;
 use crate::token_usage::extractor_for_tool;
 
 /// Entry/byte bounds of one atomic batch commit.
@@ -183,8 +186,9 @@ impl TokenUsageWorker {
 
     async fn handle_drain(&mut self, request: DrainRequest) {
         // Consume notifications that were queued before the barrier.
+        let enabled = token_usage_enabled();
         while let Ok(task) = self.notify_rx.try_recv() {
-            if token_usage_enabled() {
+            if enabled {
                 self.enqueue(task);
             }
         }
@@ -371,7 +375,6 @@ fn process_file(
     let mut reader = BufReader::with_capacity(128 * 1024, file);
     reader.seek(SeekFrom::Start(offset))?;
 
-    let mut dirty = DirtyBuckets::new();
     let mut line = String::new();
     let mut reached_end = false;
     let mut interrupted = false;
@@ -407,34 +410,39 @@ fn process_file(
                 }
             }
         }
-        dirty.extend(token_db.commit_batch(
+        token_db.commit_batch(
             &ctx.session_id,
             stream_path,
             &entries,
             offset,
             extractor.state_json().as_deref(),
-        )?);
+        )?;
     }
 
-    if reached_end && !interrupted {
-        token_db.update_file_metadata(&ctx.session_id, stream_path, size, modified)?;
+    if interrupted {
+        // Shutdown mid-pass: entries and cursor are committed, and the
+        // size/mtime snapshot stays stale, so the next pass resumes and
+        // reconciles emission.
+        return Ok(());
     }
-
-    emit_changed_buckets(token_db, ctx, &dirty, sink)
+    emit_changed_buckets(token_db, ctx, sink)?;
+    // The quiet-skip snapshot is written only after emission succeeded, so a
+    // failed hand-off (or a crash anywhere in this pass) leaves the file
+    // "changed" and the next pass re-runs reconciliation.
+    token_db.update_file_metadata(&ctx.session_id, stream_path, size, modified)
 }
 
-/// Re-aggregate each dirty bucket and emit those whose fingerprint differs
-/// from the last emitted one, marking them emitted only after the sink
-/// accepted the events.
+/// Reconcile every bucket the session has entries or emission state for, and
+/// emit those whose aggregate fingerprint differs from the last emitted one,
+/// marking them emitted only after the sink accepted the events.
 fn emit_changed_buckets(
     token_db: &TokenUsageDatabase,
     ctx: &EmissionContext,
-    dirty: &DirtyBuckets,
     sink: impl Fn(&[MetricEvent]) -> Result<(), GitAiError>,
 ) -> Result<(), GitAiError> {
     let mut events = Vec::new();
     let mut emitted = Vec::new();
-    for (model, bucket) in dirty {
+    for (model, bucket) in &token_db.session_buckets(&ctx.session_id)? {
         let aggregate = token_db.aggregate_bucket(&ctx.session_id, model, *bucket)?;
         let fingerprint = aggregate.fingerprint();
         if token_db
@@ -757,18 +765,16 @@ mod tests {
         assert!(result.is_err());
 
         // Entries and cursor were committed, but the bucket was not marked
-        // emitted: the next pass over a changed file re-emits it. Touch the
-        // file so the size/mtime skip doesn't apply.
-        let mut content = fs::read_to_string(&transcript).unwrap();
-        content.push_str(&claude_line("m2", "r2", "2026-01-01T00:02:00Z", 5));
-        content.push('\n');
-        fs::write(&transcript, content).unwrap();
+        // emitted and the size/mtime snapshot was not written: the next pass
+        // over the *unchanged* file reconciles and emits it.
         let events = run(&db, &transcript).unwrap();
         assert_eq!(events.len(), 1);
         assert_eq!(
             value_u64(&events[0], token_usage_pos::MESSAGE_COUNT),
-            Some(2)
+            Some(1)
         );
+        // And a further pass stays quiet.
+        assert!(run(&db, &transcript).unwrap().is_empty());
     }
 
     fn stream_record(session_id: &str, tool: &str, path: &str) -> StreamRecord {

--- a/src/daemon/token_usage_worker.rs
+++ b/src/daemon/token_usage_worker.rs
@@ -168,7 +168,7 @@ impl TokenUsageWorker {
         sweep_ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
         sweep_ticker.tick().await; // skip the immediate tick
 
-        self.enqueue_sweep_tasks();
+        self.enqueue_sweep_tasks().await;
 
         loop {
             if self.shutdown_flag.load(Ordering::Relaxed) {
@@ -195,7 +195,7 @@ impl TokenUsageWorker {
                     }
                 }
                 _ = sweep_ticker.tick() => {
-                    self.enqueue_sweep_tasks();
+                    self.enqueue_sweep_tasks().await;
                 }
                 Some(task) = self.notify_rx.recv() => {
                     self.enqueue_notify(task);
@@ -256,47 +256,23 @@ impl TokenUsageWorker {
     }
 
     /// Enqueue supported transcripts the streams database knows about whose
-    /// files changed since the last completed pass. New files have no
-    /// snapshot yet and are always enqueued, which is what backfills history
-    /// for sessions tracked before this feature ran; missing files are
-    /// skipped quietly.
-    fn enqueue_sweep_tasks(&mut self) {
-        let streams = match self.streams_db.all_streams() {
-            Ok(streams) => streams,
-            Err(e) => {
-                tracing::warn!(error = %e, "token-usage sweep: failed to list streams");
-                return;
-            }
-        };
-        let tracked: HashMap<String, TrackedFile> = match self.token_db.all_files() {
-            Ok(files) => files
-                .into_iter()
-                .map(|file| (file.stream_path.clone(), file))
-                .collect(),
-            Err(e) => {
-                tracing::warn!(error = %e, "token-usage sweep: failed to list tracked files");
-                return;
-            }
-        };
-        for stream in streams {
-            if stream.stream_kind != "transcript" || extractor_for_tool(&stream.tool).is_none() {
-                continue;
-            }
-            let Ok(metadata) = std::fs::metadata(&stream.stream_path) else {
-                continue;
-            };
-            if let Some(file) = tracked.get(&stream.stream_path)
-                && file.last_known_size as u64 == metadata.len()
-                && file.last_modified == modified_secs(&metadata)
-                && !file.pending_flush
+    /// files changed since the last completed pass. The DB scans and per-file
+    /// stats run in `spawn_blocking`, like all other I/O in this module.
+    async fn enqueue_sweep_tasks(&mut self) {
+        let streams_db = self.streams_db.clone();
+        let token_db = self.token_db.clone();
+        let tasks =
+            match tokio::task::spawn_blocking(move || sweep_candidates(&streams_db, &token_db))
+                .await
             {
-                continue;
-            }
-            self.enqueue_sweep(TokenUsageTask {
-                session_id: stream.session_id,
-                tool: stream.tool,
-                stream_path: stream.stream_path,
-            });
+                Ok(tasks) => tasks,
+                Err(e) => {
+                    tracing::error!(error = %e, "token-usage sweep panicked");
+                    return;
+                }
+            };
+        for task in tasks {
+            self.enqueue_sweep(task);
         }
     }
 
@@ -334,6 +310,55 @@ impl TokenUsageWorker {
             }
         }
     }
+}
+
+/// New files have no snapshot yet and are always swept, which is what
+/// backfills history for sessions tracked before this feature ran; settled
+/// files (size/mtime match, nothing pending) and missing files are skipped
+/// quietly.
+fn sweep_candidates(
+    streams_db: &StreamsDatabase,
+    token_db: &TokenUsageDatabase,
+) -> Vec<TokenUsageTask> {
+    let streams = match streams_db.all_streams() {
+        Ok(streams) => streams,
+        Err(e) => {
+            tracing::warn!(error = %e, "token-usage sweep: failed to list streams");
+            return Vec::new();
+        }
+    };
+    let tracked: HashMap<String, TrackedFile> = match token_db.all_files() {
+        Ok(files) => files
+            .into_iter()
+            .map(|file| (file.stream_path.clone(), file))
+            .collect(),
+        Err(e) => {
+            tracing::warn!(error = %e, "token-usage sweep: failed to list tracked files");
+            return Vec::new();
+        }
+    };
+    let mut tasks = Vec::new();
+    for stream in streams {
+        if stream.stream_kind != "transcript" || extractor_for_tool(&stream.tool).is_none() {
+            continue;
+        }
+        let Ok(metadata) = std::fs::metadata(&stream.stream_path) else {
+            continue;
+        };
+        if let Some(file) = tracked.get(&stream.stream_path)
+            && file.last_known_size as u64 == metadata.len()
+            && file.last_modified == modified_secs(&metadata)
+            && !file.pending_flush
+        {
+            continue;
+        }
+        tasks.push(TokenUsageTask {
+            session_id: stream.session_id,
+            tool: stream.tool,
+            stream_path: stream.stream_path,
+        });
+    }
+    tasks
 }
 
 /// Rollup identity of the session a transcript belongs to: subagent
@@ -1205,11 +1230,19 @@ mod tests {
             )
             .unwrap();
 
-        let mut worker = test_worker(streams_db, token_db);
-        worker.enqueue_sweep_tasks();
-        worker.enqueue_sweep_tasks(); // dedup: repeated sweeps don't re-add
+        let candidates = sweep_candidates(&streams_db, &token_db);
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].session_id, "s_changed");
+
+        // Enqueue dedup: repeated sweeps don't re-add queued tasks.
+        let mut worker = test_worker(streams_db.clone(), token_db.clone());
+        for task in sweep_candidates(&streams_db, &token_db) {
+            worker.enqueue_sweep(task);
+        }
+        for task in sweep_candidates(&streams_db, &token_db) {
+            worker.enqueue_sweep(task);
+        }
         assert_eq!(worker.sweep_queue.len(), 1);
-        assert_eq!(worker.sweep_queue[0].session_id, "s_changed");
         assert!(worker.notify_queue.is_empty());
     }
 

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -147,6 +147,7 @@ mod superuser_guard;
 mod sweep_e2e;
 mod test_utils_unit;
 mod tls_native_certs;
+mod token_usage;
 mod usage_period;
 mod utf8_filenames;
 mod virtual_attribution_unit;

--- a/tests/integration/token_usage.rs
+++ b/tests/integration/token_usage.rs
@@ -201,6 +201,8 @@ fn claude_transcript_emits_token_usage_bucket_events() {
     assert!(value_u64(second, token_usage_pos::EST_COST_MICRO_USD).unwrap() > 0);
 
     for event in &events {
+        // The server's ordering key must be present on real pipeline events.
+        assert!(value_u64(event, token_usage_pos::EMITTED_SEQ).unwrap() > 0);
         let attrs = EventAttributes::from_sparse(&event.attrs);
         assert_eq!(
             attrs.session_id,
@@ -414,5 +416,159 @@ fn disabled_flag_spawns_nothing_and_deletes_collected_data() {
     assert!(
         !token_db_path.exists(),
         "token-usage database must not be created with the flag off"
+    );
+}
+
+/// `claude --resume` copies the parent conversation into a NEW session file
+/// with the original message/request ids: driven through the real daemon,
+/// the copied history must not be re-counted under the new session.
+#[test]
+fn resumed_session_through_the_daemon_does_not_double_count() {
+    let (_metrics_db_dir, metrics_db_path) = isolated_metrics_db_path();
+    let repo =
+        TestRepo::new_with_daemon_env(&[("GIT_AI_TEST_METRICS_DB_PATH", metrics_db_path.as_str())]);
+    repo.git(&["commit", "--allow-empty", "-m", "initial"])
+        .expect("initial commit should succeed");
+    let repo_root = repo.canonical_path();
+
+    let original = repo_root.join("original.jsonl");
+    let history = claude_usage_line("m1", "r1", &recent_ts(1, 0), 50, None);
+    fs::write(&original, format!("{history}\n")).unwrap();
+    let file_path = repo_root.join("example.ts");
+    fs::write(&file_path, "const x = 1;\n").unwrap();
+    checkpoint_with_transcript(
+        &repo,
+        "claude",
+        "sess-original",
+        &original,
+        &file_path,
+        "const x = 1;\nconst y = 2;\n",
+    );
+    sync_token_usage_pipeline(&repo);
+    assert_eq!(token_usage_events(&metrics_db_path).len(), 1);
+
+    // The resumed session's file replays the identical history line and
+    // adds one new turn in a later bucket.
+    let resumed = repo_root.join("resumed.jsonl");
+    fs::write(
+        &resumed,
+        format!(
+            "{history}\n{}\n",
+            claude_usage_line("m2", "r2", &recent_ts(6, 0), 70, None)
+        ),
+    )
+    .unwrap();
+    checkpoint_with_transcript(
+        &repo,
+        "claude",
+        "sess-resumed",
+        &resumed,
+        &file_path,
+        "const x = 1;\nconst y = 2;\nconst z = 3;\n",
+    );
+    sync_token_usage_pipeline(&repo);
+
+    let events = token_usage_events(&metrics_db_path);
+    assert_eq!(
+        events.len(),
+        2,
+        "only the resumed session's genuinely new bucket emits"
+    );
+    let new_bucket = &events[1];
+    assert_eq!(
+        value_u64(new_bucket, token_usage_pos::BUCKET_TS),
+        Some(bucket_of(6, 0))
+    );
+    assert_eq!(
+        value_u64(new_bucket, token_usage_pos::MESSAGE_COUNT),
+        Some(1)
+    );
+    let attrs = EventAttributes::from_sparse(&new_bucket.attrs);
+    assert_eq!(
+        attrs.session_id,
+        Some(Some(generate_session_id("sess-resumed", "claude")))
+    );
+}
+
+/// Subagent transcripts (a `<parent>/subagents/*.jsonl` path) roll up to the
+/// parent session through the real daemon, and a sidechain replay of a
+/// parent message dedups across the two files.
+#[test]
+fn subagent_transcript_rolls_up_to_the_parent_session() {
+    let (_metrics_db_dir, metrics_db_path) = isolated_metrics_db_path();
+    let repo =
+        TestRepo::new_with_daemon_env(&[("GIT_AI_TEST_METRICS_DB_PATH", metrics_db_path.as_str())]);
+    repo.git(&["commit", "--allow-empty", "-m", "initial"])
+        .expect("initial commit should succeed");
+    let repo_root = repo.canonical_path();
+
+    let parent_transcript = repo_root.join("sess-parent.jsonl");
+    fs::write(
+        &parent_transcript,
+        format!(
+            "{}\n",
+            claude_usage_line("m1", "r1", &recent_ts(1, 0), 50, None)
+        ),
+    )
+    .unwrap();
+    let file_path = repo_root.join("example.ts");
+    fs::write(&file_path, "const x = 1;\n").unwrap();
+    checkpoint_with_transcript(
+        &repo,
+        "claude",
+        "sess-parent",
+        &parent_transcript,
+        &file_path,
+        "const x = 1;\nconst y = 2;\n",
+    );
+    sync_token_usage_pipeline(&repo);
+    assert_eq!(token_usage_events(&metrics_db_path).len(), 1);
+
+    // The subagent file replays the parent's message (sidechain, inflated
+    // cache reads) plus its own turn in a later bucket.
+    let subagent_dir = repo_root.join("sess-parent").join("subagents");
+    fs::create_dir_all(&subagent_dir).unwrap();
+    let subagent_transcript = subagent_dir.join("agent-1.jsonl");
+    let sidechain_replay = format!(
+        r#"{{"timestamp":"{}","isSidechain":true,"sessionId":"ext","requestId":"r-replay","message":{{"id":"m1","model":"claude-sonnet-4-20250514","usage":{{"input_tokens":100,"output_tokens":10,"cache_creation_input_tokens":0,"cache_read_input_tokens":50000}}}}}}"#,
+        recent_ts(1, 30)
+    );
+    fs::write(
+        &subagent_transcript,
+        format!(
+            "{sidechain_replay}\n{}\n",
+            claude_usage_line("m2", "r2", &recent_ts(6, 0), 70, None),
+        ),
+    )
+    .unwrap();
+    checkpoint_with_transcript(
+        &repo,
+        "claude",
+        "agent-1",
+        &subagent_transcript,
+        &file_path,
+        "const x = 1;\nconst y = 2;\nconst z = 3;\n",
+    );
+    sync_token_usage_pipeline(&repo);
+
+    let events = token_usage_events(&metrics_db_path);
+    // The sidechain replay deduped against the parent's entry (no inflated
+    // re-emission of the first bucket); only the subagent's own turn emits,
+    // attributed to the PARENT session.
+    assert_eq!(events.len(), 2);
+    let subagent_event = &events[1];
+    assert_eq!(
+        value_u64(subagent_event, token_usage_pos::BUCKET_TS),
+        Some(bucket_of(6, 0))
+    );
+    assert_eq!(
+        value_u64(subagent_event, token_usage_pos::CACHE_READ_TOKENS),
+        Some(200),
+        "the 50k-cache-read sidechain replay must not count"
+    );
+    let attrs = EventAttributes::from_sparse(&subagent_event.attrs);
+    assert_eq!(
+        attrs.session_id,
+        Some(Some(generate_session_id("sess-parent", "claude")))
     );
 }

--- a/tests/integration/token_usage.rs
+++ b/tests/integration/token_usage.rs
@@ -31,6 +31,38 @@ fn value_u64(event: &MetricEvent, pos: usize) -> Option<u64> {
     event.values.get(&pos.to_string()).and_then(|v| v.as_u64())
 }
 
+fn now_secs() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64
+}
+
+/// Recent RFC3339 timestamps (start of today + offset) so fixture entries
+/// fall inside the retention window.
+fn recent_ts(minute: u32, second: u32) -> String {
+    let base = now_secs() - (now_secs() % 86_400);
+    chrono::DateTime::from_timestamp(base + (minute * 60 + second) as i64, 0)
+        .unwrap()
+        .to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+}
+
+fn bucket_of(minute: u32, second: u32) -> u64 {
+    let base = now_secs() - (now_secs() % 86_400);
+    let ts = base as u64 + (minute * 60 + second) as u64;
+    ts - ts % 300
+}
+
+/// Barrier over the full pipeline: `sync_daemon` covers checkpoint admission
+/// and family processing, and `git-ai await` reaches `await_completion`,
+/// which drains the stream worker and then the token-usage worker before the
+/// telemetry flush - so events are in the metrics DB when it returns.
+fn sync_token_usage_pipeline(repo: &TestRepo) {
+    repo.sync_daemon();
+    repo.git_ai(&["await", "--timeout", "60"])
+        .expect("await should drain the token-usage pipeline");
+}
+
 /// Fire a pre+post checkpoint pair that carries the transcript path, editing
 /// `file_path` in between so the checkpoint records an AI change.
 fn checkpoint_with_transcript(
@@ -95,15 +127,14 @@ fn claude_transcript_emits_token_usage_bucket_events() {
 
     // Transcript history predates the checkpoint: the whole file is bucketed
     // (backfill of a session's full history from byte offset 0).
-    // 2026-01-01T00:00:00Z = 1767225600.
     let transcript_path = repo_root.join("claude-session.jsonl");
     fs::write(
         &transcript_path,
         format!(
             "{}\n{}\n{}\n",
             json!({"type": "user", "message": {"content": "hello"}}),
-            claude_usage_line("m1", "r1", "2026-01-01T00:01:00Z", 50, Some(1.25)),
-            claude_usage_line("m2", "r2", "2026-01-01T00:06:00Z", 70, None),
+            claude_usage_line("m1", "r1", &recent_ts(1, 0), 50, Some(1.25)),
+            claude_usage_line("m2", "r2", &recent_ts(6, 0), 70, None),
         ),
     )
     .unwrap();
@@ -118,7 +149,7 @@ fn claude_transcript_emits_token_usage_bucket_events() {
         &file_path,
         "const x = 1;\nconst y = 2;\n",
     );
-    repo.sync_daemon();
+    sync_token_usage_pipeline(&repo);
 
     let mut events = token_usage_events(&metrics_db_path);
     events.sort_by_key(|e| value_u64(e, token_usage_pos::BUCKET_TS));
@@ -127,7 +158,7 @@ fn claude_transcript_emits_token_usage_bucket_events() {
     let first = &events[0];
     assert_eq!(
         value_u64(first, token_usage_pos::BUCKET_TS),
-        Some(1_767_225_600)
+        Some(bucket_of(1, 0))
     );
     assert_eq!(value_u64(first, token_usage_pos::INPUT_TOKENS), Some(100));
     assert_eq!(value_u64(first, token_usage_pos::OUTPUT_TOKENS), Some(50));
@@ -155,7 +186,7 @@ fn claude_transcript_emits_token_usage_bucket_events() {
     let second = &events[1];
     assert_eq!(
         value_u64(second, token_usage_pos::BUCKET_TS),
-        Some(1_767_225_900)
+        Some(bucket_of(6, 0))
     );
     assert_eq!(value_u64(second, token_usage_pos::OUTPUT_TOKENS), Some(70));
     // No costUSD on the second entry: cost is computed from the embedded
@@ -220,9 +251,9 @@ fn codex_transcript_emits_deltas_with_reasoning_tokens() {
             "{}\n{}\n{}\n{}\n",
             json!({"timestamp": "2026-01-01T00:00:00Z", "type": "session_meta", "payload": {"id": "sess-token-codex"}}),
             json!({"timestamp": "2026-01-01T00:00:30Z", "type": "turn_context", "payload": {"model": "gpt-5.1"}}),
-            token_count("2026-01-01T00:01:00Z", 100, 40, 50, 10),
+            token_count(&recent_ts(1, 0), 100, 40, 50, 10),
             // Same bucket; cumulative totals advance by (200, 60, 40, 5).
-            token_count("2026-01-01T00:03:00Z", 300, 100, 90, 15),
+            token_count(&recent_ts(3, 0), 300, 100, 90, 15),
         ),
     )
     .unwrap();
@@ -237,14 +268,14 @@ fn codex_transcript_emits_deltas_with_reasoning_tokens() {
         &file_path,
         "fn main() {}\nfn added() {}\n",
     );
-    repo.sync_daemon();
+    sync_token_usage_pipeline(&repo);
 
     let events = token_usage_events(&metrics_db_path);
     assert_eq!(events.len(), 1, "both deltas land in one bucket");
     let event = &events[0];
     assert_eq!(
         value_u64(event, token_usage_pos::BUCKET_TS),
-        Some(1_767_225_600)
+        Some(bucket_of(1, 0))
     );
     // Normalized input excludes cached tokens: (100-40) + (200-60).
     assert_eq!(value_u64(event, token_usage_pos::INPUT_TOKENS), Some(200));
@@ -283,7 +314,7 @@ fn appended_transcript_lines_update_existing_buckets() {
         &transcript_path,
         format!(
             "{}\n",
-            claude_usage_line("m1", "r1", "2026-01-01T00:01:00Z", 50, None)
+            claude_usage_line("m1", "r1", &recent_ts(1, 0), 50, None)
         ),
     )
     .unwrap();
@@ -298,19 +329,13 @@ fn appended_transcript_lines_update_existing_buckets() {
         &file_path,
         "const x = 1;\nconst y = 2;\n",
     );
-    repo.sync_daemon();
+    sync_token_usage_pipeline(&repo);
     assert_eq!(token_usage_events(&metrics_db_path).len(), 1);
 
     // A new usage entry lands in the same bucket: the incremental pass reads
     // only the appended line and re-emits the bucket with combined totals.
     let mut content = fs::read_to_string(&transcript_path).unwrap();
-    content.push_str(&claude_usage_line(
-        "m2",
-        "r2",
-        "2026-01-01T00:02:00Z",
-        30,
-        None,
-    ));
+    content.push_str(&claude_usage_line("m2", "r2", &recent_ts(2, 0), 30, None));
     content.push('\n');
     fs::write(&transcript_path, content).unwrap();
 
@@ -322,15 +347,65 @@ fn appended_transcript_lines_update_existing_buckets() {
         &file_path,
         "const x = 1;\nconst y = 2;\nconst z = 3;\n",
     );
-    repo.sync_daemon();
+    sync_token_usage_pipeline(&repo);
 
     let events = token_usage_events(&metrics_db_path);
     assert_eq!(events.len(), 2, "the bucket re-emits once with new totals");
     let latest = &events[1];
     assert_eq!(
         value_u64(latest, token_usage_pos::BUCKET_TS),
-        Some(1_767_225_600)
+        Some(bucket_of(1, 0))
     );
     assert_eq!(value_u64(latest, token_usage_pos::OUTPUT_TOKENS), Some(80));
     assert_eq!(value_u64(latest, token_usage_pos::MESSAGE_COUNT), Some(2));
+}
+
+#[test]
+fn disabled_flag_spawns_nothing_and_deletes_collected_data() {
+    let (_metrics_db_dir, metrics_db_path) = isolated_metrics_db_path();
+    let repo = TestRepo::new_with_daemon_env(&[
+        ("GIT_AI_TEST_METRICS_DB_PATH", metrics_db_path.as_str()),
+        ("GIT_AI_TOKEN_USAGE_METRICS", "0"),
+    ]);
+    repo.git(&["commit", "--allow-empty", "-m", "initial"])
+        .expect("initial commit should succeed");
+    let repo_root = repo.canonical_path();
+
+    // Simulate data collected while the flag was on: the daemon must delete
+    // it at startup when the flag is off. (The daemon already started, so
+    // create-then-restart is not observable here; instead assert the running
+    // daemon never creates the DB and emits nothing.)
+    let transcript_path = repo_root.join("claude-session.jsonl");
+    fs::write(
+        &transcript_path,
+        format!(
+            "{}\n",
+            claude_usage_line("m1", "r1", &recent_ts(1, 0), 50, None)
+        ),
+    )
+    .unwrap();
+
+    let file_path = repo_root.join("example.ts");
+    fs::write(&file_path, "const x = 1;\n").unwrap();
+    checkpoint_with_transcript(
+        &repo,
+        "claude",
+        "sess-token-disabled",
+        &transcript_path,
+        &file_path,
+        "const x = 1;\nconst y = 2;\n",
+    );
+    sync_token_usage_pipeline(&repo);
+
+    assert!(
+        token_usage_events(&metrics_db_path).is_empty(),
+        "no TokenUsage events with the flag off"
+    );
+    let token_db_path = repo
+        .test_home_path()
+        .join(".git-ai/internal/token-usage-db");
+    assert!(
+        !token_db_path.exists(),
+        "token-usage database must not be created with the flag off"
+    );
 }

--- a/tests/integration/token_usage.rs
+++ b/tests/integration/token_usage.rs
@@ -38,18 +38,25 @@ fn now_secs() -> i64 {
         .as_secs() as i64
 }
 
-/// Recent RFC3339 timestamps (start of today + offset) so fixture entries
-/// fall inside the retention window.
+/// Stable anchor for fixture timestamps: yesterday's UTC midnight, computed
+/// once per process. Always in the past, always inside the retention window,
+/// and never shifting between fixture creation and assertion when a test
+/// straddles a UTC midnight.
+fn fixture_base() -> i64 {
+    static BASE: std::sync::OnceLock<i64> = std::sync::OnceLock::new();
+    *BASE.get_or_init(|| now_secs() - now_secs() % 86_400 - 86_400)
+}
+
+/// Recent RFC3339 timestamps so fixture entries fall inside the retention
+/// window.
 fn recent_ts(minute: u32, second: u32) -> String {
-    let base = now_secs() - (now_secs() % 86_400);
-    chrono::DateTime::from_timestamp(base + (minute * 60 + second) as i64, 0)
+    chrono::DateTime::from_timestamp(fixture_base() + (minute * 60 + second) as i64, 0)
         .unwrap()
         .to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
 }
 
 fn bucket_of(minute: u32, second: u32) -> u64 {
-    let base = now_secs() - (now_secs() % 86_400);
-    let ts = base as u64 + (minute * 60 + second) as u64;
+    let ts = fixture_base() as u64 + (minute * 60 + second) as u64;
     ts - ts % 300
 }
 

--- a/tests/integration/token_usage.rs
+++ b/tests/integration/token_usage.rs
@@ -1,0 +1,336 @@
+//! End-to-end tests for TokenUsage metric events (event id 9): checkpoint ->
+//! stream worker -> token-usage worker -> metrics DB.
+
+use crate::repos::test_repo::TestRepo;
+use git_ai::authorship::authorship_log_serialization::generate_session_id;
+use git_ai::metrics::db::MetricsDatabase;
+use git_ai::metrics::events::token_usage_pos;
+use git_ai::metrics::types::{MetricEvent, MetricEventId};
+use git_ai::metrics::{EventAttributes, PosEncoded};
+use serde_json::json;
+use std::fs;
+use std::path::Path;
+
+fn isolated_metrics_db_path() -> (tempfile::TempDir, String) {
+    let dir = tempfile::tempdir().expect("failed to create isolated metrics db dir");
+    let path = dir.path().join("metrics.db");
+    (dir, path.to_string_lossy().to_string())
+}
+
+fn token_usage_events(metrics_db_path: &str) -> Vec<MetricEvent> {
+    let db = MetricsDatabase::open_at_path(Path::new(metrics_db_path))
+        .expect("metrics db should open at isolated path");
+    db.get_metric_history(0, None, &[MetricEventId::TokenUsage as u16])
+        .expect("token usage history should be readable")
+        .into_iter()
+        .map(|record| record.event)
+        .collect()
+}
+
+fn value_u64(event: &MetricEvent, pos: usize) -> Option<u64> {
+    event.values.get(&pos.to_string()).and_then(|v| v.as_u64())
+}
+
+/// Fire a pre+post checkpoint pair that carries the transcript path, editing
+/// `file_path` in between so the checkpoint records an AI change.
+fn checkpoint_with_transcript(
+    repo: &TestRepo,
+    preset: &str,
+    session_id: &str,
+    transcript_path: &Path,
+    file_path: &Path,
+    contents: &str,
+) {
+    // Tool names/input shapes each preset accepts as a file edit.
+    let (tool_name, tool_input) = match preset {
+        "codex" => (
+            "apply_patch",
+            json!({ "patch": format!("*** Update File: {}\n", file_path.to_string_lossy()) }),
+        ),
+        _ => ("Write", json!({ "file_path": file_path.to_string_lossy() })),
+    };
+    for hook_event_name in ["PreToolUse", "PostToolUse"] {
+        let hook_input = json!({
+            "cwd": repo.canonical_path().to_string_lossy(),
+            "hook_event_name": hook_event_name,
+            "tool_name": tool_name,
+            "tool_use_id": "toolu_token_usage",
+            "session_id": session_id,
+            "transcript_path": transcript_path.to_string_lossy(),
+            "tool_input": tool_input
+        })
+        .to_string();
+        repo.git_ai(&["checkpoint", preset, "--hook-input", &hook_input])
+            .expect("checkpoint should succeed");
+        if hook_event_name == "PreToolUse" {
+            fs::write(file_path, contents).unwrap();
+        }
+    }
+}
+
+fn claude_usage_line(msg: &str, req: &str, ts: &str, output: u64, cost_usd: Option<f64>) -> String {
+    let cost = cost_usd
+        .map(|c| format!(r#""costUSD":{c},"#))
+        .unwrap_or_default();
+    format!(
+        r#"{{"timestamp":"{ts}",{cost}"sessionId":"ext","requestId":"{req}","message":{{"id":"{msg}","model":"claude-sonnet-4-20250514","usage":{{"input_tokens":100,"output_tokens":{output},"cache_creation_input_tokens":30,"cache_read_input_tokens":200}}}}}}"#
+    )
+}
+
+#[test]
+fn claude_transcript_emits_token_usage_bucket_events() {
+    let (_metrics_db_dir, metrics_db_path) = isolated_metrics_db_path();
+    let repo =
+        TestRepo::new_with_daemon_env(&[("GIT_AI_TEST_METRICS_DB_PATH", metrics_db_path.as_str())]);
+    repo.git(&[
+        "remote",
+        "add",
+        "origin",
+        "https://github.com/acme/token-usage.git",
+    ])
+    .expect("remote add should succeed");
+    repo.git(&["commit", "--allow-empty", "-m", "initial"])
+        .expect("initial commit should succeed");
+    let repo_root = repo.canonical_path();
+
+    // Transcript history predates the checkpoint: the whole file is bucketed
+    // (backfill of a session's full history from byte offset 0).
+    // 2026-01-01T00:00:00Z = 1767225600.
+    let transcript_path = repo_root.join("claude-session.jsonl");
+    fs::write(
+        &transcript_path,
+        format!(
+            "{}\n{}\n{}\n",
+            json!({"type": "user", "message": {"content": "hello"}}),
+            claude_usage_line("m1", "r1", "2026-01-01T00:01:00Z", 50, Some(1.25)),
+            claude_usage_line("m2", "r2", "2026-01-01T00:06:00Z", 70, None),
+        ),
+    )
+    .unwrap();
+
+    let file_path = repo_root.join("example.ts");
+    fs::write(&file_path, "const x = 1;\n").unwrap();
+    checkpoint_with_transcript(
+        &repo,
+        "claude",
+        "sess-token-claude",
+        &transcript_path,
+        &file_path,
+        "const x = 1;\nconst y = 2;\n",
+    );
+    repo.sync_daemon();
+
+    let mut events = token_usage_events(&metrics_db_path);
+    events.sort_by_key(|e| value_u64(e, token_usage_pos::BUCKET_TS));
+    assert_eq!(events.len(), 2, "one event per 5-minute bucket");
+
+    let first = &events[0];
+    assert_eq!(
+        value_u64(first, token_usage_pos::BUCKET_TS),
+        Some(1_767_225_600)
+    );
+    assert_eq!(value_u64(first, token_usage_pos::INPUT_TOKENS), Some(100));
+    assert_eq!(value_u64(first, token_usage_pos::OUTPUT_TOKENS), Some(50));
+    assert_eq!(
+        value_u64(first, token_usage_pos::CACHE_READ_TOKENS),
+        Some(200)
+    );
+    assert_eq!(
+        value_u64(first, token_usage_pos::CACHE_WRITE_TOKENS),
+        Some(30)
+    );
+    assert_eq!(value_u64(first, token_usage_pos::TOTAL_TOKENS), Some(380));
+    assert_eq!(value_u64(first, token_usage_pos::MESSAGE_COUNT), Some(1));
+    // costUSD 1.25 from the transcript wins over computed pricing.
+    assert_eq!(
+        value_u64(first, token_usage_pos::EST_COST_MICRO_USD),
+        Some(1_250_000)
+    );
+    // Claude reports no reasoning tokens: field stays unset.
+    assert_eq!(
+        value_u64(first, token_usage_pos::REASONING_OUTPUT_TOKENS),
+        None
+    );
+
+    let second = &events[1];
+    assert_eq!(
+        value_u64(second, token_usage_pos::BUCKET_TS),
+        Some(1_767_225_900)
+    );
+    assert_eq!(value_u64(second, token_usage_pos::OUTPUT_TOKENS), Some(70));
+    // No costUSD on the second entry: cost is computed from the embedded
+    // models.dev snapshot, so it must be non-zero.
+    assert!(value_u64(second, token_usage_pos::EST_COST_MICRO_USD).unwrap() > 0);
+
+    for event in &events {
+        let attrs = EventAttributes::from_sparse(&event.attrs);
+        assert_eq!(
+            attrs.session_id,
+            Some(Some(generate_session_id("sess-token-claude", "claude")))
+        );
+        assert_eq!(
+            attrs.external_session_id,
+            Some(Some("sess-token-claude".to_string()))
+        );
+        assert_eq!(attrs.tool, Some(Some("claude".to_string())));
+        assert_eq!(
+            attrs.model,
+            Some(Some("claude-sonnet-4-20250514".to_string()))
+        );
+        let repo_url = attrs.repo_url.flatten().expect("repo_url should be set");
+        assert!(
+            repo_url.contains("acme/token-usage"),
+            "unexpected repo_url {repo_url}"
+        );
+    }
+}
+
+#[test]
+fn codex_transcript_emits_deltas_with_reasoning_tokens() {
+    let (_metrics_db_dir, metrics_db_path) = isolated_metrics_db_path();
+    let repo =
+        TestRepo::new_with_daemon_env(&[("GIT_AI_TEST_METRICS_DB_PATH", metrics_db_path.as_str())]);
+    repo.git(&["commit", "--allow-empty", "-m", "initial"])
+        .expect("initial commit should succeed");
+    let repo_root = repo.canonical_path();
+
+    let transcript_path = repo_root.join("codex-session.jsonl");
+    let token_count = |ts: &str, input: u64, cached: u64, output: u64, reasoning: u64| {
+        json!({
+            "timestamp": ts,
+            "type": "event_msg",
+            "payload": {
+                "type": "token_count",
+                "info": {
+                    "total_token_usage": {
+                        "input_tokens": input,
+                        "cached_input_tokens": cached,
+                        "output_tokens": output,
+                        "reasoning_output_tokens": reasoning,
+                        "total_tokens": input + output
+                    }
+                }
+            }
+        })
+        .to_string()
+    };
+    fs::write(
+        &transcript_path,
+        format!(
+            "{}\n{}\n{}\n{}\n",
+            json!({"timestamp": "2026-01-01T00:00:00Z", "type": "session_meta", "payload": {"id": "sess-token-codex"}}),
+            json!({"timestamp": "2026-01-01T00:00:30Z", "type": "turn_context", "payload": {"model": "gpt-5.1"}}),
+            token_count("2026-01-01T00:01:00Z", 100, 40, 50, 10),
+            // Same bucket; cumulative totals advance by (200, 60, 40, 5).
+            token_count("2026-01-01T00:03:00Z", 300, 100, 90, 15),
+        ),
+    )
+    .unwrap();
+
+    let file_path = repo_root.join("main.rs");
+    fs::write(&file_path, "fn main() {}\n").unwrap();
+    checkpoint_with_transcript(
+        &repo,
+        "codex",
+        "sess-token-codex",
+        &transcript_path,
+        &file_path,
+        "fn main() {}\nfn added() {}\n",
+    );
+    repo.sync_daemon();
+
+    let events = token_usage_events(&metrics_db_path);
+    assert_eq!(events.len(), 1, "both deltas land in one bucket");
+    let event = &events[0];
+    assert_eq!(
+        value_u64(event, token_usage_pos::BUCKET_TS),
+        Some(1_767_225_600)
+    );
+    // Normalized input excludes cached tokens: (100-40) + (200-60).
+    assert_eq!(value_u64(event, token_usage_pos::INPUT_TOKENS), Some(200));
+    assert_eq!(
+        value_u64(event, token_usage_pos::CACHE_READ_TOKENS),
+        Some(100)
+    );
+    assert_eq!(value_u64(event, token_usage_pos::OUTPUT_TOKENS), Some(90));
+    assert_eq!(
+        value_u64(event, token_usage_pos::REASONING_OUTPUT_TOKENS),
+        Some(15)
+    );
+    assert_eq!(value_u64(event, token_usage_pos::MESSAGE_COUNT), Some(2));
+    assert!(value_u64(event, token_usage_pos::EST_COST_MICRO_USD).unwrap() > 0);
+
+    let attrs = EventAttributes::from_sparse(&event.attrs);
+    assert_eq!(attrs.tool, Some(Some("codex".to_string())));
+    assert_eq!(attrs.model, Some(Some("gpt-5.1".to_string())));
+    assert_eq!(
+        attrs.session_id,
+        Some(Some(generate_session_id("sess-token-codex", "codex")))
+    );
+}
+
+#[test]
+fn appended_transcript_lines_update_existing_buckets() {
+    let (_metrics_db_dir, metrics_db_path) = isolated_metrics_db_path();
+    let repo =
+        TestRepo::new_with_daemon_env(&[("GIT_AI_TEST_METRICS_DB_PATH", metrics_db_path.as_str())]);
+    repo.git(&["commit", "--allow-empty", "-m", "initial"])
+        .expect("initial commit should succeed");
+    let repo_root = repo.canonical_path();
+
+    let transcript_path = repo_root.join("claude-session.jsonl");
+    fs::write(
+        &transcript_path,
+        format!(
+            "{}\n",
+            claude_usage_line("m1", "r1", "2026-01-01T00:01:00Z", 50, None)
+        ),
+    )
+    .unwrap();
+
+    let file_path = repo_root.join("example.ts");
+    fs::write(&file_path, "const x = 1;\n").unwrap();
+    checkpoint_with_transcript(
+        &repo,
+        "claude",
+        "sess-token-append",
+        &transcript_path,
+        &file_path,
+        "const x = 1;\nconst y = 2;\n",
+    );
+    repo.sync_daemon();
+    assert_eq!(token_usage_events(&metrics_db_path).len(), 1);
+
+    // A new usage entry lands in the same bucket: the incremental pass reads
+    // only the appended line and re-emits the bucket with combined totals.
+    let mut content = fs::read_to_string(&transcript_path).unwrap();
+    content.push_str(&claude_usage_line(
+        "m2",
+        "r2",
+        "2026-01-01T00:02:00Z",
+        30,
+        None,
+    ));
+    content.push('\n');
+    fs::write(&transcript_path, content).unwrap();
+
+    checkpoint_with_transcript(
+        &repo,
+        "claude",
+        "sess-token-append",
+        &transcript_path,
+        &file_path,
+        "const x = 1;\nconst y = 2;\nconst z = 3;\n",
+    );
+    repo.sync_daemon();
+
+    let events = token_usage_events(&metrics_db_path);
+    assert_eq!(events.len(), 2, "the bucket re-emits once with new totals");
+    let latest = &events[1];
+    assert_eq!(
+        value_u64(latest, token_usage_pos::BUCKET_TS),
+        Some(1_767_225_600)
+    );
+    assert_eq!(value_u64(latest, token_usage_pos::OUTPUT_TOKENS), Some(80));
+    assert_eq!(value_u64(latest, token_usage_pos::MESSAGE_COUNT), Some(2));
+}


### PR DESCRIPTION
## Summary

Fourth PR of the TokenUsage stack: the daemon worker that turns transcript files into TokenUsage metric events, plus wiring and end-to-end tests.

- **Triggers (all off the trace2 ingestion path)**: a non-blocking ping from the stream worker after it successfully processes a transcript, a startup sweep, and a 30-minute ticker (missed ticks skipped, not replayed). Sweeps enumerate the streams database's `transcript` rows, so every session git-ai already knows about is **backfilled** — a newly tracked file starts at byte offset 0 and its full history (within the retention window) is bucketed. Sweep enumeration costs one stat per session compared against the token DB's size/mtime snapshot; settled sessions never reach `spawn_blocking`, DB reads, or repo discovery, and repo discovery is further deferred until events are actually emitted.
- **Queues**: notifications and sweep backfill run on separate queues; the `git-ai await` drain barrier waits only for notification-driven work (with promotion when a notification hits a file queued for backfill), so a first-start historical backfill can never starve `await` into skipping the telemetry flush. Shutdown is observed *during* processing: the worker selects on its own shutdown `Notify` around the in-flight blocking pass.
- **Incremental & quiet**: reads via `read_jsonl_line` from the persisted cursor with the extractor's substring prefilter ahead of any JSON parsing; bounded batches (1000 entries / 4 MiB) commit entries + extractor state + cursor in one token-db transaction; per-file error backoff (5s/30s/5m/30m) keeps permanently failing transcripts from re-reading on every trigger; telemetry backpressure mirrors the stream worker; the retention cutoff is applied at extraction so backfill never uploads history the prune would delete.
- **Emission durability**: changed buckets come from a single grouped reconciliation query; events carry a strictly increasing per-bucket `emitted_seq` (server keeps the highest revision, so same-second re-emissions can't tie); buckets are marked emitted only after the telemetry queue accepted the events, and the quiet-skip snapshot is written only after a fully successful pass — a failed hand-off or crash at any point is healed by the next pass.
- **Session identity**: Claude subagent transcripts roll up to the parent session (ccusage parity); cross-session resume/fork replacements invalidate the previous owner's snapshot so its buckets re-reconcile with their own attributes; forked codex single turns flush at end-of-file once the burst window has passed.
- **Privacy**: repo_url falls back to the agent's cwd inference (persisted back) like the SessionEvent path, closing the exclude-gate fail-open for sweep-backfilled sessions.
- **Feature-flag hygiene**: `token_usage_metrics` gates the worker at startup (like `transcript_streaming`) — when off, no DB is created, no worker/ticker runs, no config re-reads happen, and previously collected data is deleted.
- **Wiring**: spawned next to the stream worker with its own shutdown `Notify` (`request_shutdown` uses `notify_one`, which wakes exactly one waiter); drained in `await_completion` right after the transcript drain; the stream worker pings from both its steady-state and drain success paths.

## Non-negotiable-rules compliance

No git spawns anywhere (repo_url resolves via `resolve_repo_url_from_path` / `infer_cwd`, both gix-based file reads); nothing added to the critical ingestion path (the only touch on an existing path is one non-blocking unbounded-channel send after the stream worker finishes a task); all file/SQLite I/O in `spawn_blocking`.

## Testing

- Worker unit tests with injectable repo resolution + sink: bucket emission with revisions, quiet re-process, incremental append, cross-bucket replacement zeroing, partial trailing lines, retention at extraction, error backoff, codex reasoning flow, fork single-turn flush, cross-session invalidation, resume no-double-count, sweep prefilter/dedup, notification promotion + drain scoping, rollup error keying, backoff schedule.
- Integration tests (`tests/integration/token_usage.rs`) driving the real pipeline via `git-ai checkpoint` hook inputs behind a `git-ai await` barrier (SyncFamily alone does not cover the stream → token → metrics pipeline): claude and codex happy paths, incremental re-emission, and the disabled-flag lifecycle (no DB created, no events).

🤖 Generated with [Claude Code](https://claude.com/claude-code)