### PR TITLE
Token-usage emission-dedup e2e coverage, retention prune, exclude gate, and spec

### DIFF
--- a/docs/token-usage-events-spec.md
+++ b/docs/token-usage-events-spec.md
@@ -17,8 +17,7 @@ transcript file --(incremental read, cursor in token-usage DB)-->
     - prefilter substring check before any JSON parsing
     - per-entry token counts, model, timestamp, transcript costUSD
 --> usage_entries (deduplicated per-entry rows, token-usage DB)
---> dirty (model, bucket) set
---> re-aggregate + fingerprint compare (bucket_state)
+--> reconcile all session buckets: aggregate + fingerprint compare (bucket_state)
 --> TokenUsage MetricEvent --> telemetry queue --> POST /worker/metrics/upload
 ```
 
@@ -63,9 +62,15 @@ The server upserts on `(session_id, model, bucket_ts)` with the newest
 so a re-emitted correction - including one that lowers a bucket or zeroes it
 out entirely - always supersedes the previous value. A bucket is emitted iff
 its aggregate's fingerprint differs from the last emitted fingerprint; an
-emptied bucket therefore emits an all-zero event exactly once. Buckets are
-marked emitted only after the telemetry queue accepted the events, so a
-failed hand-off retries on the next pass.
+emptied bucket therefore emits an all-zero event exactly once. Changed
+buckets are found by reconciling fingerprints across all of the session's
+buckets on every pass (no pending-emission state lives in memory), buckets
+are marked emitted only after the telemetry queue accepted the events, and
+the quiet-skip size/mtime snapshot is written only after a fully successful
+pass - so a failed hand-off or a crash at any point is healed by the next
+pass. At upload time TokenUsage events get the same repo allow/exclude gate
+as SessionEvents (they are transcript-derived, so they keep flowing for
+sessions tracked before a repo was excluded).
 
 Values (`token_usage_pos`): `bucket_ts`, `input_tokens`, `output_tokens`,
 `cache_read_tokens`, `cache_write_tokens`, `total_tokens`,

--- a/docs/token-usage-events-spec.md
+++ b/docs/token-usage-events-spec.md
@@ -1,0 +1,90 @@
+# TokenUsage Events
+
+Token usage and estimated cost per `(session_id, model, bucket_ts)` in
+5-minute UTC buckets, computed from local agent transcripts and emitted as
+metric event id 9 (`TokenUsageValues`, `src/metrics/events.rs`).
+
+The parsing/deduplication logic is ported from
+[ccusage](https://github.com/ccusage/ccusage) (MIT) and adapted to git-ai's
+incremental transcript streaming; per-agent deviations are documented in
+`src/token_usage/{claude,codex}.rs`. v1 covers Claude Code and Codex.
+
+## Pipeline
+
+```
+transcript file --(incremental read, cursor in token-usage DB)-->
+  per-agent extractor (src/token_usage/{claude,codex}.rs)
+    - prefilter substring check before any JSON parsing
+    - per-entry token counts, model, timestamp, transcript costUSD
+--> usage_entries (deduplicated per-entry rows, token-usage DB)
+--> dirty (model, bucket) set
+--> re-aggregate + fingerprint compare (bucket_state)
+--> TokenUsage MetricEvent --> telemetry queue --> POST /worker/metrics/upload
+```
+
+Driven by `TokenUsageWorker` (`src/daemon/token_usage_worker.rs`):
+
+- **Triggers:** a non-blocking ping from the stream worker after it processes
+  a transcript, a startup sweep, and a 30-minute ticker. Sweeps enumerate the
+  streams database's `transcript` rows, so every session git-ai knows about is
+  backfilled (a new file starts at byte offset 0); transcripts that no longer
+  exist are skipped. Nothing runs on the trace2 ingestion path.
+- **Feature flag:** `token_usage_metrics` (debug: on, release: off). Read via
+  `Config::fresh()` on every trigger, so it can be disabled without a daemon
+  restart. The worker is spawned inside the `transcript_streaming` gate, since
+  its notifications come from the stream worker.
+- **Quietness:** unchanged files are skipped by size/mtime; unchanged buckets
+  are never re-emitted (fingerprints); missing files record one error and are
+  skipped by later sweeps; the telemetry-buffer backpressure mirrors the
+  stream worker.
+
+## State: `~/.git-ai/internal/token-usage-db`
+
+`TokenUsageDatabase` (`src/token_usage/db.rs`):
+
+- `tracked_files` - read cursor (byte offset) + serialized extractor state
+  per transcript file.
+- `usage_entries` - deduplicated per-entry usage. Per-entry rows (rather than
+  bucket accumulators) make ccusage's replacement policy exact: a later entry
+  can *lower* a bucket (streaming partial replaced; sidechain replay replaced
+  by the parent's entry), and the bucket then re-aggregates via SQL. Retention
+  is 90 days (pruned on sweep).
+- `bucket_state` - fingerprint of the last emitted aggregate per bucket.
+
+`commit_batch` writes entries, extractor state, and the advanced cursor in a
+single transaction. This is why the cursor lives here and not in the streams
+database: a crash can never replay transcript lines against post-batch parser
+state (which would corrupt Codex's cumulative-delta computation).
+
+## Emission semantics
+
+The server upserts on `(session_id, model, bucket_ts)` with the newest
+`event_ts` winning. Events are stamped with emission time (not bucket time),
+so a re-emitted correction - including one that lowers a bucket or zeroes it
+out entirely - always supersedes the previous value. A bucket is emitted iff
+its aggregate's fingerprint differs from the last emitted fingerprint; an
+emptied bucket therefore emits an all-zero event exactly once. Buckets are
+marked emitted only after the telemetry queue accepted the events, so a
+failed hand-off retries on the next pass.
+
+Values (`token_usage_pos`): `bucket_ts`, `input_tokens`, `output_tokens`,
+`cache_read_tokens`, `cache_write_tokens`, `total_tokens`,
+`reasoning_output_tokens` (optional; Codex reports it as a subset of output),
+`est_cost_micro_usd` (u64 micro-USD), `credits` (f64, reserved), and
+`message_count`. Standard `EventAttributes` carry tool, model, session ids,
+and repo_url (resolved from the session's working directory, no git spawn).
+
+Cost follows ccusage's "auto" mode per entry: the transcript's own `costUSD`
+wins; otherwise cost is computed from the models.dev pricing catalog
+(`src/metrics/model_pricing.rs`), including the 2x-input rate for 1-hour
+ephemeral cache writes. Pricing snapshot refreshes do not retroactively
+rewrite already-emitted buckets (only changed buckets recompute) - intended.
+
+## Session identity
+
+Claude subagent transcripts roll up to their parent session (matching
+ccusage's session semantics), which also lets sidechain replays of parent
+messages deduplicate against the parent's entries across files. Codex
+sessions are per rollout file; forked rollouts skip their replayed prefix via
+the rewritten-burst heuristic (see `src/token_usage/codex.rs` for the
+deviation from ccusage's parent-prefix matching).

--- a/docs/token-usage-events-spec.md
+++ b/docs/token-usage-events-spec.md
@@ -159,11 +159,13 @@ Reviewed decisions, accepted rather than accidental:
   replay.
 - **Sweep-discovered work sits outside the `git-ai await` drain barrier**
   (see Pipeline): backfill is eventual, matching stream-worker semantics.
-- **A fork burst split across passes can over-count once.** The end-of-file
-  flush releases a parked first turn after the burst window passes in wall
-  clock. If Codex writes the two replayed burst lines more than a second
-  apart (buffered/laggy serialization carrying sub-second recorded
+- **A fork burst split across passes can over-count one event.** The
+  end-of-file flush releases a parked first turn after the burst window
+  passes in wall clock. If Codex writes the replayed burst lines more than a
+  second apart (buffered/laggy serialization carrying sub-second recorded
   timestamps) and a pass lands in the gap, the parked replay is released as
-  own usage and its burst partner counts too — bounded to that one pair per
-  fork, and requiring write lag upstream's post-hoc whole-file reads never
+  own usage. The flush leaves the skip machine armed at the released event's
+  timestamp, so the late-arriving remainder of the burst is still skipped —
+  the over-count is bounded to that single released event per fork, and the
+  race requires write lag upstream's post-hoc whole-file reads never
   observe.

--- a/docs/token-usage-events-spec.md
+++ b/docs/token-usage-events-spec.md
@@ -16,39 +16,61 @@ transcript file --(incremental read, cursor in token-usage DB)-->
   per-agent extractor (src/token_usage/{claude,codex}.rs)
     - prefilter substring check before any JSON parsing
     - per-entry token counts, model, timestamp, transcript costUSD
---> usage_entries (deduplicated per-entry rows, token-usage DB)
---> reconcile all session buckets: aggregate + fingerprint compare (bucket_state)
+--> usage_entries (globally deduplicated per-entry rows, token-usage DB)
+--> reconcile all session buckets in one pass: aggregate + fingerprint
+    compare (bucket_state)
 --> TokenUsage MetricEvent --> telemetry queue --> POST /worker/metrics/upload
 ```
 
 Driven by `TokenUsageWorker` (`src/daemon/token_usage_worker.rs`):
 
 - **Triggers:** a non-blocking ping from the stream worker after it processes
-  a transcript, a startup sweep, and a 30-minute ticker. Sweeps enumerate the
-  streams database's `transcript` rows, so every session git-ai knows about is
-  backfilled (a new file starts at byte offset 0); transcripts that no longer
-  exist are skipped. Nothing runs on the trace2 ingestion path.
-- **Feature flag:** `token_usage_metrics` (debug: on, release: off). Read via
-  `Config::fresh()` on every trigger, so it can be disabled without a daemon
-  restart. The worker is spawned inside the `transcript_streaming` gate, since
-  its notifications come from the stream worker.
+  a transcript (success or failure of that pass), a startup sweep, and a
+  30-minute ticker (missed ticks are skipped, not replayed). Sweeps enumerate
+  the streams database's `transcript` rows, so every session git-ai knows
+  about is backfilled (a new file starts at byte offset 0); enumeration costs
+  one stat per session compared against the token database's size/mtime
+  snapshot, and per-file work only happens for files that actually changed.
+  Transcripts that no longer exist are skipped. Nothing runs on the trace2
+  ingestion path.
+- **Queues:** notifications and sweep backfill are separate queues. The
+  `git-ai await` drain barrier waits only for notification-driven work, so a
+  first-start historical backfill cannot starve `await`; a notification for a
+  file already queued for backfill promotes it. Shutdown is observed while a
+  pass is in flight (the worker selects on its own shutdown `Notify` around
+  the blocking pass).
+- **Feature flag:** `token_usage_metrics` (debug: on, release: off) gates the
+  worker at daemon startup, like `transcript_streaming`. When the flag is
+  off, no worker or ticker runs, the token-usage database is not created, and
+  a previously created one is deleted — no collected data is retained.
 - **Quietness:** unchanged files are skipped by size/mtime; unchanged buckets
-  are never re-emitted (fingerprints); missing files record one error and are
-  skipped by later sweeps; the telemetry-buffer backpressure mirrors the
-  stream worker.
+  are never re-emitted (fingerprints); files whose last pass failed back off
+  (5s/30s/5m/30m) instead of retrying on every trigger; the telemetry-buffer
+  backpressure mirrors the stream worker.
 
 ## State: `~/.git-ai/internal/token-usage-db`
 
 `TokenUsageDatabase` (`src/token_usage/db.rs`):
 
 - `tracked_files` - read cursor (byte offset) + serialized extractor state
-  per transcript file.
+  per transcript file, plus the quiet-skip snapshot, error backoff state, and
+  a pending-flush marker (a file whose extractor holds buffered entries is
+  re-processed even when its bytes have not changed).
 - `usage_entries` - deduplicated per-entry usage. Per-entry rows (rather than
   bucket accumulators) make ccusage's replacement policy exact: a later entry
   can *lower* a bucket (streaming partial replaced; sidechain replay replaced
-  by the parent's entry), and the bucket then re-aggregates via SQL. Retention
-  is 90 days (pruned on sweep).
-- `bucket_state` - fingerprint of the last emitted aggregate per bucket.
+  by the parent's entry), and the bucket then re-aggregates via SQL.
+  **Dedup is global across sessions**, matching ccusage's whole-files dedup:
+  `claude --resume`/`--continue`/fork copies the parent conversation into a
+  new session file with the original message/request ids, and session-scoped
+  dedup would re-count that history on every resume. When a replacement moves
+  an entry between sessions, the previous owner's files are invalidated so
+  its buckets re-reconcile on their next pass. Entries older than the 90-day
+  retention window are dropped at insert (backfill never uploads history the
+  prune would delete), and stored entries/bucket state are pruned atomically
+  on sweep.
+- `bucket_state` - fingerprint, emission revision (`emit_seq`), and timestamp
+  of the last emitted aggregate per bucket.
 
 `commit_batch` writes entries, extractor state, and the advanced cursor in a
 single transaction. This is why the cursor lives here and not in the streams
@@ -57,27 +79,28 @@ state (which would corrupt Codex's cumulative-delta computation).
 
 ## Emission semantics
 
-The server upserts on `(session_id, model, bucket_ts)` with the newest
-`event_ts` winning. Events are stamped with emission time (not bucket time),
-so a re-emitted correction - including one that lowers a bucket or zeroes it
-out entirely - always supersedes the previous value. A bucket is emitted iff
-its aggregate's fingerprint differs from the last emitted fingerprint; an
-emptied bucket therefore emits an all-zero event exactly once. Changed
-buckets are found by reconciling fingerprints across all of the session's
-buckets on every pass (no pending-emission state lives in memory), buckets
-are marked emitted only after the telemetry queue accepted the events, and
-the quiet-skip size/mtime snapshot is written only after a fully successful
-pass - so a failed hand-off or a crash at any point is healed by the next
-pass. At upload time TokenUsage events get the same repo allow/exclude gate
-as SessionEvents (they are transcript-derived, so they keep flowing for
-sessions tracked before a repo was excluded).
+The server upserts on `(session_id, model, bucket_ts)` keeping the **highest
+`emitted_seq`** — a strictly increasing per-bucket revision — so re-emissions
+within the same u32 second cannot tie on `event_ts`, regardless of upload
+batching or retry order. A bucket is emitted iff its aggregate's fingerprint
+differs from the last emitted fingerprint; an emptied bucket therefore emits
+an all-zero event exactly once. Changed buckets are found by reconciling
+fingerprints across all of the session's buckets in one grouped query on
+every pass (no pending-emission state lives in memory), buckets are marked
+emitted only after the telemetry queue accepted the events, and the
+quiet-skip size/mtime snapshot is written only after a fully successful pass
+— so a failed hand-off or a crash at any point is healed by the next pass.
+At upload time TokenUsage events get the same repo allow/exclude gate as
+SessionEvents (they are transcript-derived, so they keep flowing for sessions
+tracked before a repo was excluded); repo_url resolution falls back to the
+agent's cwd inference (persisted back) like the SessionEvent path.
 
 Values (`token_usage_pos`): `bucket_ts`, `input_tokens`, `output_tokens`,
 `cache_read_tokens`, `cache_write_tokens`, `total_tokens`,
 `reasoning_output_tokens` (optional; Codex reports it as a subset of output),
-`est_cost_micro_usd` (u64 micro-USD), `credits` (f64, reserved), and
-`message_count`. Standard `EventAttributes` carry tool, model, session ids,
-and repo_url (resolved from the session's working directory, no git spawn).
+`est_cost_micro_usd` (u64 micro-USD), `credits` (f64, reserved),
+`message_count`, and `emitted_seq`. Standard `EventAttributes` carry tool,
+model, session ids, and repo_url (no git spawn).
 
 Cost follows ccusage's "auto" mode per entry: the transcript's own `costUSD`
 wins; otherwise cost is computed from the models.dev pricing catalog
@@ -91,5 +114,7 @@ Claude subagent transcripts roll up to their parent session (matching
 ccusage's session semantics), which also lets sidechain replays of parent
 messages deduplicate against the parent's entries across files. Codex
 sessions are per rollout file; forked rollouts skip their replayed prefix via
-the rewritten-burst heuristic (see `src/token_usage/codex.rs` for the
-deviation from ccusage's parent-prefix matching).
+the rewritten-burst heuristic, and a fork whose transcript ends with its
+first usage event still parked is released by an end-of-file flush once the
+burst window has passed in wall-clock time (see `src/token_usage/codex.rs`
+for the deviations from ccusage's parent-prefix matching).

--- a/docs/token-usage-events-spec.md
+++ b/docs/token-usage-events-spec.md
@@ -88,7 +88,11 @@ The server upserts on `(session_id, model, bucket_ts)` keeping the **highest
 state database *before* events reach the telemetry queue so a crash between
 sink and bookkeeping can never produce two payloads with equal revisions —
 so re-emissions within the same u32 second cannot tie on `event_ts`,
-regardless of upload batching or retry order. A bucket is emitted iff its aggregate's fingerprint
+regardless of upload batching or retry order. Reserved revisions are floored
+to wall-clock seconds (`max(prev + 1, now)`), so a rebuilt state database
+(the flag toggled off deletes it; local data loss) resumes at revisions
+strictly above anything previously uploaded rather than restarting at 1 and
+losing every upsert to the server's highest-revision rule. A bucket is emitted iff its aggregate's fingerprint
 differs from the last emitted fingerprint; an emptied bucket therefore emits
 an all-zero event exactly once. Changed buckets are found by reconciling
 fingerprints across all of the session's buckets in one grouped query on
@@ -131,3 +135,24 @@ the rewritten-burst heuristic, and a fork whose transcript ends with its
 first usage event still parked is released by an end-of-file flush once the
 burst window has passed in wall-clock time (see `src/token_usage/codex.rs`
 for the deviations from ccusage's parent-prefix matching).
+
+## Accepted limitations
+
+Reviewed decisions, accepted rather than accidental:
+
+- **Corrections withheld during exclusion are not replayed.** Events filtered
+  by the repo exclude gate are marked delivered like every other metric kind;
+  a bucket corrected while its repo was excluded stays diverged on the server
+  until the bucket's aggregate changes again after un-exclusion.
+- **Uploader abandonment applies.** TokenUsage rides the shared metrics
+  uploader, which abandons records after six failed upload attempts
+  (~20 hours offline). The state database has already marked those buckets
+  emitted; a later genuine change re-emits at a higher revision and heals the
+  gap, but a correction whose bucket never changes again is lost.
+- **Rewritten transcript content stays counted.** Entries have no per-file
+  ownership, so history that a rewrite/truncation removed from a transcript
+  keeps its rows (bounded by 90-day retention). Transcripts are append-only
+  in practice; the shrink path re-reads from byte 0 and dedup absorbs the
+  replay.
+- **Sweep-discovered work sits outside the `git-ai await` drain barrier**
+  (see Pipeline): backfill is eventual, matching stream-worker semantics.

--- a/docs/token-usage-events-spec.md
+++ b/docs/token-usage-events-spec.md
@@ -24,8 +24,9 @@ transcript file --(incremental read, cursor in token-usage DB)-->
 
 Driven by `TokenUsageWorker` (`src/daemon/token_usage_worker.rs`):
 
-- **Triggers:** a non-blocking ping from the stream worker after it processes
-  a transcript (success or failure of that pass), a startup sweep, and a
+- **Triggers:** a non-blocking ping from the stream worker after it
+  successfully processes a transcript (a failed stream pass is picked up by
+  the next sweep instead), a startup sweep, and a
   30-minute ticker (missed ticks are skipped, not replayed). Sweeps enumerate
   the streams database's `transcript` rows, so every session git-ai knows
   about is backfilled (a new file starts at byte offset 0); enumeration costs
@@ -42,7 +43,8 @@ Driven by `TokenUsageWorker` (`src/daemon/token_usage_worker.rs`):
 - **Feature flag:** `token_usage_metrics` (debug: on, release: off) gates the
   worker at daemon startup, like `transcript_streaming`. When the flag is
   off, no worker or ticker runs, the token-usage database is not created, and
-  a previously created one is deleted — no collected data is retained.
+  a previously created one is deleted at daemon startup (independent of the
+  `transcript_streaming` gate) — no collected data is retained.
 - **Quietness:** unchanged files are skipped by size/mtime; unchanged buckets
   are never re-emitted (fingerprints); files whose last pass failed back off
   (5s/30s/5m/30m) instead of retrying on every trigger; the telemetry-buffer
@@ -64,11 +66,13 @@ Driven by `TokenUsageWorker` (`src/daemon/token_usage_worker.rs`):
   `claude --resume`/`--continue`/fork copies the parent conversation into a
   new session file with the original message/request ids, and session-scoped
   dedup would re-count that history on every resume. When a replacement moves
-  an entry between sessions, the previous owner's files are invalidated so
-  its buckets re-reconcile on their next pass. Entries older than the 90-day
-  retention window are dropped at insert (backfill never uploads history the
-  prune would delete), and stored entries/bucket state are pruned atomically
-  on sweep.
+  an entry between sessions, the previous owner is durably flagged
+  (`needs_reconcile`, in the same transaction) and re-reconciled DB-only —
+  inline after the pass and from sweeps for crash recovery — so the
+  correction lands even if that session's transcripts were deleted. Entries
+  older than the 90-day retention window are dropped at insert (backfill
+  never uploads history the prune would delete), and stored entries/bucket
+  state are pruned atomically on sweep.
 - `bucket_state` - fingerprint, emission revision (`emit_seq`), and timestamp
   of the last emitted aggregate per bucket.
 
@@ -80,9 +84,11 @@ state (which would corrupt Codex's cumulative-delta computation).
 ## Emission semantics
 
 The server upserts on `(session_id, model, bucket_ts)` keeping the **highest
-`emitted_seq`** — a strictly increasing per-bucket revision — so re-emissions
-within the same u32 second cannot tie on `event_ts`, regardless of upload
-batching or retry order. A bucket is emitted iff its aggregate's fingerprint
+`emitted_seq`** — a strictly increasing per-bucket revision, reserved in the
+state database *before* events reach the telemetry queue so a crash between
+sink and bookkeeping can never produce two payloads with equal revisions —
+so re-emissions within the same u32 second cannot tie on `event_ts`,
+regardless of upload batching or retry order. A bucket is emitted iff its aggregate's fingerprint
 differs from the last emitted fingerprint; an emptied bucket therefore emits
 an all-zero event exactly once. Changed buckets are found by reconciling
 fingerprints across all of the session's buckets in one grouped query on

--- a/docs/token-usage-events-spec.md
+++ b/docs/token-usage-events-spec.md
@@ -147,8 +147,11 @@ Reviewed decisions, accepted rather than accidental:
 - **Uploader abandonment applies.** TokenUsage rides the shared metrics
   uploader, which abandons records after six failed upload attempts
   (~20 hours offline). The state database has already marked those buckets
-  emitted; a later genuine change re-emits at a higher revision and heals the
-  gap, but a correction whose bucket never changes again is lost.
+  emitted, so this loses any emission — first emissions included (e.g. a
+  historical backfill that ran entirely during a >20h upload outage), not
+  just corrections. A later genuine change to a bucket re-emits it at a
+  higher revision and heals that bucket, but a bucket that never changes
+  again is lost.
 - **Rewritten transcript content stays counted.** Entries have no per-file
   ownership, so history that a rewrite/truncation removed from a transcript
   keeps its rows (bounded by 90-day retention). Transcripts are append-only
@@ -156,3 +159,11 @@ Reviewed decisions, accepted rather than accidental:
   replay.
 - **Sweep-discovered work sits outside the `git-ai await` drain barrier**
   (see Pipeline): backfill is eventual, matching stream-worker semantics.
+- **A fork burst split across passes can over-count once.** The end-of-file
+  flush releases a parked first turn after the burst window passes in wall
+  clock. If Codex writes the two replayed burst lines more than a second
+  apart (buffered/laggy serialization carrying sub-second recorded
+  timestamps) and a pass lands in the gap, the parked replay is released as
+  own usage and its burst partner counts too — bounded to that one pair per
+  fork, and requiring write lag upstream's post-hoc whole-file reads never
+  observe.

--- a/docs/token-usage-events-spec.md
+++ b/docs/token-usage-events-spec.md
@@ -109,10 +109,17 @@ Values (`token_usage_pos`): `bucket_ts`, `input_tokens`, `output_tokens`,
 model, session ids, and repo_url (no git spawn).
 
 Cost follows ccusage's "auto" mode per entry: the transcript's own `costUSD`
-wins; otherwise cost is computed from the models.dev pricing catalog
-(`src/metrics/model_pricing.rs`), including the 2x-input rate for 1-hour
-ephemeral cache writes. Pricing snapshot refreshes do not retroactively
-rewrite already-emitted buckets (only changed buckets recompute) - intended.
+wins (negative/non-finite values are treated as absent, and every per-entry
+cost clamps to a $10k sanity ceiling); otherwise cost is computed from the
+models.dev pricing catalog (`src/metrics/model_pricing.rs`), including the
+2x-input rate for 1-hour ephemeral cache writes and a cache-read fallback of
+a tenth of the input rate when the catalog omits one. Pricing snapshot
+refreshes do not retroactively rewrite already-emitted buckets (only changed
+buckets recompute) - intended. Documented pricing deviations from ccusage
+(all from pricing via models.dev only): no long-context tiers, no fast-speed
+multipliers, no `codex-auto-review` model mapping; `git-ai usage`
+approximates from the same catalog without the 1h/fallback refinements, so
+TokenUsage events are the authoritative dollars.
 
 ## Session identity
 

--- a/src/daemon/telemetry_worker.rs
+++ b/src/daemon/telemetry_worker.rs
@@ -1167,7 +1167,11 @@ where
 }
 
 fn should_deliver_metric_event(config: &Config, event: &MetricEvent) -> bool {
-    if event.event_id != MetricEventId::SessionEvent as u16 {
+    // Transcript-derived events keep flowing for sessions tracked before a
+    // repo was excluded, so they get the same upload-time repo gate.
+    let transcript_derived = event.event_id == MetricEventId::SessionEvent as u16
+        || event.event_id == MetricEventId::TokenUsage as u16;
+    if !transcript_derived {
         return true;
     }
 

--- a/src/daemon/token_usage_worker.rs
+++ b/src/daemon/token_usage_worker.rs
@@ -315,6 +315,18 @@ impl TokenUsageWorker {
         self.pop_queue(false)
     }
 
+    /// Retention prune, run once per sweep off the async loop.
+    async fn prune_old_entries(&self) {
+        let token_db = self.token_db.clone();
+        let _ = tokio::task::spawn_blocking(move || {
+            let cutoff = retention_cutoff_bucket(now_secs());
+            if let Err(e) = token_db.prune_buckets_before(cutoff) {
+                tracing::warn!(error = %e, "token-usage retention prune failed");
+            }
+        })
+        .await;
+    }
+
     /// Enqueue supported transcripts the streams database knows about whose
     /// files changed since the last completed pass. The DB scans and per-file
     /// stats run in `spawn_blocking`, like all other I/O in this module.
@@ -334,18 +346,6 @@ impl TokenUsageWorker {
         for task in tasks {
             self.enqueue_sweep(task);
         }
-    }
-
-    /// Retention prune, run once per sweep off the async loop.
-    async fn prune_old_entries(&self) {
-        let token_db = self.token_db.clone();
-        let _ = tokio::task::spawn_blocking(move || {
-            let cutoff = retention_cutoff_bucket(now_secs());
-            if let Err(e) = token_db.prune_buckets_before(cutoff) {
-                tracing::warn!(error = %e, "token-usage retention prune failed");
-            }
-        })
-        .await;
     }
 
     /// Reconcile cross-session flags off the async loop (used by sweeps for

--- a/tests/daemon_mode.rs
+++ b/tests/daemon_mode.rs
@@ -20,7 +20,9 @@ use git_ai::daemon::{
 #[cfg(not(windows))]
 use git_ai::git::repository::find_repository_in_path;
 use git_ai::metrics::db::MetricsDatabase;
-use git_ai::metrics::{EventAttributes, MetricEvent, PosEncoded, SessionEventValues};
+use git_ai::metrics::{
+    EventAttributes, MetricEvent, PosEncoded, SessionEventValues, TokenUsageValues,
+};
 use repos::test_file::ExpectedLineExt;
 use repos::test_repo::{
     DAEMON_SPAWN_LOADER_RETRY_ATTEMPTS, DaemonTestCompletionLogEntry, DaemonTestScope, TestRepo,
@@ -7917,6 +7919,73 @@ fn daemon_marks_repository_filtered_session_events_delivered_without_uploading_t
     let uploaded_requests = serde_json::to_string(&mock_api.collect_requests()).unwrap();
     assert!(uploaded_requests.contains("allowed-session"));
     assert!(!uploaded_requests.contains("excluded-session"));
+
+    let metrics_db = MetricsDatabase::open_at_path(&metrics_db_path).unwrap();
+    let status = metrics_db.status().unwrap();
+    assert_eq!(status.delivered, 2);
+}
+
+/// TokenUsage events are transcript-derived like SessionEvents and get the
+/// same upload-time repo gate: sessions tracked before a repo was excluded
+/// keep producing them, so exclusion must apply at delivery.
+#[test]
+fn daemon_marks_repository_filtered_token_usage_events_delivered_without_uploading_them() {
+    let mut mock_api = MockApiServer::start();
+    let metrics_db_path = std::env::temp_dir().join(format!(
+        "git-ai-filtered-token-usage-events-{}.db",
+        git_ai::uuid::generate_v4()
+    ));
+    let repo = TestRepo::new_with_daemon_env(&[
+        ("GIT_AI_API_BASE_URL", mock_api.base_url()),
+        ("GIT_AI_API_KEY", "test-api-key"),
+        (
+            "GIT_AI_TEST_METRICS_DB_PATH",
+            metrics_db_path.to_str().unwrap(),
+        ),
+    ]);
+    fs::write(
+        repo.test_home_path().join(".git-ai/config.json"),
+        r#"{"allow_repositories":["https://github.com/acme/*"],"exclude_repositories":["git@github.com:acme/private"]}"#,
+    )
+    .unwrap();
+
+    let token_usage_event = |session_id: &str, repo_url: &str| {
+        MetricEvent::from_values(
+            TokenUsageValues::new()
+                .bucket_ts(1_767_225_600)
+                .input_tokens(10)
+                .output_tokens(5)
+                .total_tokens(15)
+                .est_cost_micro_usd(100)
+                .message_count(1),
+            EventAttributes::with_version("test")
+                .session_id(session_id)
+                .tool("claude")
+                .model("claude-sonnet-4")
+                .repo_url(repo_url)
+                .to_sparse(),
+        )
+    };
+    let events = [
+        token_usage_event("allowed-usage", "https://github.com/acme/public"),
+        token_usage_event("excluded-usage", "https://github.com/acme/private"),
+    ];
+    let serialized_events = events
+        .iter()
+        .map(serde_json::to_string)
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+    MetricsDatabase::open_at_path(&metrics_db_path)
+        .unwrap()
+        .insert_events(&serialized_events)
+        .unwrap();
+
+    repo.git_ai(&["await", "--timeout", "30"])
+        .expect("await should flush metrics");
+
+    let uploaded_requests = serde_json::to_string(&mock_api.collect_requests()).unwrap();
+    assert!(uploaded_requests.contains("allowed-usage"));
+    assert!(!uploaded_requests.contains("excluded-usage"));
 
     let metrics_db = MetricsDatabase::open_at_path(&metrics_db_path).unwrap();
     let status = metrics_db.status().unwrap();

--- a/tests/daemon_mode.rs
+++ b/tests/daemon_mode.rs
@@ -8078,6 +8078,158 @@ fn reingest_command_redelivers_bounded_and_all_metrics_through_daemon() {
     );
 }
 
+/// Pins the fail-open semantics for TokenUsage events with NO repo_url under
+/// an exclude-only config: they upload (matching SessionEvent semantics -
+/// exclusion needs a URL to match). The worker minimizes this window by
+/// resolving repo_url with the infer_cwd fallback and persisting it for
+/// DB-only corrections; sessions that never resolve one are indistinguishable
+/// from non-repo work.
+#[test]
+fn token_usage_without_repo_url_passes_an_exclude_only_gate() {
+    let mut mock_api = MockApiServer::start();
+    let metrics_db_path = std::env::temp_dir().join(format!(
+        "git-ai-no-repo-token-usage-{}.db",
+        git_ai::uuid::generate_v4()
+    ));
+    let repo = TestRepo::new_with_daemon_env(&[
+        ("GIT_AI_API_BASE_URL", mock_api.base_url()),
+        ("GIT_AI_API_KEY", "test-api-key"),
+        (
+            "GIT_AI_TEST_METRICS_DB_PATH",
+            metrics_db_path.to_str().unwrap(),
+        ),
+    ]);
+    fs::write(
+        repo.test_home_path().join(".git-ai/config.json"),
+        r#"{"exclude_repositories":["git@github.com:acme/private"]}"#,
+    )
+    .unwrap();
+
+    let event = MetricEvent::from_values(
+        TokenUsageValues::new()
+            .bucket_ts(1_767_225_600)
+            .input_tokens(10)
+            .total_tokens(10)
+            .message_count(1),
+        EventAttributes::with_version("test")
+            .session_id("no-repo-usage")
+            .tool("claude")
+            .model("claude-sonnet-4")
+            .to_sparse(),
+    );
+    MetricsDatabase::open_at_path(&metrics_db_path)
+        .unwrap()
+        .insert_events(&[serde_json::to_string(&event).unwrap()])
+        .unwrap();
+
+    repo.git_ai(&["await", "--timeout", "30"])
+        .expect("await should flush metrics");
+
+    let uploaded_requests = serde_json::to_string(&mock_api.collect_requests()).unwrap();
+    assert!(
+        uploaded_requests.contains("no-repo-usage"),
+        "no-repo_url events upload under exclude-only configs (documented fail-open)"
+    );
+}
+
+/// The exclude gate through the REAL pipeline: with the repo's remote in
+/// exclude_repositories, the checkpoint-time gate refuses tracking outright
+/// (defense layer 1), so no TokenUsage events are even produced - and
+/// nothing crosses the wire. (The upload-time gate above is defense layer 2,
+/// for sessions tracked BEFORE a repo was excluded.)
+#[test]
+fn excluded_repo_token_usage_never_uploads_via_the_real_pipeline() {
+    let mut mock_api = MockApiServer::start();
+    let metrics_db_path = std::env::temp_dir().join(format!(
+        "git-ai-excluded-pipeline-token-usage-{}.db",
+        git_ai::uuid::generate_v4()
+    ));
+    let repo = TestRepo::new_with_daemon_env(&[
+        ("GIT_AI_API_BASE_URL", mock_api.base_url()),
+        ("GIT_AI_API_KEY", "test-api-key"),
+        (
+            "GIT_AI_TEST_METRICS_DB_PATH",
+            metrics_db_path.to_str().unwrap(),
+        ),
+    ]);
+    fs::write(
+        repo.test_home_path().join(".git-ai/config.json"),
+        r#"{"exclude_repositories":["https://github.com/acme/private"]}"#,
+    )
+    .unwrap();
+    repo.git(&[
+        "remote",
+        "add",
+        "origin",
+        "https://github.com/acme/private.git",
+    ])
+    .expect("remote add should succeed");
+    repo.git(&["commit", "--allow-empty", "-m", "initial"])
+        .expect("initial commit should succeed");
+    let repo_root = repo.canonical_path();
+
+    let transcript_path = repo_root.join("claude-session.jsonl");
+    fs::write(
+        &transcript_path,
+        r#"{"timestamp":"2026-08-23T00:01:00Z","sessionId":"ext","requestId":"r1","message":{"id":"m1","model":"claude-sonnet-4-20250514","usage":{"input_tokens":100,"output_tokens":50,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}
+"#,
+    )
+    .unwrap();
+    let file_path = repo_root.join("example.ts");
+    fs::write(
+        &file_path,
+        "const x = 1;
+",
+    )
+    .unwrap();
+    for hook_event_name in ["PreToolUse", "PostToolUse"] {
+        let hook_input = serde_json::json!({
+            "cwd": repo_root.to_string_lossy(),
+            "hook_event_name": hook_event_name,
+            "tool_name": "Write",
+            "tool_use_id": "toolu_excluded",
+            "session_id": "sess-excluded",
+            "transcript_path": transcript_path.to_string_lossy(),
+            "tool_input": { "file_path": file_path.to_string_lossy() }
+        })
+        .to_string();
+        repo.git_ai(&["checkpoint", "claude", "--hook-input", &hook_input])
+            .expect("checkpoint should succeed");
+        if hook_event_name == "PreToolUse" {
+            fs::write(
+                &file_path,
+                "const x = 1;
+const y = 2;
+",
+            )
+            .unwrap();
+        }
+    }
+    repo.git_ai(&["await", "--timeout", "30"])
+        .expect("await should flush metrics");
+
+    // The checkpoint-time gate refused tracking: no TokenUsage events were
+    // produced at all for the excluded repo...
+    let db = MetricsDatabase::open_at_path(&metrics_db_path).unwrap();
+    let produced = db
+        .get_metric_history(
+            0,
+            None,
+            &[git_ai::metrics::types::MetricEventId::TokenUsage as u16],
+        )
+        .unwrap();
+    assert!(
+        produced.is_empty(),
+        "an excluded repo must not be tracked at all"
+    );
+    // ...and nothing crossed the wire.
+    let uploaded_requests = serde_json::to_string(&mock_api.collect_requests()).unwrap();
+    assert!(
+        !uploaded_requests.contains("sess-excluded"),
+        "excluded repo token usage must never upload"
+    );
+}
+
 #[test]
 fn await_is_marked_beta_and_returns_promptly_when_idle() {
     let repo = TestRepo::new_with_daemon_scope(DaemonTestScope::Dedicated);

--- a/tests/integration/token_usage.rs
+++ b/tests/integration/token_usage.rs
@@ -679,13 +679,7 @@ fn replacement_lowering_a_bucket_reemits_lower_totals() {
     // The parent's own entry arrives later: non-sidechain wins despite lower
     // totals, so the bucket must re-emit with the corrected (lower) numbers.
     let mut content = fs::read_to_string(&transcript_path).unwrap();
-    content.push_str(&claude_usage_line(
-        "m1",
-        "r1",
-        &recent_ts(1, 30),
-        10,
-        None,
-    ));
+    content.push_str(&claude_usage_line("m1", "r1", &recent_ts(1, 30), 10, None));
     content.push('\n');
     fs::write(&transcript_path, content).unwrap();
 
@@ -746,13 +740,7 @@ fn emptied_bucket_emits_zero_exactly_once() {
     // larger totals: the original bucket empties and must emit zero so the
     // server stays in sync.
     let mut content = fs::read_to_string(&transcript_path).unwrap();
-    content.push_str(&claude_usage_line(
-        "m1",
-        "r1",
-        &recent_ts(6, 0),
-        90,
-        None,
-    ));
+    content.push_str(&claude_usage_line("m1", "r1", &recent_ts(6, 0), 90, None));
     content.push('\n');
     fs::write(&transcript_path, content).unwrap();
 

--- a/tests/integration/token_usage.rs
+++ b/tests/integration/token_usage.rs
@@ -572,3 +572,294 @@ fn subagent_transcript_rolls_up_to_the_parent_session() {
         Some(Some(generate_session_id("sess-parent", "claude")))
     );
 }
+
+/// Fields present on a sidechain replay line: same message id as the parent
+/// but a different request id and inflated cache reads (the ccusage scenario
+/// the message-id fallback dedup exists for).
+fn sidechain_usage_line(msg: &str, req: &str, ts: &str, cache_read: u64) -> String {
+    format!(
+        r#"{{"timestamp":"{ts}","isSidechain":true,"sessionId":"ext","requestId":"{req}","message":{{"id":"{msg}","model":"claude-sonnet-4-20250514","usage":{{"input_tokens":100,"output_tokens":10,"cache_creation_input_tokens":0,"cache_read_input_tokens":{cache_read}}}}}}}"#
+    )
+}
+
+#[test]
+fn unchanged_buckets_are_not_reemitted() {
+    let (_metrics_db_dir, metrics_db_path) = isolated_metrics_db_path();
+    let repo =
+        TestRepo::new_with_daemon_env(&[("GIT_AI_TEST_METRICS_DB_PATH", metrics_db_path.as_str())]);
+    repo.git(&["commit", "--allow-empty", "-m", "initial"])
+        .expect("initial commit should succeed");
+    let repo_root = repo.canonical_path();
+
+    let transcript_path = repo_root.join("claude-session.jsonl");
+    fs::write(
+        &transcript_path,
+        format!(
+            "{}\n",
+            claude_usage_line("m1", "r1", &recent_ts(1, 0), 50, None)
+        ),
+    )
+    .unwrap();
+
+    let file_path = repo_root.join("example.ts");
+    fs::write(&file_path, "const x = 1;\n").unwrap();
+    checkpoint_with_transcript(
+        &repo,
+        "claude",
+        "sess-token-quiet",
+        &transcript_path,
+        &file_path,
+        "const x = 1;\nconst y = 2;\n",
+    );
+    sync_token_usage_pipeline(&repo);
+    assert_eq!(token_usage_events(&metrics_db_path).len(), 1);
+
+    // The transcript grows, but only with non-usage lines: the file is
+    // re-read incrementally, the bucket aggregate is unchanged, and no event
+    // is emitted.
+    let mut content = fs::read_to_string(&transcript_path).unwrap();
+    content.push_str(&json!({"type": "user", "message": {"content": "more chatter"}}).to_string());
+    content.push('\n');
+    fs::write(&transcript_path, content).unwrap();
+
+    checkpoint_with_transcript(
+        &repo,
+        "claude",
+        "sess-token-quiet",
+        &transcript_path,
+        &file_path,
+        "const x = 1;\nconst y = 2;\nconst z = 3;\n",
+    );
+    sync_token_usage_pipeline(&repo);
+    assert_eq!(
+        token_usage_events(&metrics_db_path).len(),
+        1,
+        "an unchanged bucket must not re-emit"
+    );
+}
+
+#[test]
+fn replacement_lowering_a_bucket_reemits_lower_totals() {
+    let (_metrics_db_dir, metrics_db_path) = isolated_metrics_db_path();
+    let repo =
+        TestRepo::new_with_daemon_env(&[("GIT_AI_TEST_METRICS_DB_PATH", metrics_db_path.as_str())]);
+    repo.git(&["commit", "--allow-empty", "-m", "initial"])
+        .expect("initial commit should succeed");
+    let repo_root = repo.canonical_path();
+
+    // A sidechain replay is seen first with inflated cache reads.
+    let transcript_path = repo_root.join("claude-session.jsonl");
+    fs::write(
+        &transcript_path,
+        format!(
+            "{}\n",
+            sidechain_usage_line("m1", "r-side", &recent_ts(1, 0), 50_000)
+        ),
+    )
+    .unwrap();
+
+    let file_path = repo_root.join("example.ts");
+    fs::write(&file_path, "const x = 1;\n").unwrap();
+    checkpoint_with_transcript(
+        &repo,
+        "claude",
+        "sess-token-lower",
+        &transcript_path,
+        &file_path,
+        "const x = 1;\nconst y = 2;\n",
+    );
+    sync_token_usage_pipeline(&repo);
+    let events = token_usage_events(&metrics_db_path);
+    assert_eq!(events.len(), 1);
+    assert_eq!(
+        value_u64(&events[0], token_usage_pos::CACHE_READ_TOKENS),
+        Some(50_000)
+    );
+
+    // The parent's own entry arrives later: non-sidechain wins despite lower
+    // totals, so the bucket must re-emit with the corrected (lower) numbers.
+    let mut content = fs::read_to_string(&transcript_path).unwrap();
+    content.push_str(&claude_usage_line(
+        "m1",
+        "r1",
+        &recent_ts(1, 30),
+        10,
+        None,
+    ));
+    content.push('\n');
+    fs::write(&transcript_path, content).unwrap();
+
+    checkpoint_with_transcript(
+        &repo,
+        "claude",
+        "sess-token-lower",
+        &transcript_path,
+        &file_path,
+        "const x = 1;\nconst y = 2;\nconst z = 3;\n",
+    );
+    sync_token_usage_pipeline(&repo);
+
+    let events = token_usage_events(&metrics_db_path);
+    assert_eq!(events.len(), 2);
+    let latest = &events[1];
+    assert_eq!(
+        value_u64(latest, token_usage_pos::CACHE_READ_TOKENS),
+        Some(200)
+    );
+    assert_eq!(value_u64(latest, token_usage_pos::OUTPUT_TOKENS), Some(10));
+    assert_eq!(value_u64(latest, token_usage_pos::MESSAGE_COUNT), Some(1));
+}
+
+#[test]
+fn emptied_bucket_emits_zero_exactly_once() {
+    let (_metrics_db_dir, metrics_db_path) = isolated_metrics_db_path();
+    let repo =
+        TestRepo::new_with_daemon_env(&[("GIT_AI_TEST_METRICS_DB_PATH", metrics_db_path.as_str())]);
+    repo.git(&["commit", "--allow-empty", "-m", "initial"])
+        .expect("initial commit should succeed");
+    let repo_root = repo.canonical_path();
+
+    let transcript_path = repo_root.join("claude-session.jsonl");
+    fs::write(
+        &transcript_path,
+        format!(
+            "{}\n",
+            claude_usage_line("m1", "r1", &recent_ts(1, 0), 50, None)
+        ),
+    )
+    .unwrap();
+
+    let file_path = repo_root.join("example.ts");
+    fs::write(&file_path, "const x = 1;\n").unwrap();
+    checkpoint_with_transcript(
+        &repo,
+        "claude",
+        "sess-token-zero",
+        &transcript_path,
+        &file_path,
+        "const x = 1;\nconst y = 2;\n",
+    );
+    sync_token_usage_pipeline(&repo);
+    assert_eq!(token_usage_events(&metrics_db_path).len(), 1);
+
+    // A streaming re-emit of the same message lands in the next bucket with
+    // larger totals: the original bucket empties and must emit zero so the
+    // server stays in sync.
+    let mut content = fs::read_to_string(&transcript_path).unwrap();
+    content.push_str(&claude_usage_line(
+        "m1",
+        "r1",
+        &recent_ts(6, 0),
+        90,
+        None,
+    ));
+    content.push('\n');
+    fs::write(&transcript_path, content).unwrap();
+
+    checkpoint_with_transcript(
+        &repo,
+        "claude",
+        "sess-token-zero",
+        &transcript_path,
+        &file_path,
+        "const x = 1;\nconst y = 2;\nconst z = 3;\n",
+    );
+    sync_token_usage_pipeline(&repo);
+
+    let mut events = token_usage_events(&metrics_db_path);
+    assert_eq!(events.len(), 3, "zeroed bucket + refilled bucket");
+    let latest = events.split_off(1);
+    let zero = latest
+        .iter()
+        .find(|e| value_u64(e, token_usage_pos::BUCKET_TS) == Some(bucket_of(1, 0)))
+        .expect("original bucket re-emitted");
+    assert_eq!(value_u64(zero, token_usage_pos::TOTAL_TOKENS), Some(0));
+    assert_eq!(value_u64(zero, token_usage_pos::MESSAGE_COUNT), Some(0));
+    assert_eq!(
+        value_u64(zero, token_usage_pos::EST_COST_MICRO_USD),
+        Some(0)
+    );
+    let moved = latest
+        .iter()
+        .find(|e| value_u64(e, token_usage_pos::BUCKET_TS) == Some(bucket_of(6, 0)))
+        .expect("new bucket emitted");
+    assert_eq!(value_u64(moved, token_usage_pos::OUTPUT_TOKENS), Some(90));
+
+    // A third pass over a grown-but-unchanged-usage file: the zero bucket
+    // must not re-emit again.
+    let mut content = fs::read_to_string(&transcript_path).unwrap();
+    content.push_str(&json!({"type": "user", "message": {"content": "chatter"}}).to_string());
+    content.push('\n');
+    fs::write(&transcript_path, content).unwrap();
+    checkpoint_with_transcript(
+        &repo,
+        "claude",
+        "sess-token-zero",
+        &transcript_path,
+        &file_path,
+        "const x = 1;\nconst y = 2;\nconst z = 3;\nconst w = 4;\n",
+    );
+    sync_token_usage_pipeline(&repo);
+    assert_eq!(token_usage_events(&metrics_db_path).len(), 3);
+}
+
+#[test]
+fn deleted_transcript_is_handled_quietly() {
+    let (_metrics_db_dir, metrics_db_path) = isolated_metrics_db_path();
+    let repo =
+        TestRepo::new_with_daemon_env(&[("GIT_AI_TEST_METRICS_DB_PATH", metrics_db_path.as_str())]);
+    repo.git(&["commit", "--allow-empty", "-m", "initial"])
+        .expect("initial commit should succeed");
+    let repo_root = repo.canonical_path();
+
+    let transcript_path = repo_root.join("claude-session.jsonl");
+    fs::write(
+        &transcript_path,
+        format!(
+            "{}\n",
+            claude_usage_line("m1", "r1", &recent_ts(1, 0), 50, None)
+        ),
+    )
+    .unwrap();
+
+    let file_path = repo_root.join("example.ts");
+    fs::write(&file_path, "const x = 1;\n").unwrap();
+    checkpoint_with_transcript(
+        &repo,
+        "claude",
+        "sess-token-gone",
+        &transcript_path,
+        &file_path,
+        "const x = 1;\nconst y = 2;\n",
+    );
+    sync_token_usage_pipeline(&repo);
+    assert_eq!(token_usage_events(&metrics_db_path).len(), 1);
+
+    // The transcript disappears; a later checkpoint for the same session
+    // must not panic the daemon, emit new events, or zero out the buckets
+    // already reported to the server.
+    fs::remove_file(&transcript_path).unwrap();
+    let pre_hook = json!({
+        "cwd": repo_root.to_string_lossy(),
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Write",
+        "tool_use_id": "toolu_gone",
+        "session_id": "sess-token-gone",
+        "transcript_path": transcript_path.to_string_lossy(),
+        "tool_input": { "file_path": file_path.to_string_lossy() }
+    })
+    .to_string();
+    let _ = repo.git_ai(&["checkpoint", "claude", "--hook-input", &pre_hook]);
+    sync_token_usage_pipeline(&repo);
+
+    let events = token_usage_events(&metrics_db_path);
+    assert_eq!(
+        events.len(),
+        1,
+        "no new or zeroing events for a deleted file"
+    );
+    assert_eq!(
+        value_u64(&events[0], token_usage_pos::TOTAL_TOKENS),
+        Some(380)
+    );
+}


### PR DESCRIPTION
## Summary

Final PR of the TokenUsage stack: hardening and end-to-end coverage of the emission-dedup contract.

- **E2E tests** for the server-sync guarantees: unchanged buckets stay quiet across re-reads; a sidechain replay corrected by the parent's entry re-emits the bucket with *lower* totals; a bucket emptied by a cross-bucket streaming replacement emits an all-zero event exactly once (and stays quiet afterwards); a deleted transcript is handled without new or zeroing events.
- **Retention prune** wired into the worker sweep: per-entry rows and bucket fingerprints older than 90 days are dropped off the async loop; cursors are monotonic so pruned history is never re-read.
- **Repo exclude gate**: TokenUsage events are transcript-derived like SessionEvents — sweeps keep processing transcripts of sessions tracked before a repo was added to `exclude_repositories` — so `should_deliver_metric_event` now gates both kinds on the event's repo_url at upload time (filtered events are marked delivered without being uploaded, same contract as SessionEvents; covered by a daemon-mode test mirroring the SessionEvent one).
- **`docs/token-usage-events-spec.md`**: pipeline, state database, emission semantics, and ccusage deviations for reviewers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)