### PR TITLE
Default HTTP notes for API key users

### DIFF
--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -127,7 +127,7 @@ fn print_config_help() {
     println!("  git_ai_hooks                 Hook name -> shell commands map (object)");
     println!("  codex_hooks_format           Codex hook install format (config_toml/hooks_json)");
     println!("  notes_backend.kind           Notes backend kind (git_notes/http)");
-    println!("  notes_backend.backend_url    Notes backend base URL. Required when kind=http.");
+    println!("  notes_backend.backend_url    Notes backend base URL (defaults to api_base_url)");
     println!(
         "                               May include a path prefix; endpoints are appended to it."
     );

--- a/src/config.rs
+++ b/src/config.rs
@@ -637,10 +637,9 @@ impl Config {
         self.notes_backend.kind
     }
 
-    /// Returns the configured notes backend URL, or `None` if unset.
+    /// Returns the notes backend URL.
     ///
-    /// Callers must handle `None` explicitly — typically by skipping the operation when the HTTP backend
-    /// is enabled but no URL has been configured.
+    /// When no dedicated URL is configured, this falls back to `api_base_url`.
     pub fn notes_backend_url(&self) -> Option<&str> {
         self.notes_backend.backend_url.as_deref()
     }
@@ -1177,13 +1176,32 @@ fn build_config() -> Config {
             _ => None,
         });
     let url_from_env = env::var("GIT_AI_NOTES_BACKEND_URL").ok();
+    let notes_backend_is_configured =
+        kind_from_env.is_some() || url_from_env.is_some() || file_backend.is_some();
+
+    // Unit tests share Config::get() across the entire test process while some
+    // tests temporarily set API-key environment variables. Keep that singleton
+    // deterministic; TestRepo exercises the real binary and the production default.
+    #[cfg(test)]
+    let api_key_defaults_to_http = false;
+    #[cfg(not(test))]
+    let api_key_defaults_to_http = api_key.is_some();
+
+    let default_kind = if api_key_defaults_to_http && !notes_backend_is_configured {
+        NotesBackendKind::Http
+    } else {
+        NotesBackendKind::GitNotes
+    };
 
     let notes_backend = NotesBackendConfig {
         kind: kind_from_env
             .or_else(|| file_backend.as_ref().map(|b| b.kind))
-            .unwrap_or(NotesBackendKind::GitNotes),
-        backend_url: url_from_env
-            .or_else(|| file_backend.as_ref().and_then(|b| b.backend_url.clone())),
+            .unwrap_or(default_kind),
+        backend_url: Some(resolve_notes_backend_url(
+            url_from_env,
+            file_backend.as_ref(),
+            &api_base_url,
+        )),
     };
 
     // Transcript streaming lookback: env > file > default (7 days). 0 means unlimited (None).
@@ -1295,6 +1313,16 @@ fn build_config() -> Config {
         max_checkpoint_total_lines,
         daemon_memory_limit_mb,
     }
+}
+
+fn resolve_notes_backend_url(
+    url_from_env: Option<String>,
+    file_backend: Option<&NotesBackendConfig>,
+    api_base_url: &str,
+) -> String {
+    url_from_env
+        .or_else(|| file_backend.and_then(|backend| backend.backend_url.clone()))
+        .unwrap_or_else(|| api_base_url.to_string())
 }
 
 fn normalize_daemon_memory_limit_mb(limit_mb: u64) -> Option<u64> {
@@ -2645,10 +2673,11 @@ mod tests {
     }
 
     #[test]
-    fn test_notes_backend_url_unset_returns_none() {
-        // When backend_url is absent, notes_backend_url() is None. Callers must handle the unconfigured case explicitly.
-        let config = create_test_config(vec![], vec![]);
-        assert_eq!(config.notes_backend_url(), None);
+    fn test_notes_backend_url_unset_falls_back_to_api_base_url() {
+        assert_eq!(
+            resolve_notes_backend_url(None, None, DEFAULT_API_BASE_URL),
+            DEFAULT_API_BASE_URL
+        );
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1179,15 +1179,7 @@ fn build_config() -> Config {
     let notes_backend_is_configured =
         kind_from_env.is_some() || url_from_env.is_some() || file_backend.is_some();
 
-    // Unit tests share Config::get() across the entire test process while some
-    // tests temporarily set API-key environment variables. Keep that singleton
-    // deterministic; TestRepo exercises the real binary and the production default.
-    #[cfg(test)]
-    let api_key_defaults_to_http = false;
-    #[cfg(not(test))]
-    let api_key_defaults_to_http = api_key.is_some();
-
-    let default_kind = if api_key_defaults_to_http && !notes_backend_is_configured {
+    let default_kind = if api_key.is_some() && !notes_backend_is_configured {
         NotesBackendKind::Http
     } else {
         NotesBackendKind::GitNotes

--- a/tests/daemon_mode.rs
+++ b/tests/daemon_mode.rs
@@ -882,7 +882,12 @@ fn assert_post_commit_uploads_prompt_cas() {
         patch.exclude_prompts_in_repositories = Some(vec![]);
         patch.prompt_storage = Some("default".to_string());
         patch.telemetry_oss_disabled = Some(true);
+        patch.notes_backend = Some(NotesBackendConfig {
+            kind: NotesBackendKind::GitNotes,
+            backend_url: None,
+        });
     });
+    repo.restart_dedicated_daemon_with_env_for_test(&[("GIT_AI_NOTES_BACKEND_KIND", "git_notes")]);
 
     let repo_root = repo.canonical_path();
     let file_path = repo_root.join("test.ts");

--- a/tests/integration/config_cli_coverage.rs
+++ b/tests/integration/config_cli_coverage.rs
@@ -61,6 +61,87 @@ fn get_json(repo: &TestRepo, key: &str) -> Value {
         .unwrap_or_else(|e| panic!("config get {key} returned non-JSON {out:?}: {e}"))
 }
 
+fn get_json_with_env(repo: &TestRepo, key: &str, envs: &[(&str, &str)]) -> Value {
+    let out = repo
+        .git_ai_with_env(&["config", key], envs)
+        .unwrap_or_else(|e| panic!("config get {key} failed: {e}"));
+    serde_json::from_str(out.trim())
+        .unwrap_or_else(|e| panic!("config get {key} returned non-JSON {out:?}: {e}"))
+}
+
+#[test]
+fn test_api_key_defaults_unconfigured_notes_backend_to_http() {
+    let repo = TestRepo::new();
+
+    assert_eq!(
+        get_json(&repo, "notes_backend.kind"),
+        Value::String("git_notes".to_string())
+    );
+
+    repo.git_ai(&["config", "set", "api_base_url", "https://api.example.com"])
+        .expect("set API base URL");
+    repo.git_ai(&["config", "set", "api_key", "test-api-key"])
+        .expect("set api key");
+
+    assert_eq!(
+        get_json(&repo, "notes_backend.kind"),
+        Value::String("http".to_string())
+    );
+    assert_eq!(
+        get_json(&repo, "notes_backend.backend_url"),
+        Value::String("https://api.example.com".to_string())
+    );
+}
+
+#[test]
+fn test_api_key_preserves_existing_notes_backend_config() {
+    let repo = TestRepo::new();
+
+    repo.git_ai(&[
+        "config",
+        "set",
+        "notes_backend.backend_url",
+        "https://notes.example.com",
+    ])
+    .expect("set notes backend URL");
+    repo.git_ai(&["config", "set", "api_key", "test-api-key"])
+        .expect("set api key");
+
+    assert_eq!(
+        get_json(&repo, "notes_backend.kind"),
+        Value::String("git_notes".to_string())
+    );
+    assert_eq!(
+        get_json(&repo, "notes_backend.backend_url"),
+        Value::String("https://notes.example.com".to_string())
+    );
+
+    assert_eq!(
+        get_json_with_env(
+            &repo,
+            "notes_backend.kind",
+            &[
+                ("GIT_AI_API_KEY", "env-api-key"),
+                ("GIT_AI_NOTES_BACKEND_KIND", "http"),
+            ],
+        ),
+        Value::String("http".to_string())
+    );
+
+    let env_configured_repo = TestRepo::new();
+    assert_eq!(
+        get_json_with_env(
+            &env_configured_repo,
+            "notes_backend.kind",
+            &[
+                ("GIT_AI_API_KEY", "env-api-key"),
+                ("GIT_AI_NOTES_BACKEND_URL", "https://notes.example.com"),
+            ],
+        ),
+        Value::String("git_notes".to_string())
+    );
+}
+
 #[test]
 fn test_config_allow_superuser_set_get_unset() {
     let repo = TestRepo::new();


### PR DESCRIPTION
## Summary

- default unconfigured notes backends to HTTP when an API key is present
- preserve any existing notes backend configuration
- fall back to `api_base_url` when no dedicated notes backend URL is set

## Testing

- `task fmt`
- `task build`
- `task lint`
- `task test`