### PR TITLE
Expose a public notes_add_batch_direct on the crate

### DIFF
--- a/src/git/refs.rs
+++ b/src/git/refs.rs
@@ -447,6 +447,21 @@ pub fn copy_missing_notes_for_commits_from_ref(
     Ok(copied)
 }
 
+/// Write a batch of authorship notes directly to the git-notes backend
+/// (`refs/notes/ai`), bypassing `crate::git::notes_api`'s backend routing.
+///
+/// For external crates that embed this library and operate on repositories
+/// they manage themselves: they need a deterministic write that cannot be
+/// redirected by an ambient notes-backend configuration. Code inside this
+/// crate must keep going through `crate::git::notes_api` (see
+/// `git_backend_for_tests` below for why the raw functions stay private).
+pub fn notes_add_batch_direct(
+    repo: &Repository,
+    entries: &[(String, String)],
+) -> Result<(), GitAiError> {
+    notes_add_batch(repo, entries)
+}
+
 pub(in crate::git) fn notes_add_batch(
     repo: &Repository,
     entries: &[(String, String)],


### PR DESCRIPTION
Adds `git::refs::notes_add_batch_direct`, a public, documented entry point for the raw batch git-notes write (`refs/notes/ai`).

External crates that embed this library and operate on repositories they manage themselves need a deterministic write that cannot be redirected by an ambient notes-backend configuration. Until now the only ungated path was `notes_api::write_notes_batch`, which dispatches on `Config::get().notes_backend_kind()`; the raw function was reachable only through the `test-support` feature's `git_backend_for_tests` wrappers, which are documented as tests-only.

The raw `notes_add_batch` stays `pub(in crate::git)`, so code inside the crate is still forced through `notes_api`'s backend routing — the new wrapper only widens the surface for library consumers, and its docs state exactly what it bypasses.

No behavior change; `cargo test --lib` (2387 tests), clippy, and fmt are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/2222" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->