### PR TITLE
Fix macOS path matching in the codex stream-identity e2e

### DIFF
--- a/tests/integration/streams_e2e.rs
+++ b/tests/integration/streams_e2e.rs
@@ -841,11 +841,17 @@ fn codex_fork_rollout_checkpoint_tracks_one_stream_keyed_by_filename() {
         .join("internal")
         .join("transcripts-db");
     let db = StreamsDatabase::open(&db_path).unwrap();
+    // The daemon canonicalizes stream paths before storing them (macOS tmp
+    // dirs live under the /var -> /private/var symlink); comparing against
+    // the canonicalized path also pins that checkpoint registration and
+    // sweep discovery converge on the same key - the invariant that keeps
+    // one row per file.
+    let canonical_rollout = rollout.canonicalize().unwrap().display().to_string();
     let rows: Vec<StreamRecord> = db
         .all_streams()
         .unwrap()
         .into_iter()
-        .filter(|r| r.stream_path == rollout.display().to_string())
+        .filter(|r| r.stream_path == canonical_rollout)
         .collect();
     assert_eq!(
         rows.len(),


### PR DESCRIPTION
## Summary

Follow-up to #2204: `streams_e2e::codex_fork_rollout_checkpoint_tracks_one_stream_keyed_by_filename` fails on macOS because the daemon stores **canonicalized** stream paths (`handle_checkpoint_notification` canonicalizes before registering), and macOS temp dirs sit under the `/var -> /private/var` symlink — so the test's exact raw-path filter matched zero rows. Failing job: https://github.com/git-ai-project/git-ai/actions/runs/32983558889/job/98225989529

Test-only change; no product code touched. The product is already symlink-resilient: both registration boundaries (checkpoint notifications and sweep discovery) canonicalize before keying rows, which is the mechanism that guarantees one stream row per file. The test now compares against the **canonicalized** rollout path, which is portable (test and daemon call the same std canonicalize on every platform) and strictly stronger than the raw comparison: it also pins that the two registration paths converge on the same key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)