### PR TITLE
fix(status): normalize stored pathspecs to NFC

### DIFF
--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -130,10 +130,11 @@ fn run_status(json: bool, diff_only: bool) -> Result<(), GitAiError> {
 
     let mut pathspecs: HashSet<String> = checkpoints
         .iter()
-        .flat_map(|cp| cp.entries.iter().map(|e| e.file.clone()))
+        .flat_map(|cp| cp.entries.iter().map(|e| normalize_status_path(&e.file)))
         .filter(|file| !should_ignore_file_with_matcher(file, &ignore_matcher))
         .collect();
     for file_path in working_va.files() {
+        let file_path = normalize_status_path(&file_path);
         if !should_ignore_file_with_matcher(&file_path, &ignore_matcher) {
             pathspecs.insert(file_path);
         }
@@ -296,7 +297,7 @@ fn parse_working_dir_numstat_stats(
         // Parse numstat format: "added\tdeleted\tfilename"
         let parts: Vec<&str> = line.split('\t').collect();
         if parts.len() >= 3 {
-            let file_path: String = crate::utils::unescape_git_path(parts[2]).nfc().collect();
+            let file_path = normalize_status_path(&crate::utils::unescape_git_path(parts[2]));
 
             // Post-filter by pathspec when we couldn't pass them as CLI args
             if needs_post_filter
@@ -325,6 +326,10 @@ fn parse_working_dir_numstat_stats(
     }
 
     (added_lines, deleted_lines)
+}
+
+fn normalize_status_path(path: &str) -> String {
+    path.nfc().collect()
 }
 
 /// Count AI-attributed lines from InitialAttributions (uncommitted changes)
@@ -397,7 +402,7 @@ mod tests {
     #[test]
     fn numstat_normalizes_decomposed_non_ascii_paths() {
         let mut pathspecs = HashSet::new();
-        pathspecs.insert("café.txt".to_string());
+        pathspecs.insert(normalize_status_path("cafe\u{301}.txt"));
         let ignore_matcher = build_ignore_matcher(&[]);
 
         let stats = parse_working_dir_numstat_stats(

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -250,7 +250,7 @@ fn get_working_dir_diff_stats(
         if paths.is_empty() {
             return Ok((0, 0));
         }
-        if paths.len() > MAX_PATHSPEC_ARGS {
+        if needs_working_dir_post_filter(paths) {
             // Disable rename detection so git reports renames as separate
             // delete + add entries with clean filenames. Without this,
             // numstat outputs "old => new" arrow notation in the filename
@@ -277,6 +277,10 @@ fn get_working_dir_diff_stats(
         needs_post_filter,
         ignore_matcher,
     ))
+}
+
+fn needs_working_dir_post_filter(paths: &HashSet<String>) -> bool {
+    paths.len() > MAX_PATHSPEC_ARGS || paths.iter().any(|path| !path.is_ascii())
 }
 
 fn parse_working_dir_numstat_stats(
@@ -383,6 +387,13 @@ mod tests {
         );
 
         assert_eq!((added, deleted), (3, 1));
+    }
+
+    #[test]
+    fn non_ascii_pathspecs_force_post_filtering() {
+        let pathspecs = HashSet::from(["caf\u{e9}.txt".to_string()]);
+
+        assert!(needs_working_dir_post_filter(&pathspecs));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- NFC-normalize status pathspecs loaded from checkpoints and working logs
- use the same normalization helper for parsed Git numstat paths
- extend the decomposed-Unicode regression test to exercise pathspec canonicalization before post-filter matching

## Validation
- `task fmt`
- `task lint`
- `task test TEST_FILTER=commands::status::tests::numstat_normalizes_decomposed_non_ascii_paths`
- related `numstat_` tests (15 passing across unit/integration)

The full local suite also encountered two unrelated failures already present on current main: `daemon::tests::conflict_resolution_note_read_errors_are_not_silently_ignored` and `git::authorship_traversal::tests::test_load_ai_touched_files_for_specific_commits`. The first reproduces in isolation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/2224" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->