### PR TITLE
feat(pricing): keep models.dev context tiers and fast multipliers in the catalog

### DIFF
--- a/src/metrics/local_stats.rs
+++ b/src/metrics/local_stats.rs
@@ -582,8 +582,8 @@ impl CodexSessionAccum {
 fn estimate_cost(acc: &TokenAccum, pricing: &ModelPricing) -> f64 {
     (acc.input as f64 * pricing.input
         + acc.output as f64 * pricing.output
-        + acc.cache_creation as f64 * pricing.cache_write
-        + acc.cache_read as f64 * pricing.cache_read)
+        + acc.cache_creation as f64 * pricing.cache_write_rate()
+        + acc.cache_read as f64 * pricing.cache_read_rate())
         / 1_000_000.0
 }
 
@@ -1419,8 +1419,8 @@ mod tests {
         // 20 cache read, 10 cache creation.
         let expected = (100.0 * pricing.input
             + 50.0 * pricing.output
-            + 20.0 * pricing.cache_read
-            + 10.0 * pricing.cache_write)
+            + 20.0 * pricing.cache_read_rate()
+            + 10.0 * pricing.cache_write_rate())
             / 1_000_000.0;
         assert!(expected > 0.0);
         assert!((stats.tokens.estimated_cost_usd - expected).abs() < 1e-12);

--- a/src/metrics/local_stats.rs
+++ b/src/metrics/local_stats.rs
@@ -579,6 +579,12 @@ impl CodexSessionAccum {
     }
 }
 
+/// Rough display estimate for `git-ai usage`: flat base rates with the
+/// Claude-shape defaults for unpublished cache rates (0.1x input for reads,
+/// 1.25x for writes) for every tool. The TokenUsage event pipeline
+/// (`src/token_usage/cost.rs`) is the authoritative dollars — it prices
+/// per entry with tier, speed, and per-tool cache-rate semantics (e.g. Codex
+/// bills unpublished cache reads at the full input rate).
 fn estimate_cost(acc: &TokenAccum, pricing: &ModelPricing) -> f64 {
     (acc.input as f64 * pricing.input
         + acc.output as f64 * pricing.output

--- a/src/metrics/local_stats.rs
+++ b/src/metrics/local_stats.rs
@@ -611,7 +611,7 @@ fn cost_for_message_slice(entries: impl Iterator<Item = (String, TokenAccum)>) -
     }
     model_totals
         .iter()
-        .filter_map(|(model, acc)| pricing_for(model).map(|p| estimate_cost(acc, p)))
+        .filter_map(|(model, acc)| pricing_for(model).map(|p| estimate_cost(acc, &p)))
         .sum()
 }
 
@@ -648,7 +648,7 @@ fn build_token_summary(
         if let Some(pricing) = pricing_for(&short) {
             *cost_by_day
                 .entry(ts_to_local(ts).date_naive())
-                .or_insert(0.0) += estimate_cost(&acc, pricing);
+                .or_insert(0.0) += estimate_cost(&acc, &pricing);
         }
 
         let entry = model_tokens.entry(short.clone()).or_default();
@@ -686,7 +686,7 @@ fn build_token_summary(
         if let Some(pricing) = pricing_for(&short) {
             *cost_by_day
                 .entry(ts_to_local(acc.last_usage_ts).date_naive())
-                .or_insert(0.0) += estimate_cost(&mapped, pricing);
+                .or_insert(0.0) += estimate_cost(&mapped, &pricing);
         }
 
         let entry = model_tokens.entry(short.clone()).or_default();
@@ -742,7 +742,7 @@ fn build_token_summary(
         summary.cache_read += acc.cache_read;
         summary.cache_creation += acc.cache_creation;
 
-        let cost = pricing_for(&model).map(|p| estimate_cost(&acc, p));
+        let cost = pricing_for(&model).map(|p| estimate_cost(&acc, &p));
         if let Some(c) = cost {
             summary.estimated_cost_usd += c;
         }

--- a/src/metrics/model_pricing.rs
+++ b/src/metrics/model_pricing.rs
@@ -34,6 +34,13 @@ use std::sync::{Mutex, OnceLock};
 const EMBEDDED_SNAPSHOT: &str = include_str!("models_dev_pricing_snapshot.json");
 const MODELS_DEV_API_URL: &str = "https://models.dev/api.json";
 const CACHE_FILE_NAME: &str = "models_dev_pricing.json";
+/// Format version of the on-disk cache. Bump whenever `ModelPricing`'s
+/// serialized shape changes meaning: caches written under another format are
+/// ignored (the embedded snapshot applies) until a refresh rewrites them,
+/// never reinterpreted — a pre-tier cache stored explicit 0.0 for unpublished
+/// cache rates, which the optional-rate schema would read as published-free
+/// pricing, and it carries no tiers or fast multipliers.
+const PRICING_CACHE_VERSION: u32 = 2;
 /// Minimum interval between refresh *attempts* (successful or not), so
 /// offline machines don't stall on the fetch timeout at every invocation.
 const REFRESH_INTERVAL_SECS: u64 = 24 * 3600;
@@ -308,6 +315,7 @@ fn catalog() -> &'static PricingCatalog {
     CATALOG.get_or_init(|| {
         if !use_embedded_only()
             && let Some(cache) = cache_path().and_then(|path| read_json_file::<PricingCache>(&path))
+            && cache.is_current_format()
             && !cache.models.is_empty()
         {
             return PricingCatalog::from_entries(cache.models);
@@ -325,8 +333,17 @@ fn embedded_catalog() -> PricingCatalog {
 /// attempt (used for throttling, so failed attempts are also spaced out).
 #[derive(Serialize, Deserialize)]
 struct PricingCache {
+    /// See [`PRICING_CACHE_VERSION`]; pre-version files default to 0.
+    #[serde(default)]
+    version: u32,
     last_attempt_at: u64,
     models: BTreeMap<String, ModelPricing>,
+}
+
+impl PricingCache {
+    fn is_current_format(&self) -> bool {
+        self.version == PRICING_CACHE_VERSION
+    }
 }
 
 fn cache_path() -> Option<PathBuf> {
@@ -363,10 +380,11 @@ fn is_fresh(last_attempt_at: u64, now: u64) -> bool {
 }
 
 /// Fold a fetch result into the next cache state. On failure the previously
-/// fetched models are kept, but the embedded snapshot is never copied into
-/// the cache: an empty cache keeps falling through to the (possibly newer)
-/// snapshot shipped with the running binary, while the bumped attempt
-/// timestamp still throttles the next fetch.
+/// fetched models are kept — unless they were written under another format,
+/// which must not be relabeled as current — but the embedded snapshot is
+/// never copied into the cache: an empty cache keeps falling through to the
+/// (possibly newer) snapshot shipped with the running binary, while the
+/// bumped attempt timestamp still throttles the next fetch.
 fn next_cache(
     existing: Option<PricingCache>,
     fetched: Result<BTreeMap<String, ModelPricing>, String>,
@@ -374,9 +392,13 @@ fn next_cache(
 ) -> PricingCache {
     let models = match fetched {
         Ok(models) => models,
-        Err(_) => existing.map(|cache| cache.models).unwrap_or_default(),
+        Err(_) => existing
+            .filter(PricingCache::is_current_format)
+            .map(|cache| cache.models)
+            .unwrap_or_default(),
     };
     PricingCache {
+        version: PRICING_CACHE_VERSION,
         last_attempt_at: now,
         models,
     }
@@ -847,6 +869,7 @@ mod tests {
 
         // A later failure keeps previously *fetched* models.
         let existing = PricingCache {
+            version: PRICING_CACHE_VERSION,
             last_attempt_at: 100,
             models: fetched_models(),
         };
@@ -856,12 +879,32 @@ mod tests {
 
         // Success replaces the models outright.
         let existing = PricingCache {
+            version: PRICING_CACHE_VERSION,
             last_attempt_at: 200,
             models: BTreeMap::new(),
         };
         let cache = next_cache(Some(existing), Ok(fetched_models()), 300);
         assert_eq!(cache.last_attempt_at, 300);
         assert_eq!(cache.models, fetched_models());
+    }
+
+    #[test]
+    fn other_format_cache_files_are_ignored_not_reinterpreted() {
+        // A cache written before cache rates became optional stores explicit
+        // 0.0 for unpublished rates, which the optional-rate schema would
+        // read as published-free pricing (and it carries no tiers or fast
+        // multipliers). Such files must be discarded — the embedded snapshot
+        // applies — never reinterpreted.
+        let old: PricingCache = serde_json::from_str(
+            r#"{"last_attempt_at":100,"models":{"gpt-5-pro":{"input":15.0,"output":120.0,"cache_read":0.0,"cache_write":0.0}}}"#,
+        )
+        .unwrap();
+        assert!(!old.is_current_format(), "pre-version files default to 0");
+        // A failed refresh drops the other-format models rather than
+        // relabeling them as current.
+        let next = next_cache(Some(old), Err("offline".to_string()), 200);
+        assert!(next.models.is_empty());
+        assert_eq!(next.version, PRICING_CACHE_VERSION);
     }
 
     #[test]
@@ -883,12 +926,14 @@ mod tests {
         write_json_file(
             &path,
             &PricingCache {
+                version: PRICING_CACHE_VERSION,
                 last_attempt_at: 1234567890,
                 models: fetched_models(),
             },
         );
 
         let cache: PricingCache = read_json_file(&path).unwrap();
+        assert!(cache.is_current_format());
         assert_eq!(cache.last_attempt_at, 1234567890);
         assert_eq!(cache.models, fetched_models());
     }

--- a/src/metrics/model_pricing.rs
+++ b/src/metrics/model_pricing.rs
@@ -73,10 +73,14 @@ const FAMILY_FALLBACK_TOKENS: [&str; 7] =
 /// "fast" tier is not its API priority pricing), so they are hand-tracked
 /// against vendor price sheets. Exact entries apply to that catalog id only —
 /// "gpt-5.5-pro" must not inherit gpt-5.5's multiplier.
-const FAST_MULTIPLIER_EXACT: [(&str, f64); 6] = [
+const FAST_MULTIPLIER_EXACT: [(&str, f64); 7] = [
     ("gpt-5.6-sol", 2.0),
     ("gpt-5.6-terra", 2.0),
     ("gpt-5.6-luna", 2.0),
+    // The bare family id is an alias that bills as gpt-5.6-sol (ccusage
+    // `pricing_alias`); models.dev catalogs it as its own entry, so it needs
+    // its own multiplier row.
+    ("gpt-5.6", 2.0),
     ("gpt-5.5", 2.5),
     ("gpt-5.4", 2.0),
     ("gpt-5.3-codex", 2.0),
@@ -795,7 +799,9 @@ mod tests {
             "openai": {
                 "models": {
                     "gpt-5.5": {"cost": {"input": 5.0, "output": 30.0}},
-                    "gpt-5.5-pro": {"cost": {"input": 30.0, "output": 180.0}}
+                    "gpt-5.5-pro": {"cost": {"input": 30.0, "output": 180.0}},
+                    "gpt-5.6": {"cost": {"input": 4.0, "output": 20.0}},
+                    "gpt-5.6-sol": {"cost": {"input": 4.0, "output": 20.0}}
                 }
             },
             "anthropic": {
@@ -819,6 +825,13 @@ mod tests {
         assert_eq!(
             catalog.pricing_for("gpt-5.5-pro").unwrap().fast_multiplier,
             1.0
+        );
+        // The bare gpt-5.6 alias bills as gpt-5.6-sol (ccusage
+        // `pricing_alias`), fast multiplier included.
+        assert_eq!(catalog.pricing_for("gpt-5.6").unwrap().fast_multiplier, 2.0);
+        assert_eq!(
+            catalog.pricing_for("gpt-5.6-sol").unwrap().fast_multiplier,
+            2.0
         );
         assert_eq!(
             catalog

--- a/src/metrics/model_pricing.rs
+++ b/src/metrics/model_pricing.rs
@@ -87,30 +87,35 @@ const FAST_MULTIPLIER_EXACT: [(&str, f64); 7] = [
 ];
 
 /// Prefix entries also cover the base model's date-suffixed and tier-variant
-/// catalog ids (ccusage's `normalized_prefix` section).
-const FAST_MULTIPLIER_PREFIX: [(&str, f64); 3] = [
+/// catalog ids (ccusage's `normalized_prefix` section). Anthropic's pricing
+/// page currently offers fast mode on Opus 5 and Opus 4.8 only, both at 2x
+/// ($10/$50 vs $5/$25); the 4-6/4-7 rows are kept for transcripts recorded
+/// under the earlier fast research preview (matching ccusage and LiteLLM's
+/// hand-tracked values for that era — today 4-7 fast requests error and 4-6
+/// runs at standard billing).
+const FAST_MULTIPLIER_PREFIX: [(&str, f64); 4] = [
     ("claude-opus-4-6", 6.0),
     ("claude-opus-4-7", 6.0),
     ("claude-opus-4-8", 2.0),
+    ("claude-opus-5", 2.0),
 ];
 
-/// Anthropic's published long-context premium: every token of a request whose
-/// context exceeds 200K bills at these rates on 1M-context models. models.dev
-/// only records these tiers under gateway spellings (google-vertex, azure)
-/// that the provider allowlist drops, so they are hand-tracked here and
-/// stamped onto first-party entries that carry no tiers of their own. Prefix
-/// semantics like [`FAST_MULTIPLIER_PREFIX`]. Both override tables are
-/// applied when a catalog is *loaded* (not when it is fetched/trimmed), so
-/// editing them takes effect on upgrade even against a previously fetched
-/// on-disk cache.
-const CLAUDE_LONG_CONTEXT_PREFIX: [(&str, LongContextRates); 6] = [
-    ("claude-sonnet-4", SONNET_LONG_CONTEXT),
-    ("claude-sonnet-4-5", SONNET_LONG_CONTEXT),
-    ("claude-sonnet-4-6", SONNET_LONG_CONTEXT),
-    ("claude-opus-4-6", OPUS_LONG_CONTEXT),
-    ("claude-opus-4-7", OPUS_LONG_CONTEXT),
-    ("claude-opus-4-8", OPUS_LONG_CONTEXT),
-];
+/// Anthropic's >200K long-context premium applies ONLY to the pre-4.6
+/// 1M-context beta: per the pricing page's "Long context pricing" section,
+/// "Claude 4.6 and later models ... include the full 1M token context window
+/// at standard pricing" — so 4.6+ models must NOT be listed here. Of the
+/// premium-era models, only Sonnet 4.5 is still served first-party (plain
+/// Sonnet 4 is retired, and a bare "claude-sonnet-4" row would token-prefix
+/// onto 4-6 and later ids). models.dev's first-party entries carry no tiers
+/// — correct data for 4.6+, an omission for 4.5 — so 4.5's rates are
+/// hand-tracked from the 1M-beta announcement (2x input, 1.5x output, cache
+/// multipliers on the premium input rate; LiteLLM's `above_200k` for
+/// sonnet-4-5 records the same values). Prefix semantics like
+/// [`FAST_MULTIPLIER_PREFIX`]. Both override tables are applied when a
+/// catalog is *loaded* (not when it is fetched/trimmed), so editing them
+/// takes effect on upgrade even against a previously fetched on-disk cache.
+const CLAUDE_LONG_CONTEXT_PREFIX: [(&str, LongContextRates); 1] =
+    [("claude-sonnet-4-5", SONNET_LONG_CONTEXT)];
 
 const SONNET_LONG_CONTEXT: LongContextRates = LongContextRates {
     threshold: 200_000,
@@ -118,14 +123,6 @@ const SONNET_LONG_CONTEXT: LongContextRates = LongContextRates {
     output: Some(22.5),
     cache_read: Some(0.6),
     cache_write: Some(7.5),
-};
-
-const OPUS_LONG_CONTEXT: LongContextRates = LongContextRates {
-    threshold: 200_000,
-    input: Some(10.0),
-    output: Some(37.5),
-    cache_read: Some(1.0),
-    cache_write: Some(12.5),
 };
 
 /// One above-threshold pricing band (per-million-token USD).
@@ -877,10 +874,14 @@ mod tests {
         let api_json = serde_json::json!({
             "anthropic": {
                 "models": {
-                    "claude-sonnet-4-6": {"cost": {
+                    "claude-sonnet-4-5": {"cost": {
                         "input": 3.0, "output": 15.0, "cache_read": 0.3, "cache_write": 3.75
                     }},
-                    "claude-sonnet-4-6-20260115": {"cost": {"input": 3.0, "output": 15.0}},
+                    "claude-sonnet-4-5-20250929": {"cost": {"input": 3.0, "output": 15.0}},
+                    // 4.6+ prices flat across the full 1M window (pricing
+                    // page, "Long context pricing") and must NOT inherit the
+                    // 4-5 row via prefix matching.
+                    "claude-sonnet-4-6": {"cost": {"input": 3.0, "output": 15.0}},
                     // A published tier must win over the hand-tracked one.
                     "claude-opus-4-8": {"cost": {
                         "input": 5.0, "output": 25.0,
@@ -894,11 +895,11 @@ mod tests {
 
         let entries = trim_catalog(&api_json).unwrap();
         assert_eq!(
-            entries["claude-sonnet-4-6"].long_context_threshold, None,
+            entries["claude-sonnet-4-5"].long_context_threshold, None,
             "trim output is pure models.dev data"
         );
         let catalog = PricingCatalog::from_entries(entries);
-        let sonnet = catalog.pricing_for("claude-sonnet-4-6").unwrap();
+        let sonnet = catalog.pricing_for("claude-sonnet-4-5").unwrap();
         assert_eq!(sonnet.long_context_threshold, Some(200_000));
         assert_eq!(sonnet.input_above, Some(6.0));
         assert_eq!(sonnet.output_above, Some(22.5));
@@ -906,11 +907,19 @@ mod tests {
         assert_eq!(sonnet.cache_write_above, Some(7.5));
         assert_eq!(
             catalog
-                .pricing_for("claude-sonnet-4-6-20260115")
+                .pricing_for("claude-sonnet-4-5-20250929")
                 .unwrap()
                 .long_context_threshold,
             Some(200_000),
             "date-suffixed spellings inherit the premium"
+        );
+        assert_eq!(
+            catalog
+                .pricing_for("claude-sonnet-4-6")
+                .unwrap()
+                .long_context_threshold,
+            None,
+            "4.6+ models price flat across the 1M window"
         );
         let opus = catalog.pricing_for("claude-opus-4-8").unwrap();
         assert_eq!(
@@ -1014,12 +1023,17 @@ mod tests {
         assert_eq!(sol.long_context_threshold, Some(272_000));
         assert!(sol.input_above.is_some());
         assert_eq!(sol.fast_multiplier, 2.0);
-        let sonnet = catalog.pricing_for("claude-sonnet-4-6").unwrap();
-        assert_eq!(sonnet.long_context_threshold, Some(200_000));
-        assert_eq!(sonnet.input_above, Some(6.0));
+        // Anthropic prices Claude 4.6+ flat across the 1M window ("Long
+        // context pricing" on the pricing page); only pre-4.6 1M-beta
+        // models carry the >200K premium.
+        let sonnet45 = catalog.pricing_for("claude-sonnet-4-5").unwrap();
+        assert_eq!(sonnet45.long_context_threshold, Some(200_000));
+        assert_eq!(sonnet45.input_above, Some(6.0));
+        let sonnet46 = catalog.pricing_for("claude-sonnet-4-6").unwrap();
+        assert_eq!(sonnet46.long_context_threshold, None);
         let opus = catalog.pricing_for("claude-opus-4-8").unwrap();
         assert_eq!(opus.fast_multiplier, 2.0);
-        assert_eq!(opus.long_context_threshold, Some(200_000));
+        assert_eq!(opus.long_context_threshold, None);
         let fable = catalog.pricing_for("claude-fable-5").unwrap();
         assert_eq!(fable.fast_multiplier, 1.0);
         assert_eq!(fable.long_context_threshold, None);

--- a/src/metrics/model_pricing.rs
+++ b/src/metrics/model_pricing.rs
@@ -17,9 +17,13 @@
 //! catalog id at token boundaries, then by family fallback (see
 //! [`PricingCatalog::pricing_for`]).
 //!
-//! Tiered pricing (e.g. higher rates above 200k context) is intentionally
-//! ignored: recorded token usage carries no per-request context size, and the
-//! resulting figures are estimates either way.
+//! Beyond flat rates, entries carry the model's long-context pricing tier
+//! (models.dev `cost.tiers` with a `context` bound: every token of a request
+//! whose context exceeds the threshold bills at the above-threshold rates)
+//! and a fast/priority speed multiplier. Neither vendors nor models.dev
+//! publish fast-tier pricing, and models.dev's first-party Anthropic entries
+//! omit their long-context tiers, so both are hand-tracked in override
+//! tables below, applied when the catalog is trimmed.
 
 use crate::utils::{read_json_file, unix_timestamp_now, write_json_file};
 use serde::{Deserialize, Serialize};
@@ -56,16 +60,137 @@ const PROVIDER_ALLOWLIST: [&str; 8] = [
 const FAMILY_FALLBACK_TOKENS: [&str; 7] =
     ["opus", "sonnet", "haiku", "fable", "gpt", "gemini", "grok"];
 
-/// Per-million-token pricing for a model (USD). Cache fields default to 0 —
-/// models.dev omits them for models without prompt caching.
+/// Fast/priority speed multipliers over a request's whole cost, ported from
+/// ccusage's fast-multiplier-overrides.json (MIT License, Copyright (c) 2025
+/// @ryoppippi). No machine-readable source publishes these (OpenAI's Codex
+/// "fast" tier is not its API priority pricing), so they are hand-tracked
+/// against vendor price sheets. Exact entries apply to that catalog id only —
+/// "gpt-5.5-pro" must not inherit gpt-5.5's multiplier.
+const FAST_MULTIPLIER_EXACT: [(&str, f64); 6] = [
+    ("gpt-5.6-sol", 2.0),
+    ("gpt-5.6-terra", 2.0),
+    ("gpt-5.6-luna", 2.0),
+    ("gpt-5.5", 2.5),
+    ("gpt-5.4", 2.0),
+    ("gpt-5.3-codex", 2.0),
+];
+
+/// Prefix entries also cover the base model's date-suffixed and tier-variant
+/// catalog ids (ccusage's `normalized_prefix` section).
+const FAST_MULTIPLIER_PREFIX: [(&str, f64); 3] = [
+    ("claude-opus-4-6", 6.0),
+    ("claude-opus-4-7", 6.0),
+    ("claude-opus-4-8", 2.0),
+];
+
+/// Anthropic's published long-context premium: every token of a request whose
+/// context exceeds 200K bills at these rates on 1M-context models. models.dev
+/// only records these tiers under gateway spellings (google-vertex, azure)
+/// that the provider allowlist drops, so they are hand-tracked here and
+/// stamped onto first-party entries that carry no tiers of their own. Prefix
+/// semantics like [`FAST_MULTIPLIER_PREFIX`].
+const CLAUDE_LONG_CONTEXT_PREFIX: [(&str, LongContextRates); 6] = [
+    ("claude-sonnet-4", SONNET_LONG_CONTEXT),
+    ("claude-sonnet-4-5", SONNET_LONG_CONTEXT),
+    ("claude-sonnet-4-6", SONNET_LONG_CONTEXT),
+    ("claude-opus-4-6", OPUS_LONG_CONTEXT),
+    ("claude-opus-4-7", OPUS_LONG_CONTEXT),
+    ("claude-opus-4-8", OPUS_LONG_CONTEXT),
+];
+
+const SONNET_LONG_CONTEXT: LongContextRates = LongContextRates {
+    threshold: 200_000,
+    input: Some(6.0),
+    output: Some(22.5),
+    cache_read: Some(0.6),
+    cache_write: Some(7.5),
+};
+
+const OPUS_LONG_CONTEXT: LongContextRates = LongContextRates {
+    threshold: 200_000,
+    input: Some(10.0),
+    output: Some(37.5),
+    cache_read: Some(1.0),
+    cache_write: Some(12.5),
+};
+
+/// One above-threshold pricing band (per-million-token USD).
+#[derive(Debug, Clone, Copy)]
+struct LongContextRates {
+    threshold: u64,
+    input: Option<f64>,
+    output: Option<f64>,
+    cache_read: Option<f64>,
+    cache_write: Option<f64>,
+}
+
+/// Per-million-token pricing for a model (USD). Cache rates are `None` when
+/// the catalog doesn't publish them — consumers distinguish published rates
+/// from the derived defaults of [`ModelPricing::cache_read_rate`] /
+/// [`ModelPricing::cache_write_rate`]. The `*_above` rates and threshold
+/// describe the model's long-context tier: a request whose context exceeds
+/// the threshold bills every token at the above rate (whole-request, not
+/// marginal), falling back per-rate to the base rate when unpublished.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ModelPricing {
     pub input: f64,
     pub output: f64,
-    #[serde(default)]
-    pub cache_read: f64,
-    #[serde(default)]
-    pub cache_write: f64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_read: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_write: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub long_context_threshold: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub input_above: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output_above: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_read_above: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_write_above: Option<f64>,
+    #[serde(default = "one", skip_serializing_if = "is_one")]
+    pub fast_multiplier: f64,
+}
+
+fn one() -> f64 {
+    1.0
+}
+
+fn is_one(value: &f64) -> bool {
+    *value == 1.0
+}
+
+impl Default for ModelPricing {
+    fn default() -> Self {
+        Self {
+            input: 0.0,
+            output: 0.0,
+            cache_read: None,
+            cache_write: None,
+            long_context_threshold: None,
+            input_above: None,
+            output_above: None,
+            cache_read_above: None,
+            cache_write_above: None,
+            fast_multiplier: 1.0,
+        }
+    }
+}
+
+impl ModelPricing {
+    /// Published cache-read rate, or ccusage's models.dev-loader default of a
+    /// tenth of the input rate (cache reads dominate Codex usage; $0 would
+    /// badly undercount).
+    pub fn cache_read_rate(&self) -> f64 {
+        self.cache_read.unwrap_or(self.input * 0.1)
+    }
+
+    /// Published cache-write rate, or ccusage's models.dev-loader default of
+    /// 1.25x the input rate.
+    pub fn cache_write_rate(&self) -> f64 {
+        self.cache_write.unwrap_or(self.input * 1.25)
+    }
 }
 
 /// A set of model pricing entries keyed by lowercased model id.
@@ -267,9 +392,85 @@ fn fetch_and_trim_catalog() -> Result<BTreeMap<String, ModelPricing>, String> {
     trim_catalog(body)
 }
 
+/// A model's `cost` object as models.dev publishes it. Unlike [`ModelPricing`]
+/// it may lack input/output (skipped) and carries tier bands verbatim.
+#[derive(Deserialize)]
+struct ModelsDevCost {
+    input: Option<f64>,
+    output: Option<f64>,
+    cache_read: Option<f64>,
+    cache_write: Option<f64>,
+    #[serde(default)]
+    tiers: Vec<ModelsDevTier>,
+}
+
+#[derive(Deserialize)]
+struct ModelsDevTier {
+    input: Option<f64>,
+    output: Option<f64>,
+    cache_read: Option<f64>,
+    cache_write: Option<f64>,
+    tier: Option<ModelsDevTierBound>,
+}
+
+#[derive(Deserialize)]
+struct ModelsDevTierBound {
+    #[serde(rename = "type")]
+    kind: Option<String>,
+    size: Option<u64>,
+}
+
+impl ModelsDevCost {
+    /// The model's long-context band: the `context`-bound tier with the
+    /// lowest threshold. [`ModelPricing`] holds one above-base band, so the
+    /// lowest threshold wins — a higher one would price everything between
+    /// the two thresholds at the base rate (ccusage `long_context_tier`).
+    fn long_context_rates(&self) -> Option<LongContextRates> {
+        self.tiers
+            .iter()
+            .filter_map(|tier| {
+                let bound = tier.tier.as_ref()?;
+                if bound.kind.as_deref() != Some("context") {
+                    return None;
+                }
+                Some(LongContextRates {
+                    threshold: bound.size.filter(|size| *size > 0)?,
+                    input: tier.input,
+                    output: tier.output,
+                    cache_read: tier.cache_read,
+                    cache_write: tier.cache_write,
+                })
+            })
+            .min_by_key(|rates| rates.threshold)
+    }
+}
+
+/// The override value whose key matches `model_id` exactly or as a
+/// token-boundary prefix ("claude-opus-4-6" also covers
+/// "claude-opus-4-6-20260205"). Catalog ids carry no provider prefixes, so
+/// the boundary-containment helper is an exact-or-prefix match here.
+fn prefix_override<T: Copy>(overrides: &[(&str, T)], model_id: &str) -> Option<T> {
+    overrides
+        .iter()
+        .find(|(base, _)| contains_at_token_boundary(model_id, base))
+        .map(|(_, value)| *value)
+}
+
+fn fast_multiplier_override(model_id: &str) -> f64 {
+    FAST_MULTIPLIER_EXACT
+        .iter()
+        .find(|(id, _)| *id == model_id)
+        .map(|(_, multiplier)| *multiplier)
+        .or_else(|| prefix_override(&FAST_MULTIPLIER_PREFIX, model_id))
+        .unwrap_or(1.0)
+}
+
 /// Reduce a full models.dev `api.json` document to a flat model-id → pricing
-/// map over the provider allowlist. Models without a parseable cost entry
-/// (missing, or lacking input/output rates) are skipped.
+/// map over the provider allowlist, keeping each model's long-context tier
+/// and stamping the hand-tracked overrides (fast multipliers always; Claude
+/// long-context rates only when the entry publishes no tiers of its own).
+/// Models without a parseable cost entry (missing, or lacking input/output
+/// rates) are skipped.
 fn trim_catalog(api_json: &str) -> Result<BTreeMap<String, ModelPricing>, String> {
     let providers: serde_json::Value = serde_json::from_str(api_json).map_err(|e| e.to_string())?;
     let mut entries = BTreeMap::new();
@@ -285,9 +486,31 @@ fn trim_catalog(api_json: &str) -> Result<BTreeMap<String, ModelPricing>, String
             let Some(cost) = model.get("cost") else {
                 continue;
             };
-            if let Ok(pricing) = serde_json::from_value::<ModelPricing>(cost.clone()) {
-                entries.insert(model_id.to_lowercase(), pricing);
-            }
+            let Ok(cost) = serde_json::from_value::<ModelsDevCost>(cost.clone()) else {
+                continue;
+            };
+            let (Some(input), Some(output)) = (cost.input, cost.output) else {
+                continue;
+            };
+            let model_id = model_id.to_lowercase();
+            let long_context = cost
+                .long_context_rates()
+                .or_else(|| prefix_override(&CLAUDE_LONG_CONTEXT_PREFIX, &model_id));
+            entries.insert(
+                model_id.clone(),
+                ModelPricing {
+                    input,
+                    output,
+                    cache_read: cost.cache_read,
+                    cache_write: cost.cache_write,
+                    long_context_threshold: long_context.map(|rates| rates.threshold),
+                    input_above: long_context.and_then(|rates| rates.input),
+                    output_above: long_context.and_then(|rates| rates.output),
+                    cache_read_above: long_context.and_then(|rates| rates.cache_read),
+                    cache_write_above: long_context.and_then(|rates| rates.cache_write),
+                    fast_multiplier: fast_multiplier_override(&model_id),
+                },
+            );
         }
     }
     if entries.is_empty() {
@@ -368,7 +591,7 @@ mod tests {
         );
         assert_eq!(
             catalog.pricing_for("claude-opus-4-1"),
-            catalog.pricing_for("claude-opus-5"),
+            catalog.pricing_for("claude-opus-4-7"),
             "uncataloged opus ids price at the median opus rate"
         );
         assert!(
@@ -425,12 +648,12 @@ mod tests {
         let pricing = &entries["claude-test-1"];
         assert_eq!(pricing.input, 1.0);
         assert_eq!(pricing.output, 2.0);
-        assert_eq!(pricing.cache_read, 0.1);
-        assert_eq!(pricing.cache_write, 1.25);
+        assert_eq!(pricing.cache_read, Some(0.1));
+        assert_eq!(pricing.cache_write, Some(1.25));
     }
 
     #[test]
-    fn trim_catalog_defaults_missing_cache_rates_to_zero() {
+    fn trim_catalog_keeps_unpublished_cache_rates_distinguishable() {
         let api_json = serde_json::json!({
             "openai": {
                 "models": {
@@ -442,8 +665,154 @@ mod tests {
 
         let entries = trim_catalog(&api_json).unwrap();
         let pricing = &entries["gpt-test-pro"];
-        assert_eq!(pricing.cache_read, 0.0);
-        assert_eq!(pricing.cache_write, 0.0);
+        // None (unpublished) must stay distinguishable from an explicit 0 —
+        // the Codex cost path bills unpublished cache reads at the full input
+        // rate but explicit rates as published.
+        assert_eq!(pricing.cache_read, None);
+        assert_eq!(pricing.cache_write, None);
+        assert_eq!(pricing.cache_read_rate(), 1.5);
+        assert_eq!(pricing.cache_write_rate(), 18.75);
+        let explicit_zero = ModelPricing {
+            input: 15.0,
+            cache_read: Some(0.0),
+            cache_write: Some(0.0),
+            ..Default::default()
+        };
+        assert_eq!(explicit_zero.cache_read_rate(), 0.0);
+        assert_eq!(explicit_zero.cache_write_rate(), 0.0);
+    }
+
+    #[test]
+    fn trim_catalog_keeps_the_lowest_context_tier() {
+        let api_json = serde_json::json!({
+            "openai": {
+                "models": {
+                    "gpt-test": {"cost": {
+                        "input": 4.0, "output": 20.0, "cache_read": 0.4,
+                        "tiers": [
+                            {"input": 16.0, "output": 60.0, "tier": {"type": "context", "size": 544000}},
+                            {"input": 8.0, "output": 30.0, "cache_read": 0.8, "tier": {"type": "context", "size": 272000}},
+                            {"input": 99.0, "output": 99.0, "tier": {"type": "tokens", "size": 100}},
+                            {"input": 99.0, "output": 99.0, "tier": {"type": "context", "size": 0}}
+                        ]
+                    }}
+                }
+            }
+        })
+        .to_string();
+
+        let pricing = &trim_catalog(&api_json).unwrap()["gpt-test"];
+        // Two context bands: the lowest threshold wins (one above-base band —
+        // keeping the higher one would price everything between the two
+        // thresholds at the base rate). Non-context and zero-size bounds are
+        // not usable as a token threshold.
+        assert_eq!(pricing.long_context_threshold, Some(272_000));
+        assert_eq!(pricing.input_above, Some(8.0));
+        assert_eq!(pricing.output_above, Some(30.0));
+        assert_eq!(pricing.cache_read_above, Some(0.8));
+        assert_eq!(pricing.cache_write_above, None);
+    }
+
+    #[test]
+    fn fast_multipliers_attach_exactly_and_by_prefix() {
+        let api_json = serde_json::json!({
+            "openai": {
+                "models": {
+                    "gpt-5.5": {"cost": {"input": 5.0, "output": 30.0}},
+                    "gpt-5.5-pro": {"cost": {"input": 30.0, "output": 180.0}}
+                }
+            },
+            "anthropic": {
+                "models": {
+                    "claude-opus-4-6": {"cost": {"input": 5.0, "output": 25.0}},
+                    "claude-opus-4-6-20260205": {"cost": {"input": 5.0, "output": 25.0}},
+                    "claude-fable-5": {"cost": {"input": 10.0, "output": 50.0}}
+                }
+            }
+        })
+        .to_string();
+
+        let entries = trim_catalog(&api_json).unwrap();
+        assert_eq!(entries["gpt-5.5"].fast_multiplier, 2.5);
+        // gpt entries are exact-only: the pro variant has its own pricing and
+        // no published fast tier.
+        assert_eq!(entries["gpt-5.5-pro"].fast_multiplier, 1.0);
+        assert_eq!(entries["claude-opus-4-6"].fast_multiplier, 6.0);
+        // Prefix entries cover date-suffixed spellings of the base model.
+        assert_eq!(entries["claude-opus-4-6-20260205"].fast_multiplier, 6.0);
+        assert_eq!(entries["claude-fable-5"].fast_multiplier, 1.0);
+    }
+
+    #[test]
+    fn claude_long_context_premium_is_stamped_when_models_dev_lacks_tiers() {
+        let api_json = serde_json::json!({
+            "anthropic": {
+                "models": {
+                    "claude-sonnet-4-6": {"cost": {
+                        "input": 3.0, "output": 15.0, "cache_read": 0.3, "cache_write": 3.75
+                    }},
+                    "claude-sonnet-4-6-20260115": {"cost": {"input": 3.0, "output": 15.0}},
+                    // A published tier must win over the hand-tracked one.
+                    "claude-opus-4-8": {"cost": {
+                        "input": 5.0, "output": 25.0,
+                        "tiers": [{"input": 11.0, "output": 40.0, "tier": {"type": "context", "size": 250000}}]
+                    }},
+                    "claude-fable-5": {"cost": {"input": 10.0, "output": 50.0}}
+                }
+            }
+        })
+        .to_string();
+
+        let entries = trim_catalog(&api_json).unwrap();
+        let sonnet = &entries["claude-sonnet-4-6"];
+        assert_eq!(sonnet.long_context_threshold, Some(200_000));
+        assert_eq!(sonnet.input_above, Some(6.0));
+        assert_eq!(sonnet.output_above, Some(22.5));
+        assert_eq!(sonnet.cache_read_above, Some(0.6));
+        assert_eq!(sonnet.cache_write_above, Some(7.5));
+        assert_eq!(
+            entries["claude-sonnet-4-6-20260115"].long_context_threshold,
+            Some(200_000),
+            "date-suffixed spellings inherit the premium"
+        );
+        let opus = &entries["claude-opus-4-8"];
+        assert_eq!(opus.long_context_threshold, Some(250_000));
+        assert_eq!(opus.input_above, Some(11.0));
+        assert_eq!(
+            entries["claude-fable-5"].long_context_threshold, None,
+            "models without a tracked premium stay flat"
+        );
+    }
+
+    #[test]
+    fn flat_snapshot_json_without_tier_fields_still_parses() {
+        // The pre-tier snapshot/cache format: plain rates, no tier fields.
+        let catalog = PricingCatalog::from_snapshot_json(
+            r#"{"claude-test-1": {"input": 1.0, "output": 2.0, "cache_read": 0.1, "cache_write": 1.25}}"#,
+        )
+        .unwrap();
+        let pricing = catalog.pricing_for("claude-test-1").unwrap();
+        assert_eq!(pricing.cache_read, Some(0.1));
+        assert_eq!(pricing.long_context_threshold, None);
+        assert_eq!(pricing.fast_multiplier, 1.0);
+    }
+
+    #[test]
+    fn embedded_snapshot_carries_tiers_and_fast_multipliers() {
+        let catalog = embedded_catalog();
+        let sol = catalog.pricing_for("gpt-5.6-sol").unwrap();
+        assert_eq!(sol.long_context_threshold, Some(272_000));
+        assert!(sol.input_above.is_some());
+        assert_eq!(sol.fast_multiplier, 2.0);
+        let sonnet = catalog.pricing_for("claude-sonnet-4-6").unwrap();
+        assert_eq!(sonnet.long_context_threshold, Some(200_000));
+        assert_eq!(sonnet.input_above, Some(6.0));
+        let opus = catalog.pricing_for("claude-opus-4-8").unwrap();
+        assert_eq!(opus.fast_multiplier, 2.0);
+        assert_eq!(opus.long_context_threshold, Some(200_000));
+        let fable = catalog.pricing_for("claude-fable-5").unwrap();
+        assert_eq!(fable.fast_multiplier, 1.0);
+        assert_eq!(fable.long_context_threshold, None);
     }
 
     #[test]
@@ -460,8 +829,9 @@ mod tests {
             ModelPricing {
                 input: 10.0,
                 output: 50.0,
-                cache_read: 1.0,
-                cache_write: 12.5,
+                cache_read: Some(1.0),
+                cache_write: Some(12.5),
+                ..Default::default()
             },
         );
         models

--- a/src/metrics/model_pricing.rs
+++ b/src/metrics/model_pricing.rs
@@ -23,7 +23,7 @@
 //! and a fast/priority speed multiplier. Neither vendors nor models.dev
 //! publish fast-tier pricing, and models.dev's first-party Anthropic entries
 //! omit their long-context tiers, so both are hand-tracked in override
-//! tables below, applied when the catalog is trimmed.
+//! tables below, applied when a catalog is loaded.
 
 use crate::utils::{read_json_file, unix_timestamp_now, write_json_file};
 use serde::{Deserialize, Serialize};
@@ -477,7 +477,7 @@ impl ModelsDevCost {
             .as_array()
             .into_iter()
             .flatten()
-            .filter_map(|band| serde_json::from_value::<ModelsDevTier>(band.clone()).ok())
+            .filter_map(|band| ModelsDevTier::deserialize(band).ok())
             .filter_map(|tier| {
                 let bound = tier.tier.as_ref()?;
                 if bound.kind.as_deref() != Some("context") {
@@ -498,11 +498,15 @@ impl ModelsDevCost {
 /// The override value whose key matches `model_id` exactly or as a
 /// token-boundary prefix ("claude-opus-4-6" also covers
 /// "claude-opus-4-6-20260205"). Catalog ids carry no provider prefixes, so
-/// the boundary-containment helper is an exact-or-prefix match here.
+/// the boundary-containment helper is an exact-or-prefix match here. The
+/// longest matching key wins (like [`PricingCatalog::pricing_for`]'s fuzzy
+/// arm): "claude-sonnet-4" also prefixes "claude-sonnet-4-5", so first-match
+/// would silently shadow the more specific row.
 fn prefix_override<T: Copy>(overrides: &[(&str, T)], model_id: &str) -> Option<T> {
     overrides
         .iter()
-        .find(|(base, _)| contains_at_token_boundary(model_id, base))
+        .filter(|(base, _)| contains_at_token_boundary(model_id, base))
+        .max_by_key(|(base, _)| base.len())
         .map(|(_, value)| *value)
 }
 
@@ -838,6 +842,21 @@ mod tests {
                 .fast_multiplier,
             1.0
         );
+    }
+
+    #[test]
+    fn prefix_override_prefers_the_longest_matching_key() {
+        // "claude-sonnet-4" also token-boundary-prefixes "claude-sonnet-4-5":
+        // a more specific row must win regardless of table order, or edits to
+        // it are silently shadowed (CLAUDE_LONG_CONTEXT_PREFIX lists both).
+        let overrides = [("claude-sonnet-4", 1.0), ("claude-sonnet-4-5", 2.0)];
+        assert_eq!(prefix_override(&overrides, "claude-sonnet-4-5"), Some(2.0));
+        assert_eq!(
+            prefix_override(&overrides, "claude-sonnet-4-5-20260601"),
+            Some(2.0)
+        );
+        assert_eq!(prefix_override(&overrides, "claude-sonnet-4"), Some(1.0));
+        assert_eq!(prefix_override(&overrides, "claude-opus-4"), None);
     }
 
     #[test]

--- a/src/metrics/model_pricing.rs
+++ b/src/metrics/model_pricing.rs
@@ -95,7 +95,10 @@ const FAST_MULTIPLIER_PREFIX: [(&str, f64); 3] = [
 /// only records these tiers under gateway spellings (google-vertex, azure)
 /// that the provider allowlist drops, so they are hand-tracked here and
 /// stamped onto first-party entries that carry no tiers of their own. Prefix
-/// semantics like [`FAST_MULTIPLIER_PREFIX`].
+/// semantics like [`FAST_MULTIPLIER_PREFIX`]. Both override tables are
+/// applied when a catalog is *loaded* (not when it is fetched/trimmed), so
+/// editing them takes effect on upgrade even against a previously fetched
+/// on-disk cache.
 const CLAUDE_LONG_CONTEXT_PREFIX: [(&str, LongContextRates); 6] = [
     ("claude-sonnet-4", SONNET_LONG_CONTEXT),
     ("claude-sonnet-4-5", SONNET_LONG_CONTEXT),
@@ -138,7 +141,7 @@ struct LongContextRates {
 /// describe the model's long-context tier: a request whose context exceeds
 /// the threshold bills every token at the above rate (whole-request, not
 /// marginal), falling back per-rate to the base rate when unpublished.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct ModelPricing {
     pub input: f64,
     pub output: f64,
@@ -206,7 +209,8 @@ pub struct PricingCatalog {
 }
 
 impl PricingCatalog {
-    fn from_entries(entries: BTreeMap<String, ModelPricing>) -> Self {
+    fn from_entries(mut entries: BTreeMap<String, ModelPricing>) -> Self {
+        apply_overrides(&mut entries);
         Self { entries }
     }
 
@@ -229,16 +233,20 @@ impl PricingCatalog {
     /// 3. Family fallback: ids the catalog doesn't know at all (legacy or
     ///    too new) are priced like the median-priced model of their family,
     ///    so they estimate at family rates instead of silently costing $0.
-    pub fn pricing_for(&self, model: &str) -> Option<&ModelPricing> {
+    pub fn pricing_for(&self, model: &str) -> Option<ModelPricing> {
         let model = model.to_lowercase();
         if let Some(pricing) = self.entries.get(&model) {
-            return Some(pricing);
+            return Some(*pricing);
         }
+        // A token-boundary match returns the catalog entry verbatim,
+        // including its multiplier/tier — that's how date-suffixed and
+        // variant spellings inherit their base model's data, and it matches
+        // ccusage's fuzzy lookup, which also returns full entries.
         self.entries
             .iter()
             .filter(|(id, _)| contains_at_token_boundary(&model, id))
             .max_by_key(|(id, _)| id.len())
-            .map(|(_, pricing)| pricing)
+            .map(|(_, pricing)| *pricing)
             .or_else(|| self.family_fallback(&model))
     }
 
@@ -247,7 +255,7 @@ impl PricingCatalog {
     /// gives a representative family rate that's robust to outliers in either
     /// direction — legacy expensive entries (gpt-4 at ~24x gpt-5's input
     /// rate) as much as nano/mini variants — without parsing version numbers.
-    fn family_fallback(&self, model: &str) -> Option<&ModelPricing> {
+    fn family_fallback(&self, model: &str) -> Option<ModelPricing> {
         let token = FAMILY_FALLBACK_TOKENS
             .iter()
             .find(|token| contains_at_token_boundary(model, token))?;
@@ -262,7 +270,21 @@ impl PricingCatalog {
                 .then(a.output.total_cmp(&b.output))
                 .then(id_a.cmp(id_b))
         });
-        family.get(family.len() / 2).map(|(_, pricing)| *pricing)
+        // A family-median ESTIMATE must not inherit one specific model's
+        // hand-tracked fast multiplier or long-context tier: an unknown
+        // fast-tier model would otherwise bill at up to 6x the median rate
+        // and corrupt the emitted long-context splits.
+        family
+            .get(family.len() / 2)
+            .map(|(_, pricing)| ModelPricing {
+                long_context_threshold: None,
+                input_above: None,
+                output_above: None,
+                cache_read_above: None,
+                cache_write_above: None,
+                fast_multiplier: 1.0,
+                ..**pricing
+            })
     }
 }
 
@@ -287,8 +309,8 @@ fn contains_at_token_boundary(haystack: &str, needle: &str) -> bool {
 /// present, embedded snapshot otherwise). Memoized per distinct id: misses of
 /// the exact-match fast path scan the catalog linearly, and callers invoke
 /// this once per recorded message.
-pub fn pricing_for(model: &str) -> Option<&'static ModelPricing> {
-    static MEMO: OnceLock<Mutex<HashMap<String, Option<&'static ModelPricing>>>> = OnceLock::new();
+pub fn pricing_for(model: &str) -> Option<ModelPricing> {
+    static MEMO: OnceLock<Mutex<HashMap<String, Option<ModelPricing>>>> = OnceLock::new();
     let memo = MEMO.get_or_init(|| Mutex::new(HashMap::new()));
     if let Ok(cache) = memo.lock()
         && let Some(cached) = cache.get(model)
@@ -415,7 +437,10 @@ fn fetch_and_trim_catalog() -> Result<BTreeMap<String, ModelPricing>, String> {
 }
 
 /// A model's `cost` object as models.dev publishes it. Unlike [`ModelPricing`]
-/// it may lack input/output (skipped) and carries tier bands verbatim.
+/// it may lack input/output (skipped) and carries tier bands verbatim. Tiers
+/// are held as raw JSON and parsed per band, so one novel-shaped band (or a
+/// non-array `tiers`) degrades that model to its flat rates instead of
+/// silently dropping it from the catalog.
 #[derive(Deserialize)]
 struct ModelsDevCost {
     input: Option<f64>,
@@ -423,7 +448,7 @@ struct ModelsDevCost {
     cache_read: Option<f64>,
     cache_write: Option<f64>,
     #[serde(default)]
-    tiers: Vec<ModelsDevTier>,
+    tiers: serde_json::Value,
 }
 
 #[derive(Deserialize)]
@@ -449,7 +474,10 @@ impl ModelsDevCost {
     /// the two thresholds at the base rate (ccusage `long_context_tier`).
     fn long_context_rates(&self) -> Option<LongContextRates> {
         self.tiers
-            .iter()
+            .as_array()
+            .into_iter()
+            .flatten()
+            .filter_map(|band| serde_json::from_value::<ModelsDevTier>(band.clone()).ok())
             .filter_map(|tier| {
                 let bound = tier.tier.as_ref()?;
                 if bound.kind.as_deref() != Some("context") {
@@ -478,6 +506,26 @@ fn prefix_override<T: Copy>(overrides: &[(&str, T)], model_id: &str) -> Option<T
         .map(|(_, value)| *value)
 }
 
+/// Stamp the hand-tracked overrides onto a loaded catalog: fast multipliers
+/// always, the Claude long-context premium only where the entry publishes no
+/// tiers of its own. Runs at load time so an override edit shipped in a new
+/// binary applies even to a previously fetched cache (idempotent over caches
+/// written before this moved out of the trim step).
+fn apply_overrides(entries: &mut BTreeMap<String, ModelPricing>) {
+    for (model_id, pricing) in entries.iter_mut() {
+        pricing.fast_multiplier = fast_multiplier_override(model_id);
+        if pricing.long_context_threshold.is_none()
+            && let Some(rates) = prefix_override(&CLAUDE_LONG_CONTEXT_PREFIX, model_id)
+        {
+            pricing.long_context_threshold = Some(rates.threshold);
+            pricing.input_above = rates.input;
+            pricing.output_above = rates.output;
+            pricing.cache_read_above = rates.cache_read;
+            pricing.cache_write_above = rates.cache_write;
+        }
+    }
+}
+
 fn fast_multiplier_override(model_id: &str) -> f64 {
     FAST_MULTIPLIER_EXACT
         .iter()
@@ -488,11 +536,10 @@ fn fast_multiplier_override(model_id: &str) -> f64 {
 }
 
 /// Reduce a full models.dev `api.json` document to a flat model-id → pricing
-/// map over the provider allowlist, keeping each model's long-context tier
-/// and stamping the hand-tracked overrides (fast multipliers always; Claude
-/// long-context rates only when the entry publishes no tiers of its own).
-/// Models without a parseable cost entry (missing, or lacking input/output
-/// rates) are skipped.
+/// map over the provider allowlist, keeping each model's long-context tier.
+/// Pure models.dev data — the hand-tracked override tables are applied at
+/// load time by [`apply_overrides`]. Models without a parseable cost entry
+/// (missing, or lacking input/output rates) are skipped.
 fn trim_catalog(api_json: &str) -> Result<BTreeMap<String, ModelPricing>, String> {
     let providers: serde_json::Value = serde_json::from_str(api_json).map_err(|e| e.to_string())?;
     let mut entries = BTreeMap::new();
@@ -514,12 +561,9 @@ fn trim_catalog(api_json: &str) -> Result<BTreeMap<String, ModelPricing>, String
             let (Some(input), Some(output)) = (cost.input, cost.output) else {
                 continue;
             };
-            let model_id = model_id.to_lowercase();
-            let long_context = cost
-                .long_context_rates()
-                .or_else(|| prefix_override(&CLAUDE_LONG_CONTEXT_PREFIX, &model_id));
+            let long_context = cost.long_context_rates();
             entries.insert(
-                model_id.clone(),
+                model_id.to_lowercase(),
                 ModelPricing {
                     input,
                     output,
@@ -530,7 +574,7 @@ fn trim_catalog(api_json: &str) -> Result<BTreeMap<String, ModelPricing>, String
                     output_above: long_context.and_then(|rates| rates.output),
                     cache_read_above: long_context.and_then(|rates| rates.cache_read),
                     cache_write_above: long_context.and_then(|rates| rates.cache_write),
-                    fast_multiplier: fast_multiplier_override(&model_id),
+                    fast_multiplier: 1.0,
                 },
             );
         }
@@ -606,14 +650,20 @@ mod tests {
         // These ids are absent from the catalog (legacy, or newer than the
         // snapshot) but must estimate at family rates rather than $0. The
         // equality assertions pin the current family medians.
+        // Family fallbacks estimate at the median member's BASE rates with
+        // multipliers/tiers neutralized (see
+        // family_fallback_never_inherits_multipliers_or_tiers).
         assert_eq!(
-            catalog.pricing_for("claude-3-5-sonnet-20241022"),
-            catalog.pricing_for("claude-sonnet-4-6"),
+            catalog
+                .pricing_for("claude-3-5-sonnet-20241022")
+                .unwrap()
+                .input,
+            catalog.pricing_for("claude-sonnet-4-6").unwrap().input,
             "legacy sonnet ids price at the median sonnet rate"
         );
         assert_eq!(
-            catalog.pricing_for("claude-opus-4-1"),
-            catalog.pricing_for("claude-opus-4-7"),
+            catalog.pricing_for("claude-opus-4-1").unwrap().input,
+            catalog.pricing_for("claude-opus-4-7").unwrap().input,
             "uncataloged opus ids price at the median opus rate"
         );
         assert!(
@@ -755,14 +805,39 @@ mod tests {
         .to_string();
 
         let entries = trim_catalog(&api_json).unwrap();
-        assert_eq!(entries["gpt-5.5"].fast_multiplier, 2.5);
+        // Trim output is pure models.dev data; the override tables apply at
+        // load time so editing them takes effect against fetched caches.
+        assert_eq!(entries["gpt-5.5"].fast_multiplier, 1.0);
+        let catalog = PricingCatalog::from_entries(entries);
+        assert_eq!(catalog.pricing_for("gpt-5.5").unwrap().fast_multiplier, 2.5);
         // gpt entries are exact-only: the pro variant has its own pricing and
         // no published fast tier.
-        assert_eq!(entries["gpt-5.5-pro"].fast_multiplier, 1.0);
-        assert_eq!(entries["claude-opus-4-6"].fast_multiplier, 6.0);
+        assert_eq!(
+            catalog.pricing_for("gpt-5.5-pro").unwrap().fast_multiplier,
+            1.0
+        );
+        assert_eq!(
+            catalog
+                .pricing_for("claude-opus-4-6")
+                .unwrap()
+                .fast_multiplier,
+            6.0
+        );
         // Prefix entries cover date-suffixed spellings of the base model.
-        assert_eq!(entries["claude-opus-4-6-20260205"].fast_multiplier, 6.0);
-        assert_eq!(entries["claude-fable-5"].fast_multiplier, 1.0);
+        assert_eq!(
+            catalog
+                .pricing_for("claude-opus-4-6-20260205")
+                .unwrap()
+                .fast_multiplier,
+            6.0
+        );
+        assert_eq!(
+            catalog
+                .pricing_for("claude-fable-5")
+                .unwrap()
+                .fast_multiplier,
+            1.0
+        );
     }
 
     #[test]
@@ -786,23 +861,104 @@ mod tests {
         .to_string();
 
         let entries = trim_catalog(&api_json).unwrap();
-        let sonnet = &entries["claude-sonnet-4-6"];
+        assert_eq!(
+            entries["claude-sonnet-4-6"].long_context_threshold, None,
+            "trim output is pure models.dev data"
+        );
+        let catalog = PricingCatalog::from_entries(entries);
+        let sonnet = catalog.pricing_for("claude-sonnet-4-6").unwrap();
         assert_eq!(sonnet.long_context_threshold, Some(200_000));
         assert_eq!(sonnet.input_above, Some(6.0));
         assert_eq!(sonnet.output_above, Some(22.5));
         assert_eq!(sonnet.cache_read_above, Some(0.6));
         assert_eq!(sonnet.cache_write_above, Some(7.5));
         assert_eq!(
-            entries["claude-sonnet-4-6-20260115"].long_context_threshold,
+            catalog
+                .pricing_for("claude-sonnet-4-6-20260115")
+                .unwrap()
+                .long_context_threshold,
             Some(200_000),
             "date-suffixed spellings inherit the premium"
         );
-        let opus = &entries["claude-opus-4-8"];
-        assert_eq!(opus.long_context_threshold, Some(250_000));
+        let opus = catalog.pricing_for("claude-opus-4-8").unwrap();
+        assert_eq!(
+            opus.long_context_threshold,
+            Some(250_000),
+            "published tier wins"
+        );
         assert_eq!(opus.input_above, Some(11.0));
         assert_eq!(
-            entries["claude-fable-5"].long_context_threshold, None,
+            catalog
+                .pricing_for("claude-fable-5")
+                .unwrap()
+                .long_context_threshold,
+            None,
             "models without a tracked premium stay flat"
+        );
+    }
+
+    #[test]
+    fn family_fallback_never_inherits_multipliers_or_tiers() {
+        // A family-median ESTIMATE must not carry a specific model's
+        // hand-tracked fast multiplier or long-context tier: an unknown
+        // fast-tier opus id would otherwise bill 6x and flip the
+        // long-context split.
+        let catalog = embedded_catalog();
+        let fallback = catalog.pricing_for("claude-opus-4-1").unwrap();
+        assert_eq!(fallback.fast_multiplier, 1.0);
+        assert_eq!(fallback.long_context_threshold, None);
+        assert_eq!(fallback.input_above, None);
+        let median = catalog.pricing_for("claude-opus-4-7").unwrap();
+        assert_eq!(fallback.input, median.input);
+        assert_eq!(fallback.output, median.output);
+    }
+
+    #[test]
+    fn overrides_apply_idempotently_over_pre_split_caches() {
+        // A current-format cache written before overrides moved to load time
+        // carries them baked in; re-applying at load must be a no-op, and an
+        // override-table edit must win over the baked value.
+        let mut baked = BTreeMap::new();
+        baked.insert(
+            "claude-opus-4-8".to_string(),
+            ModelPricing {
+                input: 5.0,
+                output: 25.0,
+                long_context_threshold: Some(200_000),
+                input_above: Some(10.0),
+                fast_multiplier: 2.0,
+                ..Default::default()
+            },
+        );
+        let catalog = PricingCatalog::from_entries(baked);
+        let pricing = catalog.pricing_for("claude-opus-4-8").unwrap();
+        assert_eq!(pricing.fast_multiplier, 2.0);
+        assert_eq!(pricing.long_context_threshold, Some(200_000));
+        assert_eq!(pricing.input_above, Some(10.0), "baked tier kept as-is");
+    }
+
+    #[test]
+    fn one_malformed_tier_band_degrades_to_flat_rates_not_a_dropped_model() {
+        let api_json = serde_json::json!({
+            "openai": {
+                "models": {
+                    "gpt-null-tiers": {"cost": {"input": 4.0, "output": 20.0, "tiers": null}},
+                    "gpt-odd-band": {"cost": {
+                        "input": 4.0, "output": 20.0,
+                        "tiers": ["surprise", {"input": 8.0, "output": 30.0, "tier": {"type": "context", "size": 272000}}]
+                    }}
+                }
+            }
+        })
+        .to_string();
+        let entries = trim_catalog(&api_json).unwrap();
+        // Novel-shaped tier data must not drop the model (flat rates parse),
+        // and parseable bands next to a malformed one still apply.
+        assert_eq!(entries["gpt-null-tiers"].input, 4.0);
+        assert_eq!(entries["gpt-null-tiers"].long_context_threshold, None);
+        assert_eq!(
+            entries["gpt-odd-band"].long_context_threshold,
+            Some(272_000)
         );
     }
 

--- a/src/metrics/models_dev_pricing_snapshot.json
+++ b/src/metrics/models_dev_pricing_snapshot.json
@@ -33,19 +33,37 @@
     "input": 5.0,
     "output": 25.0,
     "cache_read": 0.5,
-    "cache_write": 6.25
+    "cache_write": 6.25,
+    "long_context_threshold": 200000,
+    "input_above": 10.0,
+    "output_above": 37.5,
+    "cache_read_above": 1.0,
+    "cache_write_above": 12.5,
+    "fast_multiplier": 6.0
   },
   "claude-opus-4-7": {
     "input": 5.0,
     "output": 25.0,
     "cache_read": 0.5,
-    "cache_write": 6.25
+    "cache_write": 6.25,
+    "long_context_threshold": 200000,
+    "input_above": 10.0,
+    "output_above": 37.5,
+    "cache_read_above": 1.0,
+    "cache_write_above": 12.5,
+    "fast_multiplier": 6.0
   },
   "claude-opus-4-8": {
     "input": 5.0,
     "output": 25.0,
     "cache_read": 0.5,
-    "cache_write": 6.25
+    "cache_write": 6.25,
+    "long_context_threshold": 200000,
+    "input_above": 10.0,
+    "output_above": 37.5,
+    "cache_read_above": 1.0,
+    "cache_write_above": 12.5,
+    "fast_multiplier": 2.0
   },
   "claude-opus-5": {
     "input": 5.0,
@@ -57,19 +75,34 @@
     "input": 3.0,
     "output": 15.0,
     "cache_read": 0.3,
-    "cache_write": 3.75
+    "cache_write": 3.75,
+    "long_context_threshold": 200000,
+    "input_above": 6.0,
+    "output_above": 22.5,
+    "cache_read_above": 0.6,
+    "cache_write_above": 7.5
   },
   "claude-sonnet-4-5-20250929": {
     "input": 3.0,
     "output": 15.0,
     "cache_read": 0.3,
-    "cache_write": 3.75
+    "cache_write": 3.75,
+    "long_context_threshold": 200000,
+    "input_above": 6.0,
+    "output_above": 22.5,
+    "cache_read_above": 0.6,
+    "cache_write_above": 7.5
   },
   "claude-sonnet-4-6": {
     "input": 3.0,
     "output": 15.0,
     "cache_read": 0.3,
-    "cache_write": 3.75
+    "cache_write": 3.75,
+    "long_context_threshold": 200000,
+    "input_above": 6.0,
+    "output_above": 22.5,
+    "cache_read_above": 0.6,
+    "cache_write_above": 7.5
   },
   "claude-sonnet-5": {
     "input": 2.0,
@@ -79,261 +112,214 @@
   },
   "codestral-latest": {
     "input": 0.3,
-    "output": 0.9,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "output": 0.9
   },
   "deep-research-max-preview-04-2026": {
     "input": 2.0,
     "output": 12.0,
     "cache_read": 0.2,
-    "cache_write": 0.0
+    "long_context_threshold": 200000,
+    "input_above": 4.0,
+    "output_above": 18.0,
+    "cache_read_above": 0.4
   },
   "deep-research-preview-04-2026": {
     "input": 2.0,
     "output": 12.0,
     "cache_read": 0.2,
-    "cache_write": 0.0
-  },
-  "deepseek-chat": {
-    "input": 0.14,
-    "output": 0.28,
-    "cache_read": 0.0028,
-    "cache_write": 0.0
-  },
-  "deepseek-reasoner": {
-    "input": 0.14,
-    "output": 0.28,
-    "cache_read": 0.0028,
-    "cache_write": 0.0
+    "long_context_threshold": 200000,
+    "input_above": 4.0,
+    "output_above": 18.0,
+    "cache_read_above": 0.4
   },
   "deepseek-v4-flash": {
     "input": 0.14,
     "output": 0.28,
-    "cache_read": 0.0028,
-    "cache_write": 0.0
+    "cache_read": 0.0028
+  },
+  "deepseek-v4-flash-vision-exp": {
+    "input": 0.14,
+    "output": 0.28,
+    "cache_read": 0.0028
   },
   "deepseek-v4-pro": {
     "input": 0.435,
     "output": 0.87,
-    "cache_read": 0.003625,
-    "cache_write": 0.0
+    "cache_read": 0.003625
   },
   "devstral-2512": {
     "input": 0.4,
-    "output": 2.0,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "output": 2.0
   },
   "devstral-latest": {
     "input": 0.4,
-    "output": 2.0,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "output": 2.0
   },
   "devstral-medium-2507": {
     "input": 0.4,
-    "output": 2.0,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "output": 2.0
   },
   "devstral-medium-latest": {
     "input": 0.4,
-    "output": 2.0,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "output": 2.0
   },
   "devstral-small-2505": {
     "input": 0.1,
-    "output": 0.3,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "output": 0.3
   },
   "devstral-small-2507": {
     "input": 0.1,
-    "output": 0.3,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "output": 0.3
   },
   "gemini-2.5-computer-use-preview-10-2025": {
     "input": 1.25,
     "output": 10.0,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "long_context_threshold": 200000,
+    "input_above": 2.5,
+    "output_above": 15.0
   },
   "gemini-2.5-flash": {
     "input": 0.3,
     "output": 2.5,
-    "cache_read": 0.03,
-    "cache_write": 0.0
+    "cache_read": 0.03
   },
   "gemini-2.5-flash-image": {
     "input": 0.3,
     "output": 30.0,
-    "cache_read": 0.075,
-    "cache_write": 0.0
+    "cache_read": 0.075
   },
   "gemini-2.5-flash-lite": {
     "input": 0.1,
     "output": 0.4,
-    "cache_read": 0.01,
-    "cache_write": 0.0
+    "cache_read": 0.01
   },
   "gemini-2.5-flash-preview-tts": {
     "input": 0.5,
-    "output": 10.0,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "output": 10.0
   },
   "gemini-2.5-pro": {
     "input": 1.25,
     "output": 10.0,
     "cache_read": 0.125,
-    "cache_write": 0.0
+    "long_context_threshold": 200000,
+    "input_above": 2.5,
+    "output_above": 15.0,
+    "cache_read_above": 0.25
   },
   "gemini-2.5-pro-preview-tts": {
     "input": 1.0,
-    "output": 20.0,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "output": 20.0
   },
   "gemini-3-flash-preview": {
     "input": 0.5,
     "output": 3.0,
-    "cache_read": 0.05,
-    "cache_write": 0.0
+    "cache_read": 0.05
   },
   "gemini-3-pro-image": {
     "input": 2.0,
-    "output": 120.0,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "output": 120.0
   },
   "gemini-3-pro-image-preview": {
     "input": 2.0,
-    "output": 120.0,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "output": 120.0
   },
   "gemini-3.1-flash-image": {
     "input": 0.5,
-    "output": 60.0,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "output": 60.0
   },
   "gemini-3.1-flash-image-preview": {
     "input": 0.5,
-    "output": 60.0,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "output": 60.0
   },
   "gemini-3.1-flash-lite": {
     "input": 0.25,
     "output": 1.5,
-    "cache_read": 0.025,
-    "cache_write": 0.0
+    "cache_read": 0.025
   },
   "gemini-3.1-flash-lite-image": {
     "input": 0.25,
-    "output": 30.0,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "output": 30.0
   },
   "gemini-3.1-flash-lite-preview": {
     "input": 0.25,
     "output": 1.5,
-    "cache_read": 0.025,
-    "cache_write": 0.0
+    "cache_read": 0.025
   },
   "gemini-3.1-flash-live-preview": {
     "input": 0.75,
-    "output": 4.5,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "output": 4.5
   },
   "gemini-3.1-flash-tts-preview": {
     "input": 1.0,
-    "output": 20.0,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "output": 20.0
   },
   "gemini-3.1-pro-preview": {
     "input": 2.0,
     "output": 12.0,
     "cache_read": 0.2,
-    "cache_write": 0.0
+    "long_context_threshold": 200000,
+    "input_above": 4.0,
+    "output_above": 18.0,
+    "cache_read_above": 0.4
   },
   "gemini-3.1-pro-preview-customtools": {
     "input": 2.0,
     "output": 12.0,
     "cache_read": 0.2,
-    "cache_write": 0.0
+    "long_context_threshold": 200000,
+    "input_above": 4.0,
+    "output_above": 18.0,
+    "cache_read_above": 0.4
   },
   "gemini-3.5-flash": {
     "input": 1.5,
     "output": 9.0,
-    "cache_read": 0.15,
-    "cache_write": 0.0
+    "cache_read": 0.15
   },
   "gemini-3.5-flash-lite": {
     "input": 0.3,
     "output": 2.5,
-    "cache_read": 0.03,
-    "cache_write": 0.0
+    "cache_read": 0.03
   },
   "gemini-3.5-live-translate-preview": {
     "input": 3.5,
-    "output": 21.0,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "output": 21.0
   },
   "gemini-3.6-flash": {
-    "input": 1.5,
-    "output": 7.5,
-    "cache_read": 0.15,
-    "cache_write": 0.0
+    "input": 0.75,
+    "output": 3.75,
+    "cache_read": 0.075
   },
   "gemini-3.7-flash": {
     "input": 0.75,
     "output": 3.75,
-    "cache_read": 0.075,
-    "cache_write": 0.0
+    "cache_read": 0.075
   },
   "gemini-embedding-001": {
     "input": 0.15,
-    "output": 0.0,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "output": 0.0
   },
   "gemini-embedding-2": {
     "input": 0.2,
-    "output": 0.0,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "output": 0.0
   },
   "gemini-flash-latest": {
-    "input": 1.5,
-    "output": 9.0,
-    "cache_read": 0.15,
-    "cache_write": 0.0
+    "input": 0.75,
+    "output": 3.75,
+    "cache_read": 0.075
   },
   "gemini-flash-lite-latest": {
-    "input": 0.25,
-    "output": 1.5,
-    "cache_read": 0.025,
-    "cache_write": 0.0
+    "input": 0.3,
+    "output": 2.5,
+    "cache_read": 0.03
   },
   "gemini-omni-flash-preview": {
     "input": 1.5,
-    "output": 17.5,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "output": 17.5
   },
   "gemini-robotics-er-1.6-preview": {
     "input": 1.0,
-    "output": 5.0,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "output": 5.0
   },
   "glm-4.5": {
     "input": 0.6,
@@ -355,9 +341,7 @@
   },
   "glm-4.5v": {
     "input": 0.6,
-    "output": 1.8,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "output": 1.8
   },
   "glm-4.6": {
     "input": 0.6,
@@ -367,9 +351,7 @@
   },
   "glm-4.6v": {
     "input": 0.3,
-    "output": 0.9,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "output": 0.9
   },
   "glm-4.7": {
     "input": 0.6,
@@ -413,6 +395,18 @@
     "cache_read": 0.26,
     "cache_write": 0.0
   },
+  "glm-5.3": {
+    "input": 1.4,
+    "output": 4.4,
+    "cache_read": 0.26,
+    "cache_write": 0.0
+  },
+  "glm-5.3-flash": {
+    "input": 0.075,
+    "output": 0.25,
+    "cache_read": 0.015,
+    "cache_write": 0.0
+  },
   "glm-5v-turbo": {
     "input": 1.2,
     "output": 4.0,
@@ -422,517 +416,470 @@
   "gpt-3.5-turbo": {
     "input": 0.5,
     "output": 1.5,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "cache_read": 0.0
   },
   "gpt-4": {
     "input": 30.0,
-    "output": 60.0,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "output": 60.0
   },
   "gpt-4-turbo": {
     "input": 10.0,
-    "output": 30.0,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "output": 30.0
   },
   "gpt-4.1": {
     "input": 2.0,
     "output": 8.0,
-    "cache_read": 0.5,
-    "cache_write": 0.0
+    "cache_read": 0.5
   },
   "gpt-4.1-mini": {
     "input": 0.4,
     "output": 1.6,
-    "cache_read": 0.1,
-    "cache_write": 0.0
+    "cache_read": 0.1
   },
   "gpt-4.1-nano": {
     "input": 0.1,
     "output": 0.4,
-    "cache_read": 0.025,
-    "cache_write": 0.0
+    "cache_read": 0.025
   },
   "gpt-4o": {
     "input": 2.5,
     "output": 10.0,
-    "cache_read": 1.25,
-    "cache_write": 0.0
+    "cache_read": 1.25
   },
   "gpt-4o-2024-05-13": {
     "input": 5.0,
-    "output": 15.0,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "output": 15.0
   },
   "gpt-4o-2024-08-06": {
     "input": 2.5,
     "output": 10.0,
-    "cache_read": 1.25,
-    "cache_write": 0.0
+    "cache_read": 1.25
   },
   "gpt-4o-2024-11-20": {
     "input": 2.5,
     "output": 10.0,
-    "cache_read": 1.25,
-    "cache_write": 0.0
+    "cache_read": 1.25
   },
   "gpt-4o-mini": {
     "input": 0.15,
     "output": 0.6,
-    "cache_read": 0.075,
-    "cache_write": 0.0
+    "cache_read": 0.075
   },
   "gpt-5": {
     "input": 1.25,
     "output": 10.0,
-    "cache_read": 0.125,
-    "cache_write": 0.0
+    "cache_read": 0.125
   },
   "gpt-5-mini": {
     "input": 0.25,
     "output": 2.0,
-    "cache_read": 0.025,
-    "cache_write": 0.0
+    "cache_read": 0.025
   },
   "gpt-5-nano": {
     "input": 0.05,
     "output": 0.4,
-    "cache_read": 0.005,
-    "cache_write": 0.0
+    "cache_read": 0.005
   },
   "gpt-5-pro": {
     "input": 15.0,
-    "output": 120.0,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "output": 120.0
   },
   "gpt-5.1": {
     "input": 1.25,
     "output": 10.0,
-    "cache_read": 0.125,
-    "cache_write": 0.0
+    "cache_read": 0.125
   },
   "gpt-5.2": {
     "input": 1.75,
     "output": 14.0,
-    "cache_read": 0.175,
-    "cache_write": 0.0
+    "cache_read": 0.175
   },
   "gpt-5.2-chat-latest": {
     "input": 1.75,
     "output": 14.0,
-    "cache_read": 0.175,
-    "cache_write": 0.0
+    "cache_read": 0.175
   },
   "gpt-5.2-pro": {
     "input": 21.0,
-    "output": 168.0,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "output": 168.0
   },
   "gpt-5.3-chat-latest": {
     "input": 1.75,
     "output": 14.0,
-    "cache_read": 0.175,
-    "cache_write": 0.0
+    "cache_read": 0.175
   },
   "gpt-5.3-codex": {
     "input": 1.75,
     "output": 14.0,
     "cache_read": 0.175,
-    "cache_write": 0.0
+    "fast_multiplier": 2.0
   },
   "gpt-5.3-codex-spark": {
     "input": 1.75,
     "output": 14.0,
-    "cache_read": 0.175,
-    "cache_write": 0.0
+    "cache_read": 0.175
   },
   "gpt-5.4": {
     "input": 2.5,
     "output": 15.0,
     "cache_read": 0.25,
-    "cache_write": 0.0
+    "long_context_threshold": 272000,
+    "input_above": 5.0,
+    "output_above": 22.5,
+    "cache_read_above": 0.5,
+    "fast_multiplier": 2.0
   },
   "gpt-5.4-mini": {
     "input": 0.75,
     "output": 4.5,
-    "cache_read": 0.075,
-    "cache_write": 0.0
+    "cache_read": 0.075
   },
   "gpt-5.4-nano": {
     "input": 0.2,
     "output": 1.25,
-    "cache_read": 0.02,
-    "cache_write": 0.0
+    "cache_read": 0.02
   },
   "gpt-5.4-pro": {
     "input": 30.0,
     "output": 180.0,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "long_context_threshold": 272000,
+    "input_above": 60.0,
+    "output_above": 270.0
   },
   "gpt-5.5": {
     "input": 5.0,
     "output": 30.0,
     "cache_read": 0.5,
-    "cache_write": 0.0
+    "long_context_threshold": 272000,
+    "input_above": 10.0,
+    "output_above": 45.0,
+    "cache_read_above": 1.0,
+    "fast_multiplier": 2.5
   },
   "gpt-5.5-pro": {
     "input": 30.0,
     "output": 180.0,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "long_context_threshold": 272000,
+    "input_above": 60.0,
+    "output_above": 270.0
   },
   "gpt-5.6": {
-    "input": 5.0,
-    "output": 30.0,
-    "cache_read": 0.5,
-    "cache_write": 6.25
+    "input": 4.0,
+    "output": 20.0,
+    "cache_read": 0.4,
+    "cache_write": 5.0,
+    "long_context_threshold": 272000,
+    "input_above": 8.0,
+    "output_above": 30.0,
+    "cache_read_above": 0.8,
+    "cache_write_above": 10.0
   },
   "gpt-5.6-luna": {
     "input": 0.2,
     "output": 1.2,
     "cache_read": 0.02,
-    "cache_write": 0.25
+    "cache_write": 0.25,
+    "long_context_threshold": 272000,
+    "input_above": 0.4,
+    "output_above": 1.8,
+    "cache_read_above": 0.04,
+    "cache_write_above": 0.5,
+    "fast_multiplier": 2.0
   },
   "gpt-5.6-sol": {
-    "input": 5.0,
-    "output": 30.0,
-    "cache_read": 0.5,
-    "cache_write": 6.25
+    "input": 4.0,
+    "output": 20.0,
+    "cache_read": 0.4,
+    "cache_write": 5.0,
+    "long_context_threshold": 272000,
+    "input_above": 8.0,
+    "output_above": 30.0,
+    "cache_read_above": 0.8,
+    "cache_write_above": 10.0,
+    "fast_multiplier": 2.0
   },
   "gpt-5.6-terra": {
     "input": 2.0,
     "output": 12.0,
     "cache_read": 0.2,
-    "cache_write": 2.5
+    "cache_write": 2.5,
+    "long_context_threshold": 272000,
+    "input_above": 4.0,
+    "output_above": 18.0,
+    "cache_read_above": 0.4,
+    "cache_write_above": 5.0,
+    "fast_multiplier": 2.0
   },
   "gpt-image-2": {
     "input": 5.0,
     "output": 30.0,
-    "cache_read": 1.25,
-    "cache_write": 0.0
+    "cache_read": 1.25
   },
   "gpt-realtime-2.1": {
     "input": 4.0,
     "output": 24.0,
-    "cache_read": 0.4,
-    "cache_write": 0.0
+    "cache_read": 0.4
   },
   "grok-4.20-0309-non-reasoning": {
     "input": 1.25,
     "output": 2.5,
     "cache_read": 0.2,
-    "cache_write": 0.0
+    "long_context_threshold": 200000,
+    "input_above": 2.5,
+    "output_above": 5.0,
+    "cache_read_above": 0.4
   },
   "grok-4.20-0309-reasoning": {
     "input": 1.25,
     "output": 2.5,
     "cache_read": 0.2,
-    "cache_write": 0.0
+    "long_context_threshold": 200000,
+    "input_above": 2.5,
+    "output_above": 5.0,
+    "cache_read_above": 0.4
   },
   "grok-4.20-multi-agent-0309": {
     "input": 1.25,
     "output": 2.5,
     "cache_read": 0.2,
-    "cache_write": 0.0
+    "long_context_threshold": 200000,
+    "input_above": 2.5,
+    "output_above": 5.0,
+    "cache_read_above": 0.4
   },
   "grok-4.3": {
     "input": 1.25,
     "output": 2.5,
     "cache_read": 0.2,
-    "cache_write": 0.0
+    "long_context_threshold": 200000,
+    "input_above": 2.5,
+    "output_above": 5.0,
+    "cache_read_above": 0.4
   },
   "grok-4.5": {
     "input": 2.0,
     "output": 6.0,
     "cache_read": 0.3,
-    "cache_write": 0.0
+    "long_context_threshold": 200000,
+    "input_above": 4.0,
+    "output_above": 12.0,
+    "cache_read_above": 0.6
   },
   "grok-4.6": {
     "input": 2.0,
     "output": 6.0,
     "cache_read": 0.5,
-    "cache_write": 0.0
+    "long_context_threshold": 200000,
+    "input_above": 4.0,
+    "output_above": 12.0,
+    "cache_read_above": 1.0
   },
   "grok-build-0.1": {
     "input": 1.0,
     "output": 2.0,
     "cache_read": 0.2,
-    "cache_write": 0.0
+    "long_context_threshold": 200000,
+    "input_above": 2.0,
+    "output_above": 4.0,
+    "cache_read_above": 0.4
   },
   "kimi-k2-0711-preview": {
     "input": 0.6,
     "output": 2.5,
-    "cache_read": 0.15,
-    "cache_write": 0.0
+    "cache_read": 0.15
   },
   "kimi-k2-0905-preview": {
     "input": 0.6,
     "output": 2.5,
-    "cache_read": 0.15,
-    "cache_write": 0.0
+    "cache_read": 0.15
   },
   "kimi-k2-thinking": {
     "input": 0.6,
     "output": 2.5,
-    "cache_read": 0.15,
-    "cache_write": 0.0
+    "cache_read": 0.15
   },
   "kimi-k2-thinking-turbo": {
     "input": 1.15,
     "output": 8.0,
-    "cache_read": 0.15,
-    "cache_write": 0.0
+    "cache_read": 0.15
   },
   "kimi-k2-turbo-preview": {
     "input": 2.4,
     "output": 10.0,
-    "cache_read": 0.6,
-    "cache_write": 0.0
+    "cache_read": 0.6
   },
   "kimi-k2.5": {
     "input": 0.6,
     "output": 3.0,
-    "cache_read": 0.1,
-    "cache_write": 0.0
+    "cache_read": 0.1
   },
   "kimi-k2.6": {
     "input": 0.95,
     "output": 4.0,
-    "cache_read": 0.16,
-    "cache_write": 0.0
+    "cache_read": 0.16
   },
   "kimi-k2.7-code": {
     "input": 0.95,
     "output": 4.0,
-    "cache_read": 0.19,
-    "cache_write": 0.0
+    "cache_read": 0.19
   },
   "kimi-k2.7-code-highspeed": {
     "input": 1.9,
     "output": 8.0,
-    "cache_read": 0.38,
-    "cache_write": 0.0
+    "cache_read": 0.38
   },
   "kimi-k3": {
     "input": 3.0,
     "output": 15.0,
-    "cache_read": 0.3,
-    "cache_write": 0.0
+    "cache_read": 0.3
   },
   "labs-devstral-small-2512": {
     "input": 0.0,
-    "output": 0.0,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "output": 0.0
   },
   "lyria-3-clip-preview": {
     "input": 0.0,
-    "output": 0.0,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "output": 0.0
   },
   "lyria-3-pro-preview": {
     "input": 0.0,
-    "output": 0.0,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "output": 0.0
   },
   "magistral-medium-latest": {
     "input": 2.0,
-    "output": 5.0,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "output": 5.0
   },
   "magistral-small": {
     "input": 0.5,
-    "output": 1.5,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "output": 1.5
   },
   "ministral-3b-latest": {
     "input": 0.04,
-    "output": 0.04,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "output": 0.04
   },
   "ministral-8b-latest": {
     "input": 0.1,
-    "output": 0.1,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "output": 0.1
   },
   "mistral-embed": {
     "input": 0.1,
-    "output": 0.0,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "output": 0.0
   },
   "mistral-large-2411": {
     "input": 2.0,
-    "output": 6.0,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "output": 6.0
   },
   "mistral-large-2512": {
     "input": 0.5,
-    "output": 1.5,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "output": 1.5
   },
   "mistral-large-latest": {
     "input": 0.5,
-    "output": 1.5,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "output": 1.5
   },
   "mistral-medium-2505": {
     "input": 0.4,
-    "output": 2.0,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "output": 2.0
   },
   "mistral-medium-2508": {
     "input": 0.4,
-    "output": 2.0,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "output": 2.0
   },
   "mistral-medium-2604": {
     "input": 1.5,
-    "output": 7.5,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "output": 7.5
   },
   "mistral-medium-latest": {
     "input": 1.5,
-    "output": 7.5,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "output": 7.5
   },
   "mistral-nemo": {
     "input": 0.15,
-    "output": 0.15,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "output": 0.15
   },
   "mistral-small-2506": {
     "input": 0.1,
-    "output": 0.3,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "output": 0.3
   },
   "mistral-small-2603": {
     "input": 0.15,
-    "output": 0.6,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "output": 0.6
   },
   "mistral-small-latest": {
     "input": 0.15,
-    "output": 0.6,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "output": 0.6
   },
   "o1": {
     "input": 15.0,
     "output": 60.0,
-    "cache_read": 7.5,
-    "cache_write": 0.0
+    "cache_read": 7.5
   },
   "o1-pro": {
     "input": 150.0,
-    "output": 600.0,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "output": 600.0
   },
   "o3": {
     "input": 2.0,
     "output": 8.0,
-    "cache_read": 0.5,
-    "cache_write": 0.0
+    "cache_read": 0.5
   },
   "o3-mini": {
     "input": 1.1,
     "output": 4.4,
-    "cache_read": 0.55,
-    "cache_write": 0.0
+    "cache_read": 0.55
   },
   "o3-pro": {
     "input": 20.0,
-    "output": 80.0,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "output": 80.0
   },
   "o4-mini": {
     "input": 1.1,
     "output": 4.4,
-    "cache_read": 0.275,
-    "cache_write": 0.0
+    "cache_read": 0.275
   },
   "open-mistral-7b": {
     "input": 0.25,
-    "output": 0.25,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "output": 0.25
   },
   "open-mistral-nemo": {
     "input": 0.15,
-    "output": 0.15,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "output": 0.15
   },
   "open-mixtral-8x22b": {
     "input": 2.0,
-    "output": 6.0,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "output": 6.0
   },
   "open-mixtral-8x7b": {
     "input": 0.7,
-    "output": 0.7,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "output": 0.7
   },
   "pixtral-12b": {
     "input": 0.15,
-    "output": 0.15,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "output": 0.15
   },
   "pixtral-large-latest": {
     "input": 2.0,
-    "output": 6.0,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "output": 6.0
   },
   "text-embedding-3-large": {
     "input": 0.13,
-    "output": 0.0,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "output": 0.0
   },
   "text-embedding-3-small": {
     "input": 0.02,
-    "output": 0.0,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "output": 0.0
   },
   "text-embedding-ada-002": {
     "input": 0.1,
-    "output": 0.0,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "output": 0.0
   },
   "voxtral-small-latest": {
     "input": 0.1,
-    "output": 0.3,
-    "cache_read": 0.0,
-    "cache_write": 0.0
+    "output": 0.3
+  },
+  "zai-glm-5-2": {
+    "input": 1.4,
+    "output": 4.4,
+    "cache_read": 0.14
   }
 }

--- a/src/metrics/models_dev_pricing_snapshot.json
+++ b/src/metrics/models_dev_pricing_snapshot.json
@@ -33,37 +33,19 @@
     "input": 5.0,
     "output": 25.0,
     "cache_read": 0.5,
-    "cache_write": 6.25,
-    "long_context_threshold": 200000,
-    "input_above": 10.0,
-    "output_above": 37.5,
-    "cache_read_above": 1.0,
-    "cache_write_above": 12.5,
-    "fast_multiplier": 6.0
+    "cache_write": 6.25
   },
   "claude-opus-4-7": {
     "input": 5.0,
     "output": 25.0,
     "cache_read": 0.5,
-    "cache_write": 6.25,
-    "long_context_threshold": 200000,
-    "input_above": 10.0,
-    "output_above": 37.5,
-    "cache_read_above": 1.0,
-    "cache_write_above": 12.5,
-    "fast_multiplier": 6.0
+    "cache_write": 6.25
   },
   "claude-opus-4-8": {
     "input": 5.0,
     "output": 25.0,
     "cache_read": 0.5,
-    "cache_write": 6.25,
-    "long_context_threshold": 200000,
-    "input_above": 10.0,
-    "output_above": 37.5,
-    "cache_read_above": 1.0,
-    "cache_write_above": 12.5,
-    "fast_multiplier": 2.0
+    "cache_write": 6.25
   },
   "claude-opus-5": {
     "input": 5.0,
@@ -75,34 +57,19 @@
     "input": 3.0,
     "output": 15.0,
     "cache_read": 0.3,
-    "cache_write": 3.75,
-    "long_context_threshold": 200000,
-    "input_above": 6.0,
-    "output_above": 22.5,
-    "cache_read_above": 0.6,
-    "cache_write_above": 7.5
+    "cache_write": 3.75
   },
   "claude-sonnet-4-5-20250929": {
     "input": 3.0,
     "output": 15.0,
     "cache_read": 0.3,
-    "cache_write": 3.75,
-    "long_context_threshold": 200000,
-    "input_above": 6.0,
-    "output_above": 22.5,
-    "cache_read_above": 0.6,
-    "cache_write_above": 7.5
+    "cache_write": 3.75
   },
   "claude-sonnet-4-6": {
     "input": 3.0,
     "output": 15.0,
     "cache_read": 0.3,
-    "cache_write": 3.75,
-    "long_context_threshold": 200000,
-    "input_above": 6.0,
-    "output_above": 22.5,
-    "cache_read_above": 0.6,
-    "cache_write_above": 7.5
+    "cache_write": 3.75
   },
   "claude-sonnet-5": {
     "input": 2.0,
@@ -511,8 +478,7 @@
   "gpt-5.3-codex": {
     "input": 1.75,
     "output": 14.0,
-    "cache_read": 0.175,
-    "fast_multiplier": 2.0
+    "cache_read": 0.175
   },
   "gpt-5.3-codex-spark": {
     "input": 1.75,
@@ -526,8 +492,7 @@
     "long_context_threshold": 272000,
     "input_above": 5.0,
     "output_above": 22.5,
-    "cache_read_above": 0.5,
-    "fast_multiplier": 2.0
+    "cache_read_above": 0.5
   },
   "gpt-5.4-mini": {
     "input": 0.75,
@@ -553,8 +518,7 @@
     "long_context_threshold": 272000,
     "input_above": 10.0,
     "output_above": 45.0,
-    "cache_read_above": 1.0,
-    "fast_multiplier": 2.5
+    "cache_read_above": 1.0
   },
   "gpt-5.5-pro": {
     "input": 30.0,
@@ -583,8 +547,7 @@
     "input_above": 0.4,
     "output_above": 1.8,
     "cache_read_above": 0.04,
-    "cache_write_above": 0.5,
-    "fast_multiplier": 2.0
+    "cache_write_above": 0.5
   },
   "gpt-5.6-sol": {
     "input": 4.0,
@@ -595,8 +558,7 @@
     "input_above": 8.0,
     "output_above": 30.0,
     "cache_read_above": 0.8,
-    "cache_write_above": 10.0,
-    "fast_multiplier": 2.0
+    "cache_write_above": 10.0
   },
   "gpt-5.6-terra": {
     "input": 2.0,
@@ -607,8 +569,7 @@
     "input_above": 4.0,
     "output_above": 18.0,
     "cache_read_above": 0.4,
-    "cache_write_above": 5.0,
-    "fast_multiplier": 2.0
+    "cache_write_above": 5.0
   },
   "gpt-image-2": {
     "input": 5.0,

--- a/src/token_usage/cost.rs
+++ b/src/token_usage/cost.rs
@@ -29,7 +29,7 @@ pub fn entry_cost_micro_usd(entry: &UsageEntry) -> Option<u64> {
     if let Some(cost) = entry.transcript_cost_micro_usd {
         return Some(cost);
     }
-    Some(cost_from_pricing(entry, pricing_for(&entry.model)?))
+    Some(cost_from_pricing(entry, &pricing_for(&entry.model)?))
 }
 
 /// The catalog-pricing arm of ccusage's "auto" mode, split out so the rate
@@ -153,7 +153,7 @@ mod tests {
         assert_eq!(cost_from_pricing(&e, &no_cache_rates), micro_usd(0.2));
         let explicit = ModelPricing {
             cache_read: Some(0.5),
-            ..no_cache_rates.clone()
+            ..no_cache_rates
         };
         assert_eq!(cost_from_pricing(&e, &explicit), micro_usd(0.5));
         // An explicitly published zero rate really is free, unlike an

--- a/src/token_usage/cost.rs
+++ b/src/token_usage/cost.rs
@@ -17,12 +17,6 @@ use crate::metrics::model_pricing::pricing_for;
 /// the 5-minute TTL.
 const CACHE_WRITE_1H_INPUT_MULTIPLIER: f64 = 2.0;
 
-/// Catalog entries that omit a cache-read rate deserialize as 0.0; ccusage
-/// defaults missing cache-read pricing to a tenth of the input rate, and
-/// cache reads are the dominant Codex token class, so $0 would badly
-/// undercount.
-const CACHE_READ_INPUT_RATE_FALLBACK: f64 = 0.1;
-
 /// Sanity ceiling for a single entry's cost: $10,000. Transcript `costUSD`
 /// is attacker/corruption-controlled input; one garbled line must not
 /// inflate a bucket by millions of dollars.
@@ -48,16 +42,11 @@ fn cost_from_pricing(
         .tokens
         .cache_write
         .saturating_sub(entry.cache_write_1h);
-    let cache_read_rate = if pricing.cache_read > 0.0 {
-        pricing.cache_read
-    } else {
-        pricing.input * CACHE_READ_INPUT_RATE_FALLBACK
-    };
     let usd = (entry.tokens.input as f64 * pricing.input
         + entry.tokens.output as f64 * pricing.output
-        + cache_write_5m as f64 * pricing.cache_write
+        + cache_write_5m as f64 * pricing.cache_write_rate()
         + entry.cache_write_1h as f64 * pricing.input * CACHE_WRITE_1H_INPUT_MULTIPLIER
-        + entry.tokens.cache_read as f64 * cache_read_rate)
+        + entry.tokens.cache_read as f64 * pricing.cache_read_rate())
         / 1_000_000.0;
     micro_usd(usd)
 }
@@ -122,8 +111,8 @@ mod tests {
         let expected = micro_usd(
             pricing.input
                 + 2.0 * pricing.output
-                + 0.5 * pricing.cache_read
-                + 0.25 * pricing.cache_write,
+                + 0.5 * pricing.cache_read_rate()
+                + 0.25 * pricing.cache_write_rate(),
         );
         assert_eq!(entry_cost_micro_usd(&e), Some(expected));
     }
@@ -139,12 +128,12 @@ mod tests {
             },
         );
         e.cache_write_1h = 400_000;
-        let expected = micro_usd(0.6 * pricing.cache_write + 0.4 * pricing.input * 2.0);
+        let expected = micro_usd(0.6 * pricing.cache_write_rate() + 0.4 * pricing.input * 2.0);
         assert_eq!(entry_cost_micro_usd(&e), Some(expected));
     }
 
     #[test]
-    fn missing_cache_read_rate_falls_back_to_a_tenth_of_input() {
+    fn unpublished_cache_rates_fall_back_to_input_derived_defaults() {
         use crate::metrics::model_pricing::ModelPricing;
         let mut e = entry(
             "any-model",
@@ -154,20 +143,26 @@ mod tests {
             },
         );
         e.transcript_cost_micro_usd = None;
-        let no_cache_rate = ModelPricing {
+        let no_cache_rates = ModelPricing {
             input: 2.0,
             output: 10.0,
-            cache_read: 0.0,
-            cache_write: 0.0,
+            ..Default::default()
         };
-        // ccusage defaults missing cache-read pricing to input * 0.1; $0
+        // ccusage defaults unpublished cache-read pricing to input * 0.1; $0
         // would badly undercount cache-heavy sessions.
-        assert_eq!(cost_from_pricing(&e, &no_cache_rate), micro_usd(0.2));
+        assert_eq!(cost_from_pricing(&e, &no_cache_rates), micro_usd(0.2));
         let explicit = ModelPricing {
-            cache_read: 0.5,
-            ..no_cache_rate
+            cache_read: Some(0.5),
+            ..no_cache_rates.clone()
         };
         assert_eq!(cost_from_pricing(&e, &explicit), micro_usd(0.5));
+        // An explicitly published zero rate really is free, unlike an
+        // unpublished one.
+        let explicit_zero = ModelPricing {
+            cache_read: Some(0.0),
+            ..no_cache_rates
+        };
+        assert_eq!(cost_from_pricing(&e, &explicit_zero), 0);
     }
 
     #[test]


### PR DESCRIPTION
The catalog previously flattened models.dev to four flat rates, so
long-context tiers and fast/priority speed pricing were unpriceable
downstream. ModelPricing now carries the model's long-context band
(whole-request above-threshold rates + threshold from models.dev
cost.tiers, lowest context bound wins) and a fast-speed multiplier.

Neither vendors nor models.dev publish fast-tier pricing, and
models.dev's first-party Anthropic entries omit their long-context
premium (it only appears under gateway spellings the provider allowlist
drops), so both are hand-tracked override tables applied at trim time:
fast multipliers ported verbatim from ccusage's overrides (MIT), and
Anthropic's published 200K premium for the 1M-context sonnet/opus
models.

Cache rates become Option so unpublished rates stay distinguishable
from explicit zeros; cache_read_rate()/cache_write_rate() accessors
keep ccusage's models.dev-loader defaults (0.1x / 1.25x input). The
snapshot is regenerated with the new fields; old snapshot/cache JSON
still parses (missing fields default to None / 1.0).

Cost math is unchanged in this commit beyond the 1.25x cache-write
default for unpublished rates (cost-inert for Codex, which reports no
cache writes); consumers of the new tier fields land separately.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
