### PR TITLE
feat(token-usage): price entries with long-context tiers and fast multipliers

### DIFF
--- a/src/metrics/model_pricing.rs
+++ b/src/metrics/model_pricing.rs
@@ -334,17 +334,44 @@ fn use_embedded_only() -> bool {
 }
 
 fn catalog() -> &'static PricingCatalog {
-    static CATALOG: OnceLock<PricingCatalog> = OnceLock::new();
+    &catalog_with_id().0
+}
+
+/// Identity of the catalog in effect, stored per priced entry so emitted
+/// costs stay attributable to the rates that produced them: the running
+/// binary's version for the embedded snapshot, a content hash for a fetched
+/// cache (the cache file carries no version of its own).
+pub fn pricing_catalog_id() -> &'static str {
+    &catalog_with_id().1
+}
+
+fn catalog_with_id() -> &'static (PricingCatalog, String) {
+    static CATALOG: OnceLock<(PricingCatalog, String)> = OnceLock::new();
     CATALOG.get_or_init(|| {
         if !use_embedded_only()
             && let Some(cache) = cache_path().and_then(|path| read_json_file::<PricingCache>(&path))
             && cache.is_current_format()
             && !cache.models.is_empty()
         {
-            return PricingCatalog::from_entries(cache.models);
+            let id = format!("modelsdev:{}", catalog_hash(&cache.models));
+            return (PricingCatalog::from_entries(cache.models), id);
         }
-        embedded_catalog()
+        (
+            embedded_catalog(),
+            format!(
+                "embedded:{}",
+                crate::authorship::authorship_log_serialization::GIT_AI_VERSION
+            ),
+        )
     })
+}
+
+/// Short content hash of a fetched catalog (12 hex chars of SHA-256 over its
+/// canonical JSON — BTreeMap keys serialize in stable order).
+fn catalog_hash(models: &BTreeMap<String, ModelPricing>) -> String {
+    use sha2::{Digest, Sha256};
+    let json = serde_json::to_string(models).unwrap_or_default();
+    format!("{:x}", Sha256::digest(json.as_bytes()))[..12].to_string()
 }
 
 fn embedded_catalog() -> PricingCatalog {

--- a/src/metrics/model_pricing.rs
+++ b/src/metrics/model_pricing.rs
@@ -340,7 +340,10 @@ fn catalog() -> &'static PricingCatalog {
 /// Identity of the catalog in effect, stored per priced entry so emitted
 /// costs stay attributable to the rates that produced them: the running
 /// binary's version for the embedded snapshot, a content hash for a fetched
-/// cache (the cache file carries no version of its own).
+/// cache (the cache file carries no version of its own). The hash covers the
+/// fetched data only — the hand-tracked override tables applied at load time
+/// are compile-time constants, so the effective rates are pinned by this id
+/// *together with* the `git_ai_version` attribute every event carries.
 pub fn pricing_catalog_id() -> &'static str {
     &catalog_with_id().1
 }

--- a/src/token_usage/claude.rs
+++ b/src/token_usage/claude.rs
@@ -9,7 +9,8 @@
 //!   (entries stream in across runs), via [`should_replace_entry`] and the
 //!   `message_id` fallback; ccusage dedups in memory over whole files.
 //! - Fast-speed entries keep their base model name (no "-fast" suffix);
-//!   `usage.speed` remains the replacement tie-breaker.
+//!   `usage.speed` carries the fast pricing multiplier (see `cost.rs`) and
+//!   remains the replacement tie-breaker.
 //! - Entries whose model is missing or `<synthetic>` are attributed to
 //!   [`UNKNOWN_MODEL`] instead of carrying no model, so tokens aren't lost.
 
@@ -656,15 +657,15 @@ mod tests {
     }
 
     #[test]
-    fn fast_speed_entries_price_at_the_base_rate() {
-        // Documented deviation: no fast-speed multiplier (the models.dev
-        // catalog has no fast rates). Pin that has_speed does not change the
-        // computed cost.
-        let base = r#"{"timestamp":"2026-01-01T00:00:00Z","message":{"id":"m","model":"claude-sonnet-4-20250514","usage":{"input_tokens":1000000,"output_tokens":0}},"requestId":"r"}"#;
-        let fast = r#"{"timestamp":"2026-01-01T00:00:00Z","message":{"id":"m","model":"claude-sonnet-4-20250514","usage":{"input_tokens":1000000,"output_tokens":0,"speed":"fast"}},"requestId":"r"}"#;
+    fn fast_speed_entries_price_at_the_fast_multiplier() {
+        // claude-opus-4-8 carries a 2x fast multiplier in the catalog; a
+        // fast-speed entry bills its whole request at it, while the base
+        // model name is unchanged.
+        let base = r#"{"timestamp":"2026-01-01T00:00:00Z","message":{"id":"m","model":"claude-opus-4-8-20260601","usage":{"input_tokens":1000000,"output_tokens":0}},"requestId":"r"}"#;
+        let fast = r#"{"timestamp":"2026-01-01T00:00:00Z","message":{"id":"m","model":"claude-opus-4-8-20260601","usage":{"input_tokens":1000000,"output_tokens":0,"speed":"fast"}},"requestId":"r"}"#;
         assert_eq!(
-            super::super::cost::entry_cost_micro_usd(&extract(base)[0]),
-            super::super::cost::entry_cost_micro_usd(&extract(fast)[0]),
+            super::super::cost::entry_cost_micro_usd(&extract(fast)[0]).unwrap(),
+            2 * super::super::cost::entry_cost_micro_usd(&extract(base)[0]).unwrap(),
         );
     }
 

--- a/src/token_usage/codex.rs
+++ b/src/token_usage/codex.rs
@@ -26,9 +26,9 @@
 //!   scalar where an object belongs) is skipped whole, where ccusage's lossy
 //!   deserializers would still process it. Timestamp parsing is slightly
 //!   more lenient than ccusage's fixed-width RFC3339 forms.
-//! - Cost: no long-context tiered pricing and no `codex-auto-review` model
-//!   mapping (that model prices at $0 unless the catalog learns it); see
-//!   `cost.rs` for the shared pricing deviations.
+//! - Cost: no `codex-auto-review` model mapping (that model prices at $0
+//!   unless the catalog learns it); see `cost.rs` for the shared pricing
+//!   rules and deviations.
 
 use serde::{Deserialize, Serialize};
 

--- a/src/token_usage/cost.rs
+++ b/src/token_usage/cost.rs
@@ -59,7 +59,10 @@ pub fn price_entry(entry: &UsageEntry) -> EntryPricing {
         };
     };
     EntryPricing {
-        cost_micro_usd: Some(cost_from_pricing(entry, &pricing)),
+        // The same tier decision selects the billed rates AND lands in the
+        // recorded long_context column the wire splits are built from, so
+        // the two can never diverge.
+        cost_micro_usd: Some(tiered_cost_from_pricing(entry, &pricing, long_context)),
         long_context,
         pricing_catalog: Some(pricing_catalog_id()),
     }
@@ -94,11 +97,18 @@ fn is_long_context(entry: &UsageEntry, pricing: &ModelPricing) -> bool {
 }
 
 /// The catalog-pricing arm of ccusage's "auto" mode, split out so the rate
-/// fallbacks are unit-testable with synthetic pricing.
+/// fallbacks are unit-testable with synthetic pricing (computes the tier
+/// decision itself; production goes through [`price_entry`], which computes
+/// it once for both the cost and the recorded flag).
+#[cfg(test)]
 fn cost_from_pricing(entry: &UsageEntry, pricing: &ModelPricing) -> u64 {
+    tiered_cost_from_pricing(entry, pricing, is_long_context(entry, pricing))
+}
+
+fn tiered_cost_from_pricing(entry: &UsageEntry, pricing: &ModelPricing, long_context: bool) -> u64 {
     let usd = match entry.pricing_shape {
-        PricingShape::Claude => claude_cost_usd(entry, pricing),
-        PricingShape::Codex => codex_cost_usd(entry, pricing),
+        PricingShape::Claude => claude_cost_usd(entry, pricing, long_context),
+        PricingShape::Codex => codex_cost_usd(entry, pricing, long_context),
     } / 1_000_000.0;
     // Fast-speed requests bill the whole request at the model's multiplier
     // (ccusage prices the fast bucket once at standard rates plus
@@ -114,12 +124,11 @@ fn cost_from_pricing(entry: &UsageEntry, pricing: &ModelPricing) -> u64 {
 /// ccusage `calculate_cost_from_pricing`: in a long-context request every
 /// rate switches to its above-threshold value, falling back per rate to the
 /// base; 1h cache writes bill at 2x the selected tier's input rate.
-fn claude_cost_usd(entry: &UsageEntry, pricing: &ModelPricing) -> f64 {
+fn claude_cost_usd(entry: &UsageEntry, pricing: &ModelPricing, long_context: bool) -> f64 {
     let cache_write_5m = entry
         .tokens
         .cache_write
         .saturating_sub(entry.cache_write_1h);
-    let long_context = is_long_context(entry, pricing);
     let rate = |base: f64, above: Option<f64>| {
         if long_context {
             above.unwrap_or(base)
@@ -145,9 +154,9 @@ fn claude_cost_usd(entry: &UsageEntry, pricing: &ModelPricing) -> f64 {
 /// unpublished cache-read rate bills at the FULL input rate of the selected
 /// tier — not the Claude path's 0.1x default — and Codex reports no cache
 /// writes, so there are no write terms.
-fn codex_cost_usd(entry: &UsageEntry, pricing: &ModelPricing) -> f64 {
+fn codex_cost_usd(entry: &UsageEntry, pricing: &ModelPricing, long_context: bool) -> f64 {
     let explicit = pricing.cache_read.is_some();
-    let (input_rate, output_rate, cache_read_rate) = if is_long_context(entry, pricing) {
+    let (input_rate, output_rate, cache_read_rate) = if long_context {
         let long_input = pricing.input_above.unwrap_or(pricing.input);
         let long_cache_read = if explicit {
             pricing
@@ -232,7 +241,7 @@ mod tests {
     #[test]
     fn transcript_cost_takes_precedence_over_computed() {
         let mut e = entry(
-            "claude-sonnet-4-20250514",
+            "claude-sonnet-4-6-20260115",
             TokenCounts {
                 input: 1_000_000,
                 ..Default::default()
@@ -245,9 +254,9 @@ mod tests {
     #[test]
     fn computes_cost_from_pricing_catalog() {
         // claude-sonnet-4 is in the embedded models.dev snapshot.
-        let pricing = pricing_for("claude-sonnet-4-20250514").expect("snapshot pricing");
+        let pricing = pricing_for("claude-sonnet-4-6-20260115").expect("snapshot pricing");
         let e = entry(
-            "claude-sonnet-4-20250514",
+            "claude-sonnet-4-6-20260115",
             TokenCounts {
                 input: 1_000_000,
                 output: 2_000_000,
@@ -270,9 +279,9 @@ mod tests {
 
     #[test]
     fn one_hour_cache_writes_cost_double_the_input_rate() {
-        let pricing = pricing_for("claude-sonnet-4-20250514").expect("snapshot pricing");
+        let pricing = pricing_for("claude-sonnet-4-6-20260115").expect("snapshot pricing");
         let mut e = entry(
-            "claude-sonnet-4-20250514",
+            "claude-sonnet-4-6-20260115",
             TokenCounts {
                 cache_write: 1_000_000,
                 ..Default::default()
@@ -529,7 +538,7 @@ mod tests {
     #[test]
     fn price_entry_records_the_tier_decision_and_catalog() {
         let long = entry(
-            "claude-sonnet-4-20250514",
+            "claude-sonnet-4-6-20260115",
             TokenCounts {
                 input: 300_000,
                 ..Default::default()

--- a/src/token_usage/cost.rs
+++ b/src/token_usage/cost.rs
@@ -69,6 +69,10 @@ pub fn price_entry(entry: &UsageEntry) -> EntryPricing {
 }
 
 /// Estimated cost of one entry in micro-USD ([`price_entry`]'s cost alone).
+/// Test-only convenience: production stores the full [`EntryPricing`], so a
+/// second entry point must not invite callers to drop the recorded
+/// long-context/catalog facts.
+#[cfg(test)]
 pub fn entry_cost_micro_usd(entry: &UsageEntry) -> Option<u64> {
     price_entry(entry).cost_micro_usd
 }
@@ -121,6 +125,17 @@ fn tiered_cost_from_pricing(entry: &UsageEntry, pricing: &ModelPricing, long_con
     micro_usd(usd * multiplier)
 }
 
+/// The billed rate for one token class: the above-threshold rate in a
+/// long-context request (falling back per rate to the base), the base rate
+/// otherwise. Shared by both cost shapes so the fallback rule cannot drift.
+fn tier_rate(long_context: bool, base: f64, above: Option<f64>) -> f64 {
+    if long_context {
+        above.unwrap_or(base)
+    } else {
+        base
+    }
+}
+
 /// ccusage `calculate_cost_from_pricing`: in a long-context request every
 /// rate switches to its above-threshold value, falling back per rate to the
 /// base; 1h cache writes bill at 2x the selected tier's input rate.
@@ -129,13 +144,7 @@ fn claude_cost_usd(entry: &UsageEntry, pricing: &ModelPricing, long_context: boo
         .tokens
         .cache_write
         .saturating_sub(entry.cache_write_1h);
-    let rate = |base: f64, above: Option<f64>| {
-        if long_context {
-            above.unwrap_or(base)
-        } else {
-            base
-        }
-    };
+    let rate = |base: f64, above: Option<f64>| tier_rate(long_context, base, above);
     entry.tokens.input as f64 * rate(pricing.input, pricing.input_above)
         + entry.tokens.output as f64 * rate(pricing.output, pricing.output_above)
         + cache_write_5m as f64 * rate(pricing.cache_write_rate(), pricing.cache_write_above)
@@ -155,32 +164,17 @@ fn claude_cost_usd(entry: &UsageEntry, pricing: &ModelPricing, long_context: boo
 /// tier — not the Claude path's 0.1x default — and Codex reports no cache
 /// writes, so there are no write terms.
 fn codex_cost_usd(entry: &UsageEntry, pricing: &ModelPricing, long_context: bool) -> f64 {
-    let explicit = pricing.cache_read.is_some();
-    let (input_rate, output_rate, cache_read_rate) = if long_context {
-        let long_input = pricing.input_above.unwrap_or(pricing.input);
-        let long_cache_read = if explicit {
-            pricing
-                .cache_read_above
-                .unwrap_or_else(|| pricing.cache_read_rate())
-        } else {
-            long_input
-        };
-        (
-            long_input,
-            pricing.output_above.unwrap_or(pricing.output),
-            long_cache_read,
-        )
+    let rate = |base: f64, above: Option<f64>| tier_rate(long_context, base, above);
+    // An unpublished cache-read rate bills like uncached input at the
+    // selected tier; a published one switches to its own above rate.
+    let cache_read_rate = if pricing.cache_read.is_some() {
+        rate(pricing.cache_read_rate(), pricing.cache_read_above)
     } else {
-        let cache_read = if explicit {
-            pricing.cache_read_rate()
-        } else {
-            pricing.input
-        };
-        (pricing.input, pricing.output, cache_read)
+        rate(pricing.input, pricing.input_above)
     };
-    entry.tokens.input as f64 * input_rate
+    entry.tokens.input as f64 * rate(pricing.input, pricing.input_above)
         + entry.tokens.cache_read as f64 * cache_read_rate
-        + entry.tokens.output as f64 * output_rate
+        + entry.tokens.output as f64 * rate(pricing.output, pricing.output_above)
 }
 
 /// Convert a USD amount to micro-USD (1e-6 USD), rounding to nearest and

--- a/src/token_usage/cost.rs
+++ b/src/token_usage/cost.rs
@@ -1,16 +1,17 @@
 //! Per-entry cost estimation (ccusage "auto" mode: a pre-computed transcript
-//! cost wins, otherwise cost is derived from the pricing catalog).
+//! cost wins, otherwise cost is derived from the pricing catalog with the
+//! per-shape long-context tiering and fast-multiplier rules below).
 //!
-//! Known deviations from ccusage, all stemming from pricing exclusively via
-//! git-ai's models.dev catalog: no long-context tiered rates, no fast-speed
-//! multipliers, and no `codex-auto-review` release-date model mapping.
-//! `git-ai usage` (src/metrics/local_stats.rs) estimates from the same
-//! catalog but without the 1h-cache multiplier or cache-read fallback (it
-//! aggregates without the 5m/1h split); TokenUsage events are the
-//! authoritative figures.
+//! Known deviations from ccusage: no `codex-auto-review` release-date model
+//! mapping, and no marginal-at-200K pricing arm (ccusage keeps LiteLLM
+//! `above_200k` data marginal when a model has above-rates but no threshold;
+//! git-ai's models.dev catalog always pairs above-rates with a threshold, so
+//! that arm is unreachable). `git-ai usage` (src/metrics/local_stats.rs)
+//! estimates from the same catalog but without tiering, multipliers, or the
+//! 1h-cache split; TokenUsage events are the authoritative figures.
 
-use super::types::UsageEntry;
-use crate::metrics::model_pricing::pricing_for;
+use super::types::{PricingShape, Speed, UsageEntry};
+use crate::metrics::model_pricing::{ModelPricing, pricing_catalog_id, pricing_for};
 
 /// 1-hour ephemeral cache writes are priced at 2x the input rate (ccusage
 /// `CACHE_CREATE_1H_INPUT_MULTIPLIER`); the flat `cache_write` rate covers
@@ -22,33 +23,155 @@ const CACHE_WRITE_1H_INPUT_MULTIPLIER: f64 = 2.0;
 /// inflate a bucket by millions of dollars.
 const MAX_ENTRY_COST_MICRO_USD: u64 = 10_000 * 1_000_000;
 
-/// Estimated cost of one entry in micro-USD: the transcript's own `costUSD`
-/// when present, otherwise computed from the models.dev pricing catalog.
-/// `None` when the model has no known pricing.
-pub fn entry_cost_micro_usd(entry: &UsageEntry) -> Option<u64> {
+/// Everything the database stores about an entry's pricing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EntryPricing {
+    /// `None` when the model has no known pricing (and no transcript cost).
+    pub cost_micro_usd: Option<u64>,
+    /// The request selected its model's long-context tier (recorded even for
+    /// transcript-priced entries: the wire's tier token splits cover every
+    /// token, whatever priced it).
+    pub long_context: bool,
+    /// Catalog in effect when the cost was computed; `None` when the cost
+    /// came from the transcript or the model has no pricing.
+    pub pricing_catalog: Option<&'static str>,
+}
+
+/// Price one entry (ccusage "auto" mode): the transcript's own `costUSD`
+/// wins, otherwise the catalog formula for the entry's [`PricingShape`],
+/// with fast-speed entries billing the whole request at the model's fast
+/// multiplier.
+pub fn price_entry(entry: &UsageEntry) -> EntryPricing {
+    let pricing = pricing_for(&entry.model);
+    let long_context = pricing.is_some_and(|pricing| is_long_context(entry, &pricing));
     if let Some(cost) = entry.transcript_cost_micro_usd {
-        return Some(cost);
+        return EntryPricing {
+            cost_micro_usd: Some(cost),
+            long_context,
+            pricing_catalog: None,
+        };
     }
-    Some(cost_from_pricing(entry, &pricing_for(&entry.model)?))
+    let Some(pricing) = pricing else {
+        return EntryPricing {
+            cost_micro_usd: None,
+            long_context,
+            pricing_catalog: None,
+        };
+    };
+    EntryPricing {
+        cost_micro_usd: Some(cost_from_pricing(entry, &pricing)),
+        long_context,
+        pricing_catalog: Some(pricing_catalog_id()),
+    }
+}
+
+/// Estimated cost of one entry in micro-USD ([`price_entry`]'s cost alone).
+pub fn entry_cost_micro_usd(entry: &UsageEntry) -> Option<u64> {
+    price_entry(entry).cost_micro_usd
+}
+
+/// Whether the request bills at its model's long-context tier: the whole
+/// request switches once its context exceeds the threshold (strict; not a
+/// marginal breakpoint). The context sum is per shape: Claude counts the
+/// full input side — uncached input, cache reads, and cache writes (ccusage
+/// `calculate_cost_from_pricing`) — while Codex compares the raw per-turn
+/// input, which is uncached input plus cache reads in git-ai's normalized
+/// counts (ccusage's codex aggregation splits on `event.input_tokens`;
+/// output never selects the tier).
+fn is_long_context(entry: &UsageEntry, pricing: &ModelPricing) -> bool {
+    let Some(threshold) = pricing.long_context_threshold else {
+        return false;
+    };
+    let context = entry
+        .tokens
+        .input
+        .saturating_add(entry.tokens.cache_read)
+        .saturating_add(match entry.pricing_shape {
+            PricingShape::Claude => entry.tokens.cache_write,
+            PricingShape::Codex => 0,
+        });
+    context > threshold
 }
 
 /// The catalog-pricing arm of ccusage's "auto" mode, split out so the rate
 /// fallbacks are unit-testable with synthetic pricing.
-fn cost_from_pricing(
-    entry: &UsageEntry,
-    pricing: &crate::metrics::model_pricing::ModelPricing,
-) -> u64 {
+fn cost_from_pricing(entry: &UsageEntry, pricing: &ModelPricing) -> u64 {
+    let usd = match entry.pricing_shape {
+        PricingShape::Claude => claude_cost_usd(entry, pricing),
+        PricingShape::Codex => codex_cost_usd(entry, pricing),
+    } / 1_000_000.0;
+    // Fast-speed requests bill the whole request at the model's multiplier
+    // (ccusage prices the fast bucket once at standard rates plus
+    // `cost * (multiplier - 1)` on top — the same thing per entry).
+    let multiplier = if entry.speed == Some(Speed::Fast) {
+        pricing.fast_multiplier
+    } else {
+        1.0
+    };
+    micro_usd(usd * multiplier)
+}
+
+/// ccusage `calculate_cost_from_pricing`: in a long-context request every
+/// rate switches to its above-threshold value, falling back per rate to the
+/// base; 1h cache writes bill at 2x the selected tier's input rate.
+fn claude_cost_usd(entry: &UsageEntry, pricing: &ModelPricing) -> f64 {
     let cache_write_5m = entry
         .tokens
         .cache_write
         .saturating_sub(entry.cache_write_1h);
-    let usd = (entry.tokens.input as f64 * pricing.input
-        + entry.tokens.output as f64 * pricing.output
-        + cache_write_5m as f64 * pricing.cache_write_rate()
-        + entry.cache_write_1h as f64 * pricing.input * CACHE_WRITE_1H_INPUT_MULTIPLIER
-        + entry.tokens.cache_read as f64 * pricing.cache_read_rate())
-        / 1_000_000.0;
-    micro_usd(usd)
+    let long_context = is_long_context(entry, pricing);
+    let rate = |base: f64, above: Option<f64>| {
+        if long_context {
+            above.unwrap_or(base)
+        } else {
+            base
+        }
+    };
+    entry.tokens.input as f64 * rate(pricing.input, pricing.input_above)
+        + entry.tokens.output as f64 * rate(pricing.output, pricing.output_above)
+        + cache_write_5m as f64 * rate(pricing.cache_write_rate(), pricing.cache_write_above)
+        + entry.cache_write_1h as f64
+            * rate(
+                pricing.input * CACHE_WRITE_1H_INPUT_MULTIPLIER,
+                pricing
+                    .input_above
+                    .map(|input| input * CACHE_WRITE_1H_INPUT_MULTIPLIER),
+            )
+        + entry.tokens.cache_read as f64 * rate(pricing.cache_read_rate(), pricing.cache_read_above)
+}
+
+/// ccusage `calculate_codex_bucket_cost`, per entry (a request is entirely
+/// long- or short-context, so the two-bucket split collapses): an
+/// unpublished cache-read rate bills at the FULL input rate of the selected
+/// tier — not the Claude path's 0.1x default — and Codex reports no cache
+/// writes, so there are no write terms.
+fn codex_cost_usd(entry: &UsageEntry, pricing: &ModelPricing) -> f64 {
+    let explicit = pricing.cache_read.is_some();
+    let (input_rate, output_rate, cache_read_rate) = if is_long_context(entry, pricing) {
+        let long_input = pricing.input_above.unwrap_or(pricing.input);
+        let long_cache_read = if explicit {
+            pricing
+                .cache_read_above
+                .unwrap_or_else(|| pricing.cache_read_rate())
+        } else {
+            long_input
+        };
+        (
+            long_input,
+            pricing.output_above.unwrap_or(pricing.output),
+            long_cache_read,
+        )
+    } else {
+        let cache_read = if explicit {
+            pricing.cache_read_rate()
+        } else {
+            pricing.input
+        };
+        (pricing.input, pricing.output, cache_read)
+    };
+    entry.tokens.input as f64 * input_rate
+        + entry.tokens.cache_read as f64 * cache_read_rate
+        + entry.tokens.output as f64 * output_rate
 }
 
 /// Convert a USD amount to micro-USD (1e-6 USD), rounding to nearest and
@@ -78,7 +201,31 @@ mod tests {
             is_sidechain: false,
             speed: None,
             speed_inferred: false,
-            pricing_shape: crate::token_usage::PricingShape::Claude,
+            pricing_shape: PricingShape::Claude,
+        }
+    }
+
+    fn codex_entry(model: &str, tokens: TokenCounts) -> UsageEntry {
+        UsageEntry {
+            pricing_shape: PricingShape::Codex,
+            ..entry(model, tokens)
+        }
+    }
+
+    /// Synthetic two-stage pricing: 200K threshold, above-rates double the
+    /// base, published cache rates.
+    fn tiered_pricing() -> ModelPricing {
+        ModelPricing {
+            input: 3.0,
+            output: 15.0,
+            cache_read: Some(0.3),
+            cache_write: Some(3.75),
+            long_context_threshold: Some(200_000),
+            input_above: Some(6.0),
+            output_above: Some(30.0),
+            cache_read_above: Some(0.6),
+            cache_write_above: Some(7.5),
+            ..Default::default()
         }
     }
 
@@ -110,11 +257,13 @@ mod tests {
                 total: 3_750_000,
             },
         );
+        // 3.75M of context crosses the sonnet 200K threshold, so every rate
+        // is the above-threshold one.
         let expected = micro_usd(
-            pricing.input
-                + 2.0 * pricing.output
-                + 0.5 * pricing.cache_read_rate()
-                + 0.25 * pricing.cache_write_rate(),
+            pricing.input_above.unwrap()
+                + 2.0 * pricing.output_above.unwrap()
+                + 0.5 * pricing.cache_read_above.unwrap()
+                + 0.25 * pricing.cache_write_above.unwrap(),
         );
         assert_eq!(entry_cost_micro_usd(&e), Some(expected));
     }
@@ -130,13 +279,163 @@ mod tests {
             },
         );
         e.cache_write_1h = 400_000;
-        let expected = micro_usd(0.6 * pricing.cache_write_rate() + 0.4 * pricing.input * 2.0);
+        // 1M of cache writes is long-context for the 200K-threshold sonnet:
+        // 1h writes bill at 2x the above-threshold input rate.
+        let expected = micro_usd(
+            0.6 * pricing.cache_write_above.unwrap() + 0.4 * pricing.input_above.unwrap() * 2.0,
+        );
         assert_eq!(entry_cost_micro_usd(&e), Some(expected));
     }
 
     #[test]
+    fn long_context_requests_bill_every_token_at_the_above_rates() {
+        // Whole-request tier selection (ccusage
+        // `prices_two_stage_model_as_whole_request_at_long_context_rates`):
+        // one token over the threshold flips every bucket, not just the
+        // marginal tokens.
+        let pricing = tiered_pricing();
+        let below = entry(
+            "m",
+            TokenCounts {
+                input: 100_000,
+                output: 1_000,
+                cache_read: 50_000,
+                cache_write: 50_000,
+                ..Default::default()
+            },
+        );
+        assert_eq!(
+            cost_from_pricing(&below, &pricing),
+            micro_usd(0.1 * 3.0 + 0.001 * 15.0 + 0.05 * 0.3 + 0.05 * 3.75)
+        );
+
+        let above = entry(
+            "m",
+            TokenCounts {
+                input: 100_001,
+                output: 1_000,
+                cache_read: 50_000,
+                cache_write: 50_000,
+                ..Default::default()
+            },
+        );
+        assert_eq!(
+            cost_from_pricing(&above, &pricing),
+            micro_usd(0.100_001 * 6.0 + 0.001 * 30.0 + 0.05 * 0.6 + 0.05 * 7.5)
+        );
+    }
+
+    #[test]
+    fn cached_context_selects_the_long_context_tier() {
+        // The vendor's tier is chosen by the request's whole context, cached
+        // or not (ccusage `cached_context_selects_the_long_context_tier`).
+        let pricing = tiered_pricing();
+        let e = entry(
+            "m",
+            TokenCounts {
+                input: 10_000,
+                cache_read: 250_000,
+                ..Default::default()
+            },
+        );
+        assert_eq!(
+            cost_from_pricing(&e, &pricing),
+            micro_usd(0.01 * 6.0 + 0.25 * 0.6)
+        );
+    }
+
+    #[test]
+    fn missing_above_rates_fall_back_to_the_base_rate() {
+        let pricing = ModelPricing {
+            input_above: Some(6.0),
+            output_above: None,
+            cache_read_above: None,
+            cache_write_above: None,
+            ..tiered_pricing()
+        };
+        let e = entry(
+            "m",
+            TokenCounts {
+                input: 300_000,
+                output: 1_000,
+                cache_read: 100_000,
+                ..Default::default()
+            },
+        );
+        assert_eq!(
+            cost_from_pricing(&e, &pricing),
+            micro_usd(0.3 * 6.0 + 0.001 * 15.0 + 0.1 * 0.3)
+        );
+    }
+
+    #[test]
+    fn codex_tier_is_selected_by_input_and_cache_reads_only() {
+        // ccusage's codex split compares the raw per-turn input (uncached +
+        // cached); output never selects the tier.
+        let pricing = tiered_pricing();
+        let output_heavy = codex_entry(
+            "m",
+            TokenCounts {
+                input: 100_000,
+                cache_read: 50_000,
+                output: 500_000,
+                ..Default::default()
+            },
+        );
+        assert_eq!(
+            cost_from_pricing(&output_heavy, &pricing),
+            micro_usd(0.1 * 3.0 + 0.05 * 0.3 + 0.5 * 15.0)
+        );
+
+        let long = codex_entry(
+            "m",
+            TokenCounts {
+                input: 180_000,
+                cache_read: 20_001,
+                output: 500,
+                ..Default::default()
+            },
+        );
+        assert_eq!(
+            cost_from_pricing(&long, &pricing),
+            micro_usd(0.18 * 6.0 + 0.020_001 * 0.6 + 0.000_5 * 30.0)
+        );
+    }
+
+    #[test]
+    fn codex_unpublished_cache_read_rate_bills_at_the_full_input_rate() {
+        // ccusage `calculate_codex_bucket_cost`: without a published
+        // cache-read rate, cached tokens bill like uncached input (and at the
+        // above input rate in long-context requests) — not the Claude path's
+        // 0.1x default.
+        let pricing = ModelPricing {
+            input: 2.0,
+            output: 10.0,
+            long_context_threshold: Some(200_000),
+            input_above: Some(4.0),
+            ..Default::default()
+        };
+        let short = codex_entry(
+            "m",
+            TokenCounts {
+                cache_read: 1_000_000,
+                ..Default::default()
+            },
+        );
+        // 1M cached alone is long-context here (input + cache_read).
+        assert_eq!(cost_from_pricing(&short, &pricing), micro_usd(1.0 * 4.0));
+        let below = codex_entry(
+            "m",
+            TokenCounts {
+                cache_read: 100_000,
+                ..Default::default()
+            },
+        );
+        assert_eq!(cost_from_pricing(&below, &pricing), micro_usd(0.1 * 2.0));
+    }
+
+    #[test]
     fn unpublished_cache_rates_fall_back_to_input_derived_defaults() {
-        use crate::metrics::model_pricing::ModelPricing;
         let mut e = entry(
             "any-model",
             TokenCounts {
@@ -150,8 +449,9 @@ mod tests {
             output: 10.0,
             ..Default::default()
         };
-        // ccusage defaults unpublished cache-read pricing to input * 0.1; $0
-        // would badly undercount cache-heavy sessions.
+        // The Claude path defaults unpublished cache-read pricing to
+        // input * 0.1 (ccusage's models.dev loader); $0 would badly
+        // undercount cache-heavy sessions.
         assert_eq!(cost_from_pricing(&e, &no_cache_rates), micro_usd(0.2));
         let explicit = ModelPricing {
             cache_read: Some(0.5),
@@ -165,6 +465,105 @@ mod tests {
             ..no_cache_rates
         };
         assert_eq!(cost_from_pricing(&e, &explicit_zero), 0);
+    }
+
+    #[test]
+    fn fast_entries_bill_the_whole_request_at_the_multiplier() {
+        let pricing = ModelPricing {
+            fast_multiplier: 2.5,
+            ..tiered_pricing()
+        };
+        let mut e = codex_entry(
+            "m",
+            TokenCounts {
+                input: 100_000,
+                cache_read: 50_000,
+                output: 1_000,
+                ..Default::default()
+            },
+        );
+        // 0.1M * 3 + 0.05M * 0.3 + 0.001M * 15 = $0.33
+        let standard = cost_from_pricing(&e, &pricing);
+        assert_eq!(standard, micro_usd(0.33));
+        e.speed = Some(Speed::Fast);
+        assert_eq!(cost_from_pricing(&e, &pricing), micro_usd(2.5 * 0.33));
+
+        // Fast composes with long-context tiering.
+        e.tokens.input = 300_000;
+        assert_eq!(
+            cost_from_pricing(&e, &pricing),
+            micro_usd(2.5 * (0.3 * 6.0 + 0.05 * 0.6 + 0.001 * 30.0))
+        );
+
+        // A standard-speed entry never picks up the multiplier.
+        e.speed = Some(Speed::Standard);
+        assert_eq!(
+            cost_from_pricing(&e, &pricing),
+            micro_usd(0.3 * 6.0 + 0.05 * 0.6 + 0.001 * 30.0)
+        );
+    }
+
+    #[test]
+    fn codex_long_context_prices_from_the_embedded_snapshot() {
+        // ccusage `prices_gpt_5_6_long_context_usage_from_embedded_pricing`:
+        // a 300K-input gpt-5.6-sol turn crosses the 272K threshold and bills
+        // entirely at the above rates.
+        let pricing = pricing_for("gpt-5.6-sol").expect("snapshot pricing");
+        let e = codex_entry(
+            "gpt-5.6-sol",
+            TokenCounts {
+                input: 280_000,
+                cache_read: 20_000,
+                output: 1_000,
+                ..Default::default()
+            },
+        );
+        let expected = micro_usd(
+            0.28 * pricing.input_above.unwrap()
+                + 0.02 * pricing.cache_read_above.unwrap()
+                + 0.001 * pricing.output_above.unwrap(),
+        );
+        assert_eq!(entry_cost_micro_usd(&e), Some(expected));
+    }
+
+    #[test]
+    fn price_entry_records_the_tier_decision_and_catalog() {
+        let long = entry(
+            "claude-sonnet-4-20250514",
+            TokenCounts {
+                input: 300_000,
+                ..Default::default()
+            },
+        );
+        let priced = price_entry(&long);
+        assert!(priced.long_context);
+        assert_eq!(priced.pricing_catalog, Some(pricing_catalog_id()));
+        assert!(priced.cost_micro_usd.unwrap() > 0);
+
+        // Transcript-priced entries keep the tier decision (the wire's token
+        // splits cover them) but claim no catalog.
+        let mut transcript = long.clone();
+        transcript.transcript_cost_micro_usd = Some(42);
+        let priced = price_entry(&transcript);
+        assert_eq!(priced.cost_micro_usd, Some(42));
+        assert!(priced.long_context);
+        assert_eq!(priced.pricing_catalog, None);
+
+        let unknown = entry(
+            "totally-unknown-model-xyz",
+            TokenCounts {
+                input: 100,
+                ..Default::default()
+            },
+        );
+        assert_eq!(
+            price_entry(&unknown),
+            EntryPricing {
+                cost_micro_usd: None,
+                long_context: false,
+                pricing_catalog: None,
+            }
+        );
     }
 
     #[test]

--- a/src/token_usage/cost.rs
+++ b/src/token_usage/cost.rs
@@ -235,7 +235,7 @@ mod tests {
     #[test]
     fn transcript_cost_takes_precedence_over_computed() {
         let mut e = entry(
-            "claude-sonnet-4-6-20260115",
+            "claude-sonnet-4-5-20250929",
             TokenCounts {
                 input: 1_000_000,
                 ..Default::default()
@@ -247,10 +247,11 @@ mod tests {
 
     #[test]
     fn computes_cost_from_pricing_catalog() {
-        // claude-sonnet-4 is in the embedded models.dev snapshot.
-        let pricing = pricing_for("claude-sonnet-4-6-20260115").expect("snapshot pricing");
+        // claude-sonnet-4-5 is in the embedded snapshot and carries the
+        // hand-tracked pre-4.6 long-context premium.
+        let pricing = pricing_for("claude-sonnet-4-5-20250929").expect("snapshot pricing");
         let e = entry(
-            "claude-sonnet-4-6-20260115",
+            "claude-sonnet-4-5-20250929",
             TokenCounts {
                 input: 1_000_000,
                 output: 2_000_000,
@@ -273,9 +274,9 @@ mod tests {
 
     #[test]
     fn one_hour_cache_writes_cost_double_the_input_rate() {
-        let pricing = pricing_for("claude-sonnet-4-6-20260115").expect("snapshot pricing");
+        let pricing = pricing_for("claude-sonnet-4-5-20250929").expect("snapshot pricing");
         let mut e = entry(
-            "claude-sonnet-4-6-20260115",
+            "claude-sonnet-4-5-20250929",
             TokenCounts {
                 cache_write: 1_000_000,
                 ..Default::default()
@@ -532,7 +533,7 @@ mod tests {
     #[test]
     fn price_entry_records_the_tier_decision_and_catalog() {
         let long = entry(
-            "claude-sonnet-4-6-20260115",
+            "claude-sonnet-4-5-20250929",
             TokenCounts {
                 input: 300_000,
                 ..Default::default()

--- a/src/token_usage/db.rs
+++ b/src/token_usage/db.rs
@@ -40,7 +40,7 @@ use std::sync::{Arc, Mutex, MutexGuard};
 use rusqlite::{Connection, OptionalExtension, Transaction, params};
 
 use super::claude::{ReplacementCandidate, should_replace};
-use super::cost::entry_cost_micro_usd;
+use super::cost::price_entry;
 use super::types::{Speed, UsageEntry, bucket_ts};
 use crate::error::GitAiError;
 
@@ -825,6 +825,7 @@ fn upsert_entry(
     entry: &UsageEntry,
 ) -> Result<Option<String>, GitAiError> {
     let bucket = bucket_ts(entry.ts);
+    let priced = price_entry(entry);
     let existing = find_dedupe_target(tx, entry)?;
     match existing {
         Some(row) => {
@@ -837,8 +838,9 @@ fn upsert_entry(
                         cache_write_1h_tokens = ?10, reasoning_output_tokens = ?11,
                         total_tokens = ?12, cost_micro_usd = ?13,
                         transcript_cost_micro_usd = ?14, is_sidechain = ?15,
-                        speed = ?16, speed_inferred = ?17
-                     WHERE rowid = ?18",
+                        speed = ?16, speed_inferred = ?17, long_context = ?18,
+                        pricing_catalog = ?19
+                     WHERE rowid = ?20",
                     params![
                         session_id,
                         entry.entry_key,
@@ -852,11 +854,13 @@ fn upsert_entry(
                         to_db_i64(entry.cache_write_1h),
                         entry.tokens.reasoning_output.map(to_db_i64),
                         to_db_i64(entry.tokens.total),
-                        entry_cost_micro_usd(entry).map(to_db_i64),
+                        priced.cost_micro_usd.map(to_db_i64),
                         entry.transcript_cost_micro_usd.map(to_db_i64),
                         entry.is_sidechain,
                         entry.speed.map(speed_to_db),
                         entry.speed_inferred,
+                        priced.long_context,
+                        priced.pricing_catalog,
                         row.rowid,
                     ],
                 )?;
@@ -873,9 +877,9 @@ fn upsert_entry(
                     input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
                     cache_write_1h_tokens, reasoning_output_tokens, total_tokens,
                     cost_micro_usd, transcript_cost_micro_usd, is_sidechain,
-                    speed, speed_inferred
+                    speed, speed_inferred, long_context, pricing_catalog
                  ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14,
-                           ?15, ?16, ?17)",
+                           ?15, ?16, ?17, ?18, ?19)",
                 params![
                     session_id,
                     entry.entry_key,
@@ -889,11 +893,13 @@ fn upsert_entry(
                     to_db_i64(entry.cache_write_1h),
                     entry.tokens.reasoning_output.map(to_db_i64),
                     to_db_i64(entry.tokens.total),
-                    entry_cost_micro_usd(entry).map(to_db_i64),
+                    priced.cost_micro_usd.map(to_db_i64),
                     entry.transcript_cost_micro_usd.map(to_db_i64),
                     entry.is_sidechain,
                     entry.speed.map(speed_to_db),
                     entry.speed_inferred,
+                    priced.long_context,
+                    priced.pricing_catalog,
                 ],
             )?;
             Ok(None)
@@ -1017,6 +1023,43 @@ mod tests {
 
     fn commit(db: &TokenUsageDatabase, entries: &[UsageEntry]) {
         commit_for(db, "s1", entries);
+    }
+
+    #[test]
+    fn upsert_stores_the_pricing_dimensions() {
+        let (_dir, db) = db();
+        let mut e = entry(
+            "k1",
+            None,
+            600,
+            TokenCounts {
+                input: 300_000,
+                output: 10,
+                total: 300_010,
+                ..Default::default()
+            },
+        );
+        // Catalog-priced (no transcript cost), fast, and over the sonnet
+        // 200K long-context threshold.
+        e.transcript_cost_micro_usd = None;
+        e.speed = Some(Speed::Fast);
+        commit_for(&db, "s1", &[e.clone()]);
+
+        let conn = db.conn.lock().unwrap();
+        let (cost, speed, long_context, catalog): (u64, i64, bool, Option<String>) = conn
+            .query_row(
+                "SELECT cost_micro_usd, speed, long_context, pricing_catalog FROM usage_entries",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .unwrap();
+        assert_eq!(Some(cost), price_entry(&e).cost_micro_usd);
+        assert_eq!(speed, 1);
+        assert!(long_context);
+        assert_eq!(
+            catalog.as_deref(),
+            Some(crate::metrics::model_pricing::pricing_catalog_id())
+        );
     }
 
     #[test]

--- a/src/token_usage/db.rs
+++ b/src/token_usage/db.rs
@@ -986,7 +986,7 @@ mod tests {
             entry_key: key.to_string(),
             message_id: message_id.map(str::to_string),
             ts,
-            model: "claude-sonnet-4-20250514".to_string(),
+            model: "claude-sonnet-4-6-20260115".to_string(),
             tokens,
             cache_write_1h: 0,
             transcript_cost_micro_usd: Some(1_000),
@@ -1129,7 +1129,7 @@ mod tests {
         commit(&db, &[entry("m1|r1", Some("m1"), 600, tokens(10, 5))]);
         let changed = db.changed_buckets("s1").unwrap();
         assert_eq!(changed.len(), 1);
-        assert_eq!(changed[0].model, "claude-sonnet-4-20250514");
+        assert_eq!(changed[0].model, "claude-sonnet-4-6-20260115");
         assert_eq!(changed[0].bucket_ts, 600);
         assert_eq!(changed[0].emit_seq, 0);
         let agg = changed[0].aggregate;
@@ -1151,13 +1151,13 @@ mod tests {
         assert!(db.sessions_needing_reconcile().unwrap().is_empty());
         // The entry stays attributed to the first-seen session.
         assert_eq!(
-            db.aggregate_bucket("s1", "claude-sonnet-4-20250514", 600)
+            db.aggregate_bucket("s1", "claude-sonnet-4-6-20260115", 600)
                 .unwrap()
                 .message_count,
             1
         );
         assert_eq!(
-            db.aggregate_bucket("s2", "claude-sonnet-4-20250514", 600)
+            db.aggregate_bucket("s2", "claude-sonnet-4-6-20260115", 600)
                 .unwrap()
                 .message_count,
             0
@@ -1190,13 +1190,13 @@ mod tests {
         db.clear_needs_reconcile("s1").unwrap();
         assert!(db.sessions_needing_reconcile().unwrap().is_empty());
         assert_eq!(
-            db.aggregate_bucket("s1", "claude-sonnet-4-20250514", 600)
+            db.aggregate_bucket("s1", "claude-sonnet-4-6-20260115", 600)
                 .unwrap()
                 .message_count,
             0
         );
         assert_eq!(
-            db.aggregate_bucket("s2", "claude-sonnet-4-20250514", 600)
+            db.aggregate_bucket("s2", "claude-sonnet-4-6-20260115", 600)
                 .unwrap()
                 .output,
             50
@@ -1208,7 +1208,7 @@ mod tests {
         let (_dir, db) = db();
         let e = entry("m1|r1", Some("m1"), 600, tokens(10, 5));
         commit(&db, std::slice::from_ref(&e));
-        let model = "claude-sonnet-4-20250514";
+        let model = "claude-sonnet-4-6-20260115";
         let before = db.aggregate_bucket("s1", model, 600).unwrap();
         // Identical replay: policy keeps the existing row, aggregate (and
         // therefore the emission fingerprint) is unchanged.
@@ -1223,14 +1223,14 @@ mod tests {
         commit(&db, &[entry("m1|r1", Some("m1"), 600, tokens(10, 5))]);
         commit(&db, &[entry("m1|r1", Some("m1"), 600, tokens(10, 50))]);
         let agg = db
-            .aggregate_bucket("s1", "claude-sonnet-4-20250514", 600)
+            .aggregate_bucket("s1", "claude-sonnet-4-6-20260115", 600)
             .unwrap();
         assert_eq!(agg.output, 50);
         assert_eq!(agg.message_count, 1);
         // Smaller totals never replace.
         commit(&db, &[entry("m1|r1", Some("m1"), 600, tokens(1, 1))]);
         assert_eq!(
-            db.aggregate_bucket("s1", "claude-sonnet-4-20250514", 600)
+            db.aggregate_bucket("s1", "claude-sonnet-4-6-20260115", 600)
                 .unwrap(),
             agg
         );
@@ -1246,7 +1246,7 @@ mod tests {
         // loses to it despite larger totals.
         commit(&db, &[replay]);
         let agg = db
-            .aggregate_bucket("s1", "claude-sonnet-4-20250514", 600)
+            .aggregate_bucket("s1", "claude-sonnet-4-6-20260115", 600)
             .unwrap();
         assert_eq!(agg.input, 10);
         assert_eq!(agg.message_count, 1);
@@ -1260,7 +1260,7 @@ mod tests {
         commit(&db, &[replay]);
         commit(&db, &[entry("m1|r1", Some("m1"), 600, tokens(10, 5))]);
         let agg = db
-            .aggregate_bucket("s1", "claude-sonnet-4-20250514", 600)
+            .aggregate_bucket("s1", "claude-sonnet-4-6-20260115", 600)
             .unwrap();
         assert_eq!(agg.input, 10);
         assert_eq!(agg.message_count, 1);
@@ -1268,7 +1268,7 @@ mod tests {
         // parent entry again leaves the aggregate untouched.
         commit(&db, &[entry("m1|r1", Some("m1"), 600, tokens(10, 5))]);
         assert_eq!(
-            db.aggregate_bucket("s1", "claude-sonnet-4-20250514", 600)
+            db.aggregate_bucket("s1", "claude-sonnet-4-6-20260115", 600)
                 .unwrap(),
             agg
         );
@@ -1282,7 +1282,7 @@ mod tests {
         commit(&db, &[entry("m1|r1", Some("m1"), 600, tokens(10, 5))]);
         commit(&db, &[entry("m1|r2", Some("m1"), 600, tokens(7, 3))]);
         let agg = db
-            .aggregate_bucket("s1", "claude-sonnet-4-20250514", 600)
+            .aggregate_bucket("s1", "claude-sonnet-4-6-20260115", 600)
             .unwrap();
         assert_eq!(agg.message_count, 2);
         assert_eq!(agg.input, 17);
@@ -1291,7 +1291,7 @@ mod tests {
     #[test]
     fn changed_buckets_skips_unchanged_and_reports_emptied() {
         let (_dir, db) = db();
-        let model = "claude-sonnet-4-20250514";
+        let model = "claude-sonnet-4-6-20260115";
         commit(&db, &[entry("m1|r1", Some("m1"), 600, tokens(10, 5))]);
         let changed = db.changed_buckets("s1").unwrap();
         assert_eq!(changed.len(), 1);
@@ -1394,7 +1394,7 @@ mod tests {
         assert!(db.all_files().unwrap().is_empty());
         assert!(db.sessions_needing_reconcile().unwrap().is_empty());
         assert_eq!(
-            db.aggregate_bucket("s1", "claude-sonnet-4-20250514", 600)
+            db.aggregate_bucket("s1", "claude-sonnet-4-6-20260115", 600)
                 .unwrap()
                 .message_count,
             0
@@ -1406,7 +1406,7 @@ mod tests {
             &[entry("m1|r1", Some("m1"), 600, tokens(10, 50))],
         );
         assert_eq!(
-            db.aggregate_bucket("s2", "claude-sonnet-4-20250514", 600)
+            db.aggregate_bucket("s2", "claude-sonnet-4-6-20260115", 600)
                 .unwrap()
                 .output,
             50
@@ -1419,7 +1419,7 @@ mod tests {
         // fingerprint write must not lead to a second payload with an equal
         // revision.
         let (_dir, db) = db();
-        let model = "claude-sonnet-4-20250514";
+        let model = "claude-sonnet-4-6-20260115";
         commit(&db, &[entry("m1|r1", Some("m1"), 600, tokens(10, 5))]);
         let changed = db.changed_buckets("s1").unwrap();
         assert_eq!(changed[0].emit_seq, 0);
@@ -1497,7 +1497,7 @@ mod tests {
             commit(&db, &[e]);
         }
         let agg = db
-            .aggregate_bucket("s1", "claude-sonnet-4-20250514", 600)
+            .aggregate_bucket("s1", "claude-sonnet-4-6-20260115", 600)
             .unwrap();
         assert_eq!(agg.input, 2 * TOKEN_VALUE_CEILING);
         assert_eq!(agg.total, 2 * TOKEN_VALUE_CEILING);
@@ -1579,7 +1579,7 @@ mod tests {
                 entry("m2|r2", Some("m2"), 999_900, tokens(1, 1)),
             ],
         );
-        let model = "claude-sonnet-4-20250514";
+        let model = "claude-sonnet-4-6-20260115";
         db.mark_emitted("s1", model, 600, "fp", 1, 1).unwrap();
         assert_eq!(db.prune_buckets_before(999_000).unwrap(), 1);
         assert_eq!(

--- a/src/token_usage/db.rs
+++ b/src/token_usage/db.rs
@@ -986,7 +986,7 @@ mod tests {
             entry_key: key.to_string(),
             message_id: message_id.map(str::to_string),
             ts,
-            model: "claude-sonnet-4-6-20260115".to_string(),
+            model: "claude-sonnet-4-5-20250929".to_string(),
             tokens,
             cache_write_1h: 0,
             transcript_cost_micro_usd: Some(1_000),
@@ -1129,7 +1129,7 @@ mod tests {
         commit(&db, &[entry("m1|r1", Some("m1"), 600, tokens(10, 5))]);
         let changed = db.changed_buckets("s1").unwrap();
         assert_eq!(changed.len(), 1);
-        assert_eq!(changed[0].model, "claude-sonnet-4-6-20260115");
+        assert_eq!(changed[0].model, "claude-sonnet-4-5-20250929");
         assert_eq!(changed[0].bucket_ts, 600);
         assert_eq!(changed[0].emit_seq, 0);
         let agg = changed[0].aggregate;
@@ -1151,13 +1151,13 @@ mod tests {
         assert!(db.sessions_needing_reconcile().unwrap().is_empty());
         // The entry stays attributed to the first-seen session.
         assert_eq!(
-            db.aggregate_bucket("s1", "claude-sonnet-4-6-20260115", 600)
+            db.aggregate_bucket("s1", "claude-sonnet-4-5-20250929", 600)
                 .unwrap()
                 .message_count,
             1
         );
         assert_eq!(
-            db.aggregate_bucket("s2", "claude-sonnet-4-6-20260115", 600)
+            db.aggregate_bucket("s2", "claude-sonnet-4-5-20250929", 600)
                 .unwrap()
                 .message_count,
             0
@@ -1190,13 +1190,13 @@ mod tests {
         db.clear_needs_reconcile("s1").unwrap();
         assert!(db.sessions_needing_reconcile().unwrap().is_empty());
         assert_eq!(
-            db.aggregate_bucket("s1", "claude-sonnet-4-6-20260115", 600)
+            db.aggregate_bucket("s1", "claude-sonnet-4-5-20250929", 600)
                 .unwrap()
                 .message_count,
             0
         );
         assert_eq!(
-            db.aggregate_bucket("s2", "claude-sonnet-4-6-20260115", 600)
+            db.aggregate_bucket("s2", "claude-sonnet-4-5-20250929", 600)
                 .unwrap()
                 .output,
             50
@@ -1208,7 +1208,7 @@ mod tests {
         let (_dir, db) = db();
         let e = entry("m1|r1", Some("m1"), 600, tokens(10, 5));
         commit(&db, std::slice::from_ref(&e));
-        let model = "claude-sonnet-4-6-20260115";
+        let model = "claude-sonnet-4-5-20250929";
         let before = db.aggregate_bucket("s1", model, 600).unwrap();
         // Identical replay: policy keeps the existing row, aggregate (and
         // therefore the emission fingerprint) is unchanged.
@@ -1223,14 +1223,14 @@ mod tests {
         commit(&db, &[entry("m1|r1", Some("m1"), 600, tokens(10, 5))]);
         commit(&db, &[entry("m1|r1", Some("m1"), 600, tokens(10, 50))]);
         let agg = db
-            .aggregate_bucket("s1", "claude-sonnet-4-6-20260115", 600)
+            .aggregate_bucket("s1", "claude-sonnet-4-5-20250929", 600)
             .unwrap();
         assert_eq!(agg.output, 50);
         assert_eq!(agg.message_count, 1);
         // Smaller totals never replace.
         commit(&db, &[entry("m1|r1", Some("m1"), 600, tokens(1, 1))]);
         assert_eq!(
-            db.aggregate_bucket("s1", "claude-sonnet-4-6-20260115", 600)
+            db.aggregate_bucket("s1", "claude-sonnet-4-5-20250929", 600)
                 .unwrap(),
             agg
         );
@@ -1246,7 +1246,7 @@ mod tests {
         // loses to it despite larger totals.
         commit(&db, &[replay]);
         let agg = db
-            .aggregate_bucket("s1", "claude-sonnet-4-6-20260115", 600)
+            .aggregate_bucket("s1", "claude-sonnet-4-5-20250929", 600)
             .unwrap();
         assert_eq!(agg.input, 10);
         assert_eq!(agg.message_count, 1);
@@ -1260,7 +1260,7 @@ mod tests {
         commit(&db, &[replay]);
         commit(&db, &[entry("m1|r1", Some("m1"), 600, tokens(10, 5))]);
         let agg = db
-            .aggregate_bucket("s1", "claude-sonnet-4-6-20260115", 600)
+            .aggregate_bucket("s1", "claude-sonnet-4-5-20250929", 600)
             .unwrap();
         assert_eq!(agg.input, 10);
         assert_eq!(agg.message_count, 1);
@@ -1268,7 +1268,7 @@ mod tests {
         // parent entry again leaves the aggregate untouched.
         commit(&db, &[entry("m1|r1", Some("m1"), 600, tokens(10, 5))]);
         assert_eq!(
-            db.aggregate_bucket("s1", "claude-sonnet-4-6-20260115", 600)
+            db.aggregate_bucket("s1", "claude-sonnet-4-5-20250929", 600)
                 .unwrap(),
             agg
         );
@@ -1282,7 +1282,7 @@ mod tests {
         commit(&db, &[entry("m1|r1", Some("m1"), 600, tokens(10, 5))]);
         commit(&db, &[entry("m1|r2", Some("m1"), 600, tokens(7, 3))]);
         let agg = db
-            .aggregate_bucket("s1", "claude-sonnet-4-6-20260115", 600)
+            .aggregate_bucket("s1", "claude-sonnet-4-5-20250929", 600)
             .unwrap();
         assert_eq!(agg.message_count, 2);
         assert_eq!(agg.input, 17);
@@ -1291,7 +1291,7 @@ mod tests {
     #[test]
     fn changed_buckets_skips_unchanged_and_reports_emptied() {
         let (_dir, db) = db();
-        let model = "claude-sonnet-4-6-20260115";
+        let model = "claude-sonnet-4-5-20250929";
         commit(&db, &[entry("m1|r1", Some("m1"), 600, tokens(10, 5))]);
         let changed = db.changed_buckets("s1").unwrap();
         assert_eq!(changed.len(), 1);
@@ -1394,7 +1394,7 @@ mod tests {
         assert!(db.all_files().unwrap().is_empty());
         assert!(db.sessions_needing_reconcile().unwrap().is_empty());
         assert_eq!(
-            db.aggregate_bucket("s1", "claude-sonnet-4-6-20260115", 600)
+            db.aggregate_bucket("s1", "claude-sonnet-4-5-20250929", 600)
                 .unwrap()
                 .message_count,
             0
@@ -1406,7 +1406,7 @@ mod tests {
             &[entry("m1|r1", Some("m1"), 600, tokens(10, 50))],
         );
         assert_eq!(
-            db.aggregate_bucket("s2", "claude-sonnet-4-6-20260115", 600)
+            db.aggregate_bucket("s2", "claude-sonnet-4-5-20250929", 600)
                 .unwrap()
                 .output,
             50
@@ -1419,7 +1419,7 @@ mod tests {
         // fingerprint write must not lead to a second payload with an equal
         // revision.
         let (_dir, db) = db();
-        let model = "claude-sonnet-4-6-20260115";
+        let model = "claude-sonnet-4-5-20250929";
         commit(&db, &[entry("m1|r1", Some("m1"), 600, tokens(10, 5))]);
         let changed = db.changed_buckets("s1").unwrap();
         assert_eq!(changed[0].emit_seq, 0);
@@ -1497,7 +1497,7 @@ mod tests {
             commit(&db, &[e]);
         }
         let agg = db
-            .aggregate_bucket("s1", "claude-sonnet-4-6-20260115", 600)
+            .aggregate_bucket("s1", "claude-sonnet-4-5-20250929", 600)
             .unwrap();
         assert_eq!(agg.input, 2 * TOKEN_VALUE_CEILING);
         assert_eq!(agg.total, 2 * TOKEN_VALUE_CEILING);
@@ -1579,7 +1579,7 @@ mod tests {
                 entry("m2|r2", Some("m2"), 999_900, tokens(1, 1)),
             ],
         );
-        let model = "claude-sonnet-4-6-20260115";
+        let model = "claude-sonnet-4-5-20250929";
         db.mark_emitted("s1", model, 600, "fp", 1, 1).unwrap();
         assert_eq!(db.prune_buckets_before(999_000).unwrap(), 1);
         assert_eq!(

--- a/src/token_usage/db.rs
+++ b/src/token_usage/db.rs
@@ -825,11 +825,11 @@ fn upsert_entry(
     entry: &UsageEntry,
 ) -> Result<Option<String>, GitAiError> {
     let bucket = bucket_ts(entry.ts);
-    let priced = price_entry(entry);
     let existing = find_dedupe_target(tx, entry)?;
     match existing {
         Some(row) => {
             if should_replace(entry.into(), row.replacement) {
+                let priced = price_entry(entry);
                 tx.execute(
                     "UPDATE usage_entries SET
                         session_id = ?1, entry_key = ?2, message_id = ?3, model = ?4,
@@ -871,6 +871,7 @@ fn upsert_entry(
             Ok(None)
         }
         None => {
+            let priced = price_entry(entry);
             tx.execute(
                 "INSERT INTO usage_entries (
                     session_id, entry_key, message_id, model, bucket_ts,


### PR DESCRIPTION
cost.rs now implements both of ccusage's catalog cost formulas, selected
by the entry's pricing shape:

- Claude (calculate_cost_from_pricing): whole-request tier selection —
  once uncached input + cache reads + cache writes exceed the model's
  threshold (strict), every rate switches to its above-threshold value,
  falling back per rate to the base; 1h cache writes bill at 2x the
  selected tier's input rate. Unpublished cache rates keep the
  0.1x/1.25x input-derived defaults.
- Codex (calculate_codex_bucket_cost, collapsed per entry): the tier is
  selected by the raw per-turn input (uncached + cached; output never
  selects), and an unpublished cache-read rate bills at the full input
  rate of the selected tier rather than the Claude default. No cache
  write terms (Codex reports none).

Fast-speed entries bill the whole request at the model's fast
multiplier on top of either formula (ccusage prices the fast bucket as
standard + cost x (multiplier - 1); identical per entry). Transcript
costUSD still wins outright and the $10k clamp stays last.

price_entry() replaces the bare cost lookup at upsert time and also
yields the request's tier decision and the id of the catalog that
priced it (embedded:<version> or modelsdev:<content-hash>); both are
stored on the entry row so bucket emission can carry the token splits
and provenance a different pricing sheet needs to recompute cost.
Recomputed costs change bucket fingerprints, so affected buckets
re-emit through the existing reconciliation.

The marginal-at-200K arm ccusage keeps for LiteLLM above_200k data
without a threshold is documented as unreachable (models.dev tiers
always carry one) and intentionally not ported.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
