### PR TITLE
feat(token-usage): speed-keyed buckets and repricing fields on the wire

### DIFF
--- a/docs/token-usage-events-spec.md
+++ b/docs/token-usage-events-spec.md
@@ -1,8 +1,10 @@
 # TokenUsage Events
 
-Token usage and estimated cost per `(session_id, model, bucket_ts)` in
-5-minute UTC buckets, computed from local agent transcripts and emitted as
-metric event id 9 (`TokenUsageValues`, `src/metrics/events.rs`).
+Token usage and estimated cost per `(session_id, model, speed, bucket_ts)`
+in 5-minute UTC buckets, computed from local agent transcripts and emitted as
+metric event id 9 (`TokenUsageValues`, `src/metrics/events.rs`). Fast and
+standard usage of one model bill at different rates, so speed (0 standard,
+1 fast) is part of the bucket identity.
 
 The parsing/deduplication logic is ported from
 [ccusage](https://github.com/ccusage/ccusage) (MIT) and adapted to git-ai's
@@ -83,7 +85,7 @@ state (which would corrupt Codex's cumulative-delta computation).
 
 ## Emission semantics
 
-The server upserts on `(session_id, model, bucket_ts)` keeping the **highest
+The server upserts on `(session_id, model, speed, bucket_ts)` keeping the **highest
 `emitted_seq`** — a strictly increasing per-bucket revision, reserved in the
 state database *before* events reach the telemetry queue so a crash between
 sink and bookkeeping can never produce two payloads with equal revisions —
@@ -109,20 +111,48 @@ Values (`token_usage_pos`): `bucket_ts`, `input_tokens`, `output_tokens`,
 `cache_read_tokens`, `cache_write_tokens`, `total_tokens`,
 `reasoning_output_tokens` (optional; Codex reports it as a subset of output),
 `est_cost_micro_usd` (u64 micro-USD), `credits` (f64, reserved),
-`message_count`, and `emitted_seq`. Standard `EventAttributes` carry tool,
-model, session ids, and repo_url (no git spawn).
+`message_count`, `emitted_seq`, `speed` (0/1, the bucket-key dimension),
+`speed_inferred` (any entry's tier came from configuration rather than the
+transcript), `cache_write_1h_tokens` (the 1h-TTL portion of
+`cache_write_tokens`), `long_context_{input,output,cache_read,cache_write,
+cache_write_1h}_tokens` (tokens of requests that selected their model's
+long-context tier; base-tier tokens are the totals minus these), and
+`transcript_cost_micro_usd` (the portion of `est_cost_micro_usd` that came
+from transcript `costUSD` fields). Standard `EventAttributes` carry tool,
+model, session ids, and repo_url (no git spawn); `custom_attributes` carries
+the id of the pricing catalog that priced the bucket's latest catalog-priced
+entry (`pricing_catalog`: `embedded:<version>` or `modelsdev:<hash>`).
 
 Cost follows ccusage's "auto" mode per entry: the transcript's own `costUSD`
 wins (negative/non-finite values are treated as absent, and every per-entry
 cost clamps to a $10k sanity ceiling); otherwise cost is computed from the
-models.dev pricing catalog (`src/metrics/model_pricing.rs`), including the
-2x-input rate for 1-hour ephemeral cache writes and a cache-read fallback of
-a tenth of the input rate when the catalog omits one. Pricing snapshot
-refreshes do not retroactively rewrite already-emitted buckets (only changed
-buckets recompute) - intended. Documented pricing deviations from ccusage
-(all from pricing via models.dev only): no long-context tiers, no fast-speed
-multipliers, no `codex-auto-review` model mapping; `git-ai usage`
-approximates from the same catalog without the 1h/fallback refinements, so
+models.dev pricing catalog (`src/metrics/model_pricing.rs`) with ccusage's
+two per-agent formulas (`src/token_usage/cost.rs`): whole-request
+long-context tier selection (Claude: uncached input + cache reads + cache
+writes vs the model's threshold; Codex: raw per-turn input only), 2x-input
+1h-cache-write pricing at the selected tier, per-shape unpublished-cache-rate
+defaults, and the model's fast multiplier over the whole request for
+fast-speed entries. Codex service tiers come from `thread_settings_applied`
+(sticky), falling back to the `service_tier` in the rollout's codex-home
+`config.toml`, else standard; unlike ccusage, the fallback is resolved and
+stored at extraction time, so a config change never retroactively reprices
+history. Fast multipliers and the Anthropic 200K long-context premium are
+hand-tracked override tables in `model_pricing.rs` (no machine-readable
+source publishes them; the latter appears in models.dev only under gateway
+spellings the provider allowlist drops).
+
+Costs are event-time: pricing snapshot refreshes do not retroactively
+rewrite already-emitted buckets (only changed buckets recompute) - intended.
+The emitted splits are the repricing contract: a different pricing sheet can
+recompute a bucket as `base tokens x base rates + long-context tokens x
+above rates` (whole-request selection already applied client-side), with 1h
+cache writes at 2x the tier's input rate, times the fast multiplier when
+`speed = 1`, plus `transcript_cost_micro_usd` as a fixed term (its tokens
+are included in the totals, so such buckets reprice approximately).
+Remaining pricing deviations from ccusage: no `codex-auto-review` model
+mapping, and no marginal-at-200K arm for above-rates-without-threshold data
+(unreachable with a models.dev-sourced catalog); `git-ai usage` approximates
+from the same catalog without tiering/multiplier/1h refinements, so
 TokenUsage events are the authoritative dollars.
 
 ## Session identity

--- a/docs/token-usage-events-spec.md
+++ b/docs/token-usage-events-spec.md
@@ -140,10 +140,11 @@ fast-speed entries. Codex service tiers come from `thread_settings_applied`
 (sticky), falling back to the `service_tier` in the rollout's codex-home
 `config.toml`, else standard; unlike ccusage, the fallback is resolved and
 stored at extraction time, so a config change never retroactively reprices
-history. Fast multipliers and the Anthropic 200K long-context premium are
-hand-tracked override tables in `model_pricing.rs` (no machine-readable
-source publishes them; the latter appears in models.dev only under gateway
-spellings the provider allowlist drops).
+history. Fast multipliers and the pre-4.6 Anthropic 200K long-context
+premium are hand-tracked override tables in `model_pricing.rs` (no
+machine-readable source publishes them). Per Anthropic's pricing page,
+Claude 4.6+ models include the full 1M context window at standard pricing,
+so the premium override covers only the 1M-beta era (sonnet-4-5).
 
 Costs are event-time: pricing snapshot refreshes do not retroactively
 rewrite already-emitted buckets (only changed buckets recompute) - intended.

--- a/docs/token-usage-events-spec.md
+++ b/docs/token-usage-events-spec.md
@@ -120,11 +120,12 @@ cache_write_1h}_tokens` (tokens of requests that selected their model's
 long-context tier; base-tier tokens are the totals minus these), and
 `transcript_cost_micro_usd` (the portion of `est_cost_micro_usd` that came
 from transcript `costUSD` fields). Standard `EventAttributes` carry tool,
-model, session ids, and repo_url (no git spawn); `custom_attributes` carries
-the id of the pricing catalog that priced the bucket's catalog-priced entries
-(`pricing_catalog`: `embedded:<version>` or `modelsdev:<hash>`; a bucket that
-mixes catalogs — a refresh plus daemon restart mid-bucket — reports the
-greatest id, an approximation).
+model, session ids, and repo_url (no git spawn); the dedicated
+`pricing_catalog` attribute carries the id of the catalog that priced the
+bucket's catalog-priced entries (`embedded:<version>` or `modelsdev:<hash>`;
+a bucket that mixes catalogs — a refresh plus daemon restart mid-bucket —
+reports the greatest id, an approximation). `custom_attributes` stays
+reserved for the org-configured attribute map every event type carries.
 
 Cost follows ccusage's "auto" mode per entry: the transcript's own `costUSD`
 wins (negative/non-finite values are treated as absent, and every per-entry

--- a/docs/token-usage-events-spec.md
+++ b/docs/token-usage-events-spec.md
@@ -112,16 +112,19 @@ Values (`token_usage_pos`): `bucket_ts`, `input_tokens`, `output_tokens`,
 `reasoning_output_tokens` (optional; Codex reports it as a subset of output),
 `est_cost_micro_usd` (u64 micro-USD), `credits` (f64, reserved),
 `message_count`, `emitted_seq`, `speed` (0/1, the bucket-key dimension),
-`speed_inferred` (any entry's tier came from configuration rather than the
-transcript), `cache_write_1h_tokens` (the 1h-TTL portion of
-`cache_write_tokens`), `long_context_{input,output,cache_read,cache_write,
+`speed_inferred` (any entry's tier was not recorded in the transcript —
+resolved from configuration or the standard default), `cache_write_1h_tokens`
+(the 1h-TTL portion of `cache_write_tokens`),
+`long_context_{input,output,cache_read,cache_write,
 cache_write_1h}_tokens` (tokens of requests that selected their model's
 long-context tier; base-tier tokens are the totals minus these), and
 `transcript_cost_micro_usd` (the portion of `est_cost_micro_usd` that came
 from transcript `costUSD` fields). Standard `EventAttributes` carry tool,
 model, session ids, and repo_url (no git spawn); `custom_attributes` carries
-the id of the pricing catalog that priced the bucket's latest catalog-priced
-entry (`pricing_catalog`: `embedded:<version>` or `modelsdev:<hash>`).
+the id of the pricing catalog that priced the bucket's catalog-priced entries
+(`pricing_catalog`: `embedded:<version>` or `modelsdev:<hash>`; a bucket that
+mixes catalogs — a refresh plus daemon restart mid-bucket — reports the
+greatest id, an approximation).
 
 Cost follows ccusage's "auto" mode per entry: the transcript's own `costUSD`
 wins (negative/non-finite values are treated as absent, and every per-entry

--- a/docs/token-usage-events-spec.md
+++ b/docs/token-usage-events-spec.md
@@ -152,7 +152,9 @@ recompute a bucket as `base tokens x base rates + long-context tokens x
 above rates` (whole-request selection already applied client-side), with 1h
 cache writes at 2x the tier's input rate, times the fast multiplier when
 `speed = 1`, plus `transcript_cost_micro_usd` as a fixed term (its tokens
-are included in the totals, so such buckets reprice approximately).
+are included in the totals, so such buckets reprice approximately; the same
+holds for buckets containing entries clamped at the $10k per-entry ceiling,
+whose token counts are not clamped).
 Remaining pricing deviations from ccusage: no `codex-auto-review` model
 mapping, and no marginal-at-200K arm for above-rates-without-threshold data
 (unreachable with a models.dev-sourced catalog); `git-ai usage` approximates

--- a/src/daemon/token_usage_worker.rs
+++ b/src/daemon/token_usage_worker.rs
@@ -1001,8 +1001,9 @@ fn emit_changed_buckets(
             attrs = attrs.repo_url(url.clone());
         }
         if let Some(catalog) = &aggregate.pricing_catalog {
-            attrs = attrs
-                .custom_attributes(serde_json::json!({ "pricing_catalog": catalog }).to_string());
+            // A dedicated attribute: custom_attributes stays reserved for
+            // the org-configured map every event type carries.
+            attrs = attrs.pricing_catalog(catalog.clone());
         }
         events.push(MetricEvent::new(&values, attrs.to_sparse()));
     }
@@ -1569,16 +1570,21 @@ mod tests {
         assert_eq!(value_u64(standard, token_usage_pos::SPEED), Some(0));
         assert_eq!(
             value_u64(standard, token_usage_pos::SPEED_INFERRED),
-            Some(0)
+            Some(1),
+            "no usage.speed marker was recorded on the standard entry"
         );
         assert_eq!(
             value_u64(standard, token_usage_pos::TRANSCRIPT_COST_MICRO_USD),
             Some(0)
         );
-        // Catalog-priced: the pricing catalog id rides custom_attributes.
+        // Catalog-priced: the pricing catalog id rides its dedicated
+        // attribute (custom_attributes stays free for the org map).
         let attrs = EventAttributes::from_sparse(&standard.attrs);
-        let custom = attrs.custom_attributes.unwrap().unwrap();
-        assert!(custom.contains("pricing_catalog"), "{custom}");
+        assert_eq!(
+            attrs.pricing_catalog.flatten().as_deref(),
+            Some(crate::metrics::model_pricing::pricing_catalog_id())
+        );
+        assert_eq!(attrs.custom_attributes, None);
 
         let fast = &events[1];
         assert_eq!(value_u64(fast, token_usage_pos::SPEED), Some(1));
@@ -1600,7 +1606,7 @@ mod tests {
             Some(500_000)
         );
         let attrs = EventAttributes::from_sparse(&fast.attrs);
-        assert!(attrs.custom_attributes.flatten().is_none());
+        assert!(attrs.pricing_catalog.flatten().is_none());
     }
 
     #[test]

--- a/src/daemon/token_usage_worker.rs
+++ b/src/daemon/token_usage_worker.rs
@@ -963,6 +963,10 @@ fn emit_changed_buckets(
         .collect();
     token_db.reserve_emit_seqs(&identity.session_id, &reservations)?;
     let repo_url = resolve_repo_url();
+    // The org-configured attribute map every event type carries (the
+    // checkpoint and session emitters attach the same one).
+    let config = crate::config::Config::fresh();
+    let custom_attributes = config.custom_attributes();
     let mut events = Vec::with_capacity(changed.len());
     for (bucket, next_seq) in &changed {
         let aggregate = &bucket.aggregate;
@@ -989,6 +993,7 @@ fn emit_changed_buckets(
             .long_context_cache_write_1h_tokens(aggregate.long_context_cache_write_1h)
             .transcript_cost_micro_usd(aggregate.transcript_cost_micro_usd);
         let mut attrs = EventAttributes::with_version(env!("CARGO_PKG_VERSION"))
+            .custom_attributes_map(custom_attributes)
             .session_id(identity.session_id.clone())
             .tool(&identity.tool)
             .model(&bucket.model);

--- a/src/daemon/token_usage_worker.rs
+++ b/src/daemon/token_usage_worker.rs
@@ -950,9 +950,16 @@ fn emit_changed_buckets(
             (bucket, next_seq)
         })
         .collect();
-    let reservations: Vec<(String, u32, u64)> = changed
+    let reservations: Vec<(String, u8, u32, u64)> = changed
         .iter()
-        .map(|(bucket, next_seq)| (bucket.model.clone(), bucket.bucket_ts, *next_seq))
+        .map(|(bucket, next_seq)| {
+            (
+                bucket.model.clone(),
+                bucket.speed,
+                bucket.bucket_ts,
+                *next_seq,
+            )
+        })
         .collect();
     token_db.reserve_emit_seqs(&identity.session_id, &reservations)?;
     let repo_url = resolve_repo_url();
@@ -971,7 +978,16 @@ fn emit_changed_buckets(
             .message_count(aggregate.message_count)
             // Strictly increasing per bucket: the server keeps the highest
             // revision, so same-second re-emissions cannot tie.
-            .emitted_seq(*next_seq);
+            .emitted_seq(*next_seq)
+            .speed(bucket.speed as u32)
+            .speed_inferred(aggregate.speed_inferred)
+            .cache_write_1h_tokens(aggregate.cache_write_1h)
+            .long_context_input_tokens(aggregate.long_context_input)
+            .long_context_output_tokens(aggregate.long_context_output)
+            .long_context_cache_read_tokens(aggregate.long_context_cache_read)
+            .long_context_cache_write_tokens(aggregate.long_context_cache_write)
+            .long_context_cache_write_1h_tokens(aggregate.long_context_cache_write_1h)
+            .transcript_cost_micro_usd(aggregate.transcript_cost_micro_usd);
         let mut attrs = EventAttributes::with_version(env!("CARGO_PKG_VERSION"))
             .session_id(identity.session_id.clone())
             .tool(&identity.tool)
@@ -984,6 +1000,10 @@ fn emit_changed_buckets(
         if let Some(url) = &repo_url {
             attrs = attrs.repo_url(url.clone());
         }
+        if let Some(catalog) = &aggregate.pricing_catalog {
+            attrs = attrs
+                .custom_attributes(serde_json::json!({ "pricing_catalog": catalog }).to_string());
+        }
         events.push(MetricEvent::new(&values, attrs.to_sparse()));
     }
     sink(&events)?;
@@ -992,6 +1012,7 @@ fn emit_changed_buckets(
         token_db.mark_emitted(
             &identity.session_id,
             &bucket.model,
+            bucket.speed,
             bucket.bucket_ts,
             &bucket.aggregate.fingerprint(),
             next_seq,
@@ -1356,7 +1377,7 @@ mod tests {
             Some(50)
         );
         let first_bucket = db
-            .aggregate_bucket(&identity.session_id, "gpt-5", bucket_of(1, 0) as u32)
+            .aggregate_bucket(&identity.session_id, "gpt-5", 0, bucket_of(1, 0) as u32)
             .unwrap();
         assert_eq!(first_bucket.message_count, 1, "no double count");
     }
@@ -1378,7 +1399,12 @@ mod tests {
         let events = run(&db, &transcript).unwrap();
         assert!(events.is_empty(), "no aggregate change from the re-read");
         let agg = db
-            .aggregate_bucket("s_test", "claude-sonnet-4-20250514", bucket_of(1, 0) as u32)
+            .aggregate_bucket(
+                "s_test",
+                "claude-sonnet-4-20250514",
+                0,
+                bucket_of(1, 0) as u32,
+            )
             .unwrap();
         assert_eq!(agg.message_count, 2);
     }
@@ -1512,6 +1538,69 @@ mod tests {
             value_u64(&events[0], token_usage_pos::INPUT_TOKENS),
             Some(10)
         );
+    }
+
+    #[test]
+    fn fast_and_standard_usage_emit_separate_bucket_events() {
+        let (_dir, db, transcript) = setup();
+        let fast_line = format!(
+            r#"{{"timestamp":"{}","sessionId":"ext-test","requestId":"r1","costUSD":0.5,"message":{{"id":"m1","model":"claude-sonnet-4-20250514","usage":{{"input_tokens":100,"output_tokens":50,"speed":"fast","cache_creation":{{"ephemeral_5m_input_tokens":10,"ephemeral_1h_input_tokens":20}}}}}}}}"#,
+            recent_ts(1, 0)
+        );
+        fs::write(
+            &transcript,
+            format!(
+                "{fast_line}\n{}\n",
+                claude_line("m2", "r2", &recent_ts(1, 30), 50)
+            ),
+        )
+        .unwrap();
+
+        let mut events = run(&db, &transcript).unwrap();
+        events.sort_by_key(|e| value_u64(e, token_usage_pos::SPEED));
+        assert_eq!(events.len(), 2, "one event per speed, same model+bucket");
+        for event in &events {
+            assert_eq!(
+                value_u64(event, token_usage_pos::BUCKET_TS),
+                Some(bucket_of(1, 0))
+            );
+        }
+        let standard = &events[0];
+        assert_eq!(value_u64(standard, token_usage_pos::SPEED), Some(0));
+        assert_eq!(
+            value_u64(standard, token_usage_pos::SPEED_INFERRED),
+            Some(0)
+        );
+        assert_eq!(
+            value_u64(standard, token_usage_pos::TRANSCRIPT_COST_MICRO_USD),
+            Some(0)
+        );
+        // Catalog-priced: the pricing catalog id rides custom_attributes.
+        let attrs = EventAttributes::from_sparse(&standard.attrs);
+        let custom = attrs.custom_attributes.unwrap().unwrap();
+        assert!(custom.contains("pricing_catalog"), "{custom}");
+
+        let fast = &events[1];
+        assert_eq!(value_u64(fast, token_usage_pos::SPEED), Some(1));
+        assert_eq!(
+            value_u64(fast, token_usage_pos::CACHE_WRITE_TOKENS),
+            Some(30)
+        );
+        assert_eq!(
+            value_u64(fast, token_usage_pos::CACHE_WRITE_1H_TOKENS),
+            Some(20)
+        );
+        // costUSD 0.5 -> the whole cost is transcript-provided; no catalog.
+        assert_eq!(
+            value_u64(fast, token_usage_pos::TRANSCRIPT_COST_MICRO_USD),
+            Some(500_000)
+        );
+        assert_eq!(
+            value_u64(fast, token_usage_pos::EST_COST_MICRO_USD),
+            Some(500_000)
+        );
+        let attrs = EventAttributes::from_sparse(&fast.attrs);
+        assert!(attrs.custom_attributes.flatten().is_none());
     }
 
     #[test]

--- a/src/metrics/attrs.rs
+++ b/src/metrics/attrs.rs
@@ -21,6 +21,7 @@ pub mod attr_pos {
     pub const PARENT_SESSION_ID: usize = 26;
     pub const EXTERNAL_PARENT_SESSION_ID: usize = 27;
     pub const CUSTOM_ATTRIBUTES: usize = 30;
+    pub const PRICING_CATALOG: usize = 31;
 }
 
 /// Common attributes for all events.
@@ -42,6 +43,7 @@ pub mod attr_pos {
 /// | 26 | parent_session_id | String | No (nullable) |
 /// | 27 | external_parent_session_id | String | No (nullable) |
 /// | 30 | custom_attributes | String (JSON) | No (nullable) |
+/// | 31 | pricing_catalog | String | No (nullable) |
 #[derive(Debug, Clone, Default)]
 pub struct EventAttributes {
     pub git_ai_version: PosField<String>,
@@ -59,6 +61,11 @@ pub struct EventAttributes {
     pub external_session_id: PosField<String>,
     pub external_parent_session_id: PosField<String>,
     pub custom_attributes: PosField<String>,
+    /// Pricing catalog that priced a TokenUsage bucket's catalog-priced
+    /// entries (e.g. "embedded:<version>", "modelsdev:<hash>"). A dedicated
+    /// slot: custom_attributes stays reserved for the org-configured
+    /// attribute map every event type carries.
+    pub pricing_catalog: PosField<String>,
 }
 
 impl EventAttributes {
@@ -249,6 +256,12 @@ impl EventAttributes {
         }
     }
 
+    // Builder methods for pricing_catalog
+    pub fn pricing_catalog(mut self, value: impl Into<String>) -> Self {
+        self.pricing_catalog = Some(Some(value.into()));
+        self
+    }
+
     // Builder methods for custom_attributes
     pub fn custom_attributes(mut self, value: impl Into<String>) -> Self {
         self.custom_attributes = Some(Some(value.into()));
@@ -323,6 +336,11 @@ impl PosEncoded for EventAttributes {
             attr_pos::CUSTOM_ATTRIBUTES,
             string_to_json(&self.custom_attributes),
         );
+        sparse_set(
+            &mut map,
+            attr_pos::PRICING_CATALOG,
+            string_to_json(&self.pricing_catalog),
+        );
         map
     }
 
@@ -346,6 +364,7 @@ impl PosEncoded for EventAttributes {
                 attr_pos::EXTERNAL_PARENT_SESSION_ID,
             ),
             custom_attributes: sparse_get_string(arr, attr_pos::CUSTOM_ATTRIBUTES),
+            pricing_catalog: sparse_get_string(arr, attr_pos::PRICING_CATALOG),
         }
     }
 }

--- a/src/metrics/attrs.rs
+++ b/src/metrics/attrs.rs
@@ -62,7 +62,7 @@ pub struct EventAttributes {
     pub external_parent_session_id: PosField<String>,
     pub custom_attributes: PosField<String>,
     /// Pricing catalog that priced a TokenUsage bucket's catalog-priced
-    /// entries (e.g. "embedded:<version>", "modelsdev:<hash>"). A dedicated
+    /// entries (e.g. `embedded:1.7.1`, `modelsdev:<hash>`). A dedicated
     /// slot: custom_attributes stays reserved for the org-configured
     /// attribute map every event type carries.
     pub pricing_catalog: PosField<String>,

--- a/src/metrics/events.rs
+++ b/src/metrics/events.rs
@@ -2358,18 +2358,35 @@ pub mod token_usage_pos {
     pub const CREDITS: usize = 8; // f64 - reserved for credit-based agents
     pub const MESSAGE_COUNT: usize = 9; // u32 - deduplicated entries in the bucket
     pub const EMITTED_SEQ: usize = 10; // u64 - per-bucket emission revision
+    pub const SPEED: usize = 11; // u32 - bucket key dimension: 0 standard, 1 fast
+    pub const SPEED_INFERRED: usize = 12; // u32 0/1 - any entry's tier inferred from config
+    pub const CACHE_WRITE_1H_TOKENS: usize = 13; // u64 - 1h-TTL portion of cache_write_tokens
+    pub const LONG_CONTEXT_INPUT_TOKENS: usize = 14; // u64 - portion billed at long-context rates
+    pub const LONG_CONTEXT_OUTPUT_TOKENS: usize = 15; // u64
+    pub const LONG_CONTEXT_CACHE_READ_TOKENS: usize = 16; // u64
+    pub const LONG_CONTEXT_CACHE_WRITE_TOKENS: usize = 17; // u64
+    pub const LONG_CONTEXT_CACHE_WRITE_1H_TOKENS: usize = 18; // u64
+    pub const TRANSCRIPT_COST_MICRO_USD: usize = 19; // u64 - portion of cost from transcript costUSD
 }
 
 /// Values for Event ID 9: token_usage
 ///
-/// One event per (session_id, model, bucket_ts): the deduplicated token usage
-/// and estimated cost of a 5-minute UTC bucket. The server upserts on that
-/// key keeping the highest emitted_seq (a strictly increasing per-bucket
-/// revision), so a bucket is re-emitted whenever its aggregate changes
-/// (including corrections downward and drops to zero) and same-second
-/// re-emissions cannot tie on the u32-second event_ts. Uses EventAttributes
-/// for standard metadata (repo_url, tool, model, session ids, etc.); the
-/// model attribute is the bucket's model.
+/// One event per (session_id, model, speed, bucket_ts): the deduplicated
+/// token usage and estimated cost of a 5-minute UTC bucket. The server
+/// upserts on that key keeping the highest emitted_seq (a strictly
+/// increasing per-bucket revision), so a bucket is re-emitted whenever its
+/// aggregate changes (including corrections downward and drops to zero) and
+/// same-second re-emissions cannot tie on the u32-second event_ts. Uses
+/// EventAttributes for standard metadata (repo_url, tool, model, session
+/// ids, etc.); the model attribute is the bucket's model, and the pricing
+/// catalog id rides custom_attributes.
+///
+/// Positions 11-19 carry what a different pricing sheet needs to recompute
+/// the cost: the speed dimension and inference flag, the 1h cache-write
+/// split, the long-context token splits (tokens of requests that selected
+/// their model's long-context tier — whole-request selection happens client
+/// side; base-tier tokens are the totals minus these), and the
+/// non-recomputable transcript-priced portion of the cost.
 ///
 /// **Fields:**
 /// | Position | Name | Type |
@@ -2385,6 +2402,15 @@ pub mod token_usage_pos {
 /// | 8 | credits | f64 (reserved, unset) |
 /// | 9 | message_count | u32 |
 /// | 10 | emitted_seq | u64 |
+/// | 11 | speed | u32 (0 standard, 1 fast; part of the bucket key) |
+/// | 12 | speed_inferred | u32 (0/1) |
+/// | 13 | cache_write_1h_tokens | u64 |
+/// | 14 | long_context_input_tokens | u64 |
+/// | 15 | long_context_output_tokens | u64 |
+/// | 16 | long_context_cache_read_tokens | u64 |
+/// | 17 | long_context_cache_write_tokens | u64 |
+/// | 18 | long_context_cache_write_1h_tokens | u64 |
+/// | 19 | transcript_cost_micro_usd | u64 |
 #[derive(Debug, Clone, Default)]
 pub struct TokenUsageValues {
     pub bucket_ts: PosField<u64>,
@@ -2398,6 +2424,15 @@ pub struct TokenUsageValues {
     pub credits: PosField<f64>,
     pub message_count: PosField<u32>,
     pub emitted_seq: PosField<u64>,
+    pub speed: PosField<u32>,
+    pub speed_inferred: PosField<u32>,
+    pub cache_write_1h_tokens: PosField<u64>,
+    pub long_context_input_tokens: PosField<u64>,
+    pub long_context_output_tokens: PosField<u64>,
+    pub long_context_cache_read_tokens: PosField<u64>,
+    pub long_context_cache_write_tokens: PosField<u64>,
+    pub long_context_cache_write_1h_tokens: PosField<u64>,
+    pub transcript_cost_micro_usd: PosField<u64>,
 }
 
 impl TokenUsageValues {
@@ -2463,6 +2498,51 @@ impl TokenUsageValues {
         self.emitted_seq = Some(Some(value));
         self
     }
+
+    pub fn speed(mut self, value: u32) -> Self {
+        self.speed = Some(Some(value));
+        self
+    }
+
+    pub fn speed_inferred(mut self, value: bool) -> Self {
+        self.speed_inferred = Some(Some(value as u32));
+        self
+    }
+
+    pub fn cache_write_1h_tokens(mut self, value: u64) -> Self {
+        self.cache_write_1h_tokens = Some(Some(value));
+        self
+    }
+
+    pub fn long_context_input_tokens(mut self, value: u64) -> Self {
+        self.long_context_input_tokens = Some(Some(value));
+        self
+    }
+
+    pub fn long_context_output_tokens(mut self, value: u64) -> Self {
+        self.long_context_output_tokens = Some(Some(value));
+        self
+    }
+
+    pub fn long_context_cache_read_tokens(mut self, value: u64) -> Self {
+        self.long_context_cache_read_tokens = Some(Some(value));
+        self
+    }
+
+    pub fn long_context_cache_write_tokens(mut self, value: u64) -> Self {
+        self.long_context_cache_write_tokens = Some(Some(value));
+        self
+    }
+
+    pub fn long_context_cache_write_1h_tokens(mut self, value: u64) -> Self {
+        self.long_context_cache_write_1h_tokens = Some(Some(value));
+        self
+    }
+
+    pub fn transcript_cost_micro_usd(mut self, value: u64) -> Self {
+        self.transcript_cost_micro_usd = Some(Some(value));
+        self
+    }
 }
 
 impl PosEncoded for TokenUsageValues {
@@ -2523,6 +2603,47 @@ impl PosEncoded for TokenUsageValues {
             token_usage_pos::EMITTED_SEQ,
             u64_to_json(&self.emitted_seq),
         );
+        sparse_set(&mut map, token_usage_pos::SPEED, u32_to_json(&self.speed));
+        sparse_set(
+            &mut map,
+            token_usage_pos::SPEED_INFERRED,
+            u32_to_json(&self.speed_inferred),
+        );
+        sparse_set(
+            &mut map,
+            token_usage_pos::CACHE_WRITE_1H_TOKENS,
+            u64_to_json(&self.cache_write_1h_tokens),
+        );
+        sparse_set(
+            &mut map,
+            token_usage_pos::LONG_CONTEXT_INPUT_TOKENS,
+            u64_to_json(&self.long_context_input_tokens),
+        );
+        sparse_set(
+            &mut map,
+            token_usage_pos::LONG_CONTEXT_OUTPUT_TOKENS,
+            u64_to_json(&self.long_context_output_tokens),
+        );
+        sparse_set(
+            &mut map,
+            token_usage_pos::LONG_CONTEXT_CACHE_READ_TOKENS,
+            u64_to_json(&self.long_context_cache_read_tokens),
+        );
+        sparse_set(
+            &mut map,
+            token_usage_pos::LONG_CONTEXT_CACHE_WRITE_TOKENS,
+            u64_to_json(&self.long_context_cache_write_tokens),
+        );
+        sparse_set(
+            &mut map,
+            token_usage_pos::LONG_CONTEXT_CACHE_WRITE_1H_TOKENS,
+            u64_to_json(&self.long_context_cache_write_1h_tokens),
+        );
+        sparse_set(
+            &mut map,
+            token_usage_pos::TRANSCRIPT_COST_MICRO_USD,
+            u64_to_json(&self.transcript_cost_micro_usd),
+        );
         map
     }
 
@@ -2539,6 +2660,33 @@ impl PosEncoded for TokenUsageValues {
             credits: sparse_get_f64(arr, token_usage_pos::CREDITS),
             message_count: sparse_get_u32(arr, token_usage_pos::MESSAGE_COUNT),
             emitted_seq: sparse_get_u64(arr, token_usage_pos::EMITTED_SEQ),
+            speed: sparse_get_u32(arr, token_usage_pos::SPEED),
+            speed_inferred: sparse_get_u32(arr, token_usage_pos::SPEED_INFERRED),
+            cache_write_1h_tokens: sparse_get_u64(arr, token_usage_pos::CACHE_WRITE_1H_TOKENS),
+            long_context_input_tokens: sparse_get_u64(
+                arr,
+                token_usage_pos::LONG_CONTEXT_INPUT_TOKENS,
+            ),
+            long_context_output_tokens: sparse_get_u64(
+                arr,
+                token_usage_pos::LONG_CONTEXT_OUTPUT_TOKENS,
+            ),
+            long_context_cache_read_tokens: sparse_get_u64(
+                arr,
+                token_usage_pos::LONG_CONTEXT_CACHE_READ_TOKENS,
+            ),
+            long_context_cache_write_tokens: sparse_get_u64(
+                arr,
+                token_usage_pos::LONG_CONTEXT_CACHE_WRITE_TOKENS,
+            ),
+            long_context_cache_write_1h_tokens: sparse_get_u64(
+                arr,
+                token_usage_pos::LONG_CONTEXT_CACHE_WRITE_1H_TOKENS,
+            ),
+            transcript_cost_micro_usd: sparse_get_u64(
+                arr,
+                token_usage_pos::TRANSCRIPT_COST_MICRO_USD,
+            ),
         }
     }
 }
@@ -2611,7 +2759,16 @@ mod token_usage_tests {
             .est_cost_micro_usd(6)
             .credits(7.5)
             .message_count(8)
-            .emitted_seq(9);
+            .emitted_seq(9)
+            .speed(1)
+            .speed_inferred(true)
+            .cache_write_1h_tokens(11)
+            .long_context_input_tokens(12)
+            .long_context_output_tokens(13)
+            .long_context_cache_read_tokens(14)
+            .long_context_cache_write_tokens(15)
+            .long_context_cache_write_1h_tokens(16)
+            .transcript_cost_micro_usd(17);
         let sparse = PosEncoded::to_sparse(&values);
         let ordered: std::collections::BTreeMap<usize, &serde_json::Value> = sparse
             .iter()
@@ -2619,7 +2776,7 @@ mod token_usage_tests {
             .collect();
         insta::assert_snapshot!(
             serde_json::to_string(&ordered).unwrap(),
-            @r#"{"0":1767225600,"1":1,"2":2,"3":3,"4":4,"5":10,"6":5,"7":6,"8":7.5,"9":8,"10":9}"#
+            @r#"{"0":1767225600,"1":1,"2":2,"3":3,"4":4,"5":10,"6":5,"7":6,"8":7.5,"9":8,"10":9,"11":1,"12":1,"13":11,"14":12,"15":13,"16":14,"17":15,"18":16,"19":17}"#
         );
     }
 

--- a/src/metrics/events.rs
+++ b/src/metrics/events.rs
@@ -2379,7 +2379,7 @@ pub mod token_usage_pos {
 /// same-second re-emissions cannot tie on the u32-second event_ts. Uses
 /// EventAttributes for standard metadata (repo_url, tool, model, session
 /// ids, etc.); the model attribute is the bucket's model, and the pricing
-/// catalog id rides custom_attributes.
+/// catalog id rides its dedicated `pricing_catalog` attribute.
 ///
 /// Positions 11-19 carry what a different pricing sheet needs to recompute
 /// the cost: the speed dimension and inference flag, the 1h cache-write

--- a/src/metrics/events.rs
+++ b/src/metrics/events.rs
@@ -2359,7 +2359,7 @@ pub mod token_usage_pos {
     pub const MESSAGE_COUNT: usize = 9; // u32 - deduplicated entries in the bucket
     pub const EMITTED_SEQ: usize = 10; // u64 - per-bucket emission revision
     pub const SPEED: usize = 11; // u32 - bucket key dimension: 0 standard, 1 fast
-    pub const SPEED_INFERRED: usize = 12; // u32 0/1 - any entry's tier inferred from config
+    pub const SPEED_INFERRED: usize = 12; // u32 0/1 - any entry's tier unrecorded (config/default)
     pub const CACHE_WRITE_1H_TOKENS: usize = 13; // u64 - 1h-TTL portion of cache_write_tokens
     pub const LONG_CONTEXT_INPUT_TOKENS: usize = 14; // u64 - portion billed at long-context rates
     pub const LONG_CONTEXT_OUTPUT_TOKENS: usize = 15; // u64

--- a/src/token_usage/db.rs
+++ b/src/token_usage/db.rs
@@ -295,15 +295,18 @@ pub struct BucketAggregate {
     /// fields — fixed under repricing (its tokens are still in the totals).
     pub transcript_cost_micro_usd: u64,
     pub message_count: u32,
-    /// Any entry's speed was inferred from configuration rather than
-    /// recorded in the transcript.
+    /// Any entry's speed was not recorded in the transcript (resolved from
+    /// configuration or the standard default instead).
     pub speed_inferred: bool,
     pub long_context_input: u64,
     pub long_context_output: u64,
     pub long_context_cache_read: u64,
     pub long_context_cache_write: u64,
     pub long_context_cache_write_1h: u64,
-    /// Latest pricing-catalog id among the bucket's catalog-priced entries.
+    /// Greatest (SQL `MAX`, i.e. lexicographic — not most recent) pricing-
+    /// catalog id among the bucket's catalog-priced entries. Buckets price
+    /// under one catalog in practice; one that mixes catalogs (a refresh
+    /// plus daemon restart mid-bucket) is identified approximately.
     pub pricing_catalog: Option<String>,
 }
 

--- a/src/token_usage/db.rs
+++ b/src/token_usage/db.rs
@@ -204,6 +204,25 @@ const MIGRATIONS: &[&str] = &[
 
     INSERT INTO schema_version (version) VALUES (3);
     "#,
+    // Version 4: buckets gain the speed dimension (fast and standard usage
+    // of one model bill at different rates, so they must never share a
+    // bucket identity on the server). Pre-release reset like v3.
+    r#"
+    DROP TABLE bucket_state;
+
+    CREATE TABLE bucket_state (
+        session_id TEXT NOT NULL,
+        model      TEXT NOT NULL,
+        speed      INTEGER NOT NULL DEFAULT 0,
+        bucket_ts  INTEGER NOT NULL,
+        emitted_fingerprint TEXT NOT NULL,
+        last_emitted_at INTEGER NOT NULL,
+        emit_seq INTEGER NOT NULL DEFAULT 0,
+        PRIMARY KEY (session_id, model, speed, bucket_ts)
+    );
+
+    INSERT INTO schema_version (version) VALUES (4);
+    "#,
 ];
 
 const TRACKED_FILE_COLUMNS: &str = "session_id, stream_path, tool, byte_offset, state_json, \
@@ -254,19 +273,38 @@ fn read_tracked_file(row: &rusqlite::Row<'_>) -> rusqlite::Result<TrackedFile> {
     })
 }
 
-/// The aggregate of one `(session_id, model, bucket_ts)` bucket, i.e. exactly
-/// the values a TokenUsage event carries.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+/// The aggregate of one `(session_id, model, speed, bucket_ts)` bucket, i.e.
+/// exactly the values a TokenUsage event carries. The long-context sums are
+/// the tokens of entries whose request selected the model's long-context
+/// tier (whole-request selection at pricing time), so a different pricing
+/// sheet can rebill the bucket: base tokens are the totals minus these.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct BucketAggregate {
     pub input: u64,
     pub output: u64,
     pub cache_read: u64,
     pub cache_write: u64,
+    /// Portion of `cache_write` written with a 1-hour TTL (billed at 2x the
+    /// input rate of the entry's tier).
+    pub cache_write_1h: u64,
     /// `Some` iff any entry in the bucket reported reasoning tokens.
     pub reasoning_output: Option<u64>,
     pub total: u64,
     pub cost_micro_usd: u64,
+    /// Portion of `cost_micro_usd` that came from transcript `costUSD`
+    /// fields — fixed under repricing (its tokens are still in the totals).
+    pub transcript_cost_micro_usd: u64,
     pub message_count: u32,
+    /// Any entry's speed was inferred from configuration rather than
+    /// recorded in the transcript.
+    pub speed_inferred: bool,
+    pub long_context_input: u64,
+    pub long_context_output: u64,
+    pub long_context_cache_read: u64,
+    pub long_context_cache_write: u64,
+    pub long_context_cache_write_1h: u64,
+    /// Latest pricing-catalog id among the bucket's catalog-priced entries.
+    pub pricing_catalog: Option<String>,
 }
 
 impl BucketAggregate {
@@ -274,16 +312,24 @@ impl BucketAggregate {
     /// drop to zero - changes the fingerprint.
     pub fn fingerprint(&self) -> String {
         format!(
-            "{}:{}:{}:{}:{}:{}:{}:{}",
+            "{}:{}:{}:{}:{}:{}:{}:{}:{}:{}:{}:{}:{}:{}:{}:{}",
             self.input,
             self.output,
             self.cache_read,
             self.cache_write,
+            self.cache_write_1h,
             self.reasoning_output
                 .map_or_else(|| "-".to_string(), |v| v.to_string()),
             self.total,
             self.cost_micro_usd,
-            self.message_count
+            self.transcript_cost_micro_usd,
+            self.message_count,
+            self.speed_inferred,
+            self.long_context_input,
+            self.long_context_output,
+            self.long_context_cache_read,
+            self.long_context_cache_write,
+            self.long_context_cache_write_1h,
         )
     }
 }
@@ -293,6 +339,9 @@ impl BucketAggregate {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChangedBucket {
     pub model: String,
+    /// Bucket speed dimension: 0 standard (including entries with no
+    /// recorded marker), 1 fast.
+    pub speed: u8,
     pub bucket_ts: u32,
     pub aggregate: BucketAggregate,
     /// Revision of the last emission for this bucket (0 when never emitted).
@@ -561,65 +610,55 @@ impl TokenUsageDatabase {
     pub fn changed_buckets(&self, session_id: &str) -> Result<Vec<ChangedBucket>, GitAiError> {
         let conn = self.lock();
 
-        // (model, bucket_ts) -> (fingerprint, emit_seq) of the last emission.
+        // (model, speed, bucket_ts) -> (fingerprint, emit_seq) of the last
+        // emission.
         let mut stmt = conn.prepare(
-            "SELECT model, bucket_ts, emitted_fingerprint, emit_seq
+            "SELECT model, speed, bucket_ts, emitted_fingerprint, emit_seq
              FROM bucket_state WHERE session_id = ?1",
         )?;
-        let emitted: Vec<(String, u32, String, i64)> = stmt
+        let emitted: Vec<(String, u8, u32, String, i64)> = stmt
             .query_map(params![session_id], |row| {
-                Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?))
-            })?
-            .collect::<Result<Vec<_>, _>>()?;
-        let mut emitted: std::collections::HashMap<(String, u32), (String, u64)> = emitted
-            .into_iter()
-            .map(|(model, bucket, fp, seq)| ((model, bucket), (fp, seq.max(0) as u64)))
-            .collect();
-
-        let mut stmt = conn.prepare(
-            "SELECT model, bucket_ts,
-                    COALESCE(SUM(input_tokens), 0),
-                    COALESCE(SUM(output_tokens), 0),
-                    COALESCE(SUM(cache_read_tokens), 0),
-                    COALESCE(SUM(cache_write_tokens), 0),
-                    COUNT(reasoning_output_tokens),
-                    COALESCE(SUM(reasoning_output_tokens), 0),
-                    COALESCE(SUM(total_tokens), 0),
-                    COALESCE(SUM(cost_micro_usd), 0),
-                    COUNT(*)
-             FROM usage_entries
-             WHERE session_id = ?1
-             GROUP BY model, bucket_ts",
-        )?;
-        let aggregates: Vec<(String, u32, BucketAggregate)> = stmt
-            .query_map(params![session_id], |row| {
-                let reasoning_entries: i64 = row.get(6)?;
                 Ok((
                     row.get(0)?,
                     row.get(1)?,
-                    BucketAggregate {
-                        input: row.get::<_, i64>(2)? as u64,
-                        output: row.get::<_, i64>(3)? as u64,
-                        cache_read: row.get::<_, i64>(4)? as u64,
-                        cache_write: row.get::<_, i64>(5)? as u64,
-                        reasoning_output: (reasoning_entries > 0)
-                            .then(|| row.get::<_, i64>(7).map(|v| v as u64))
-                            .transpose()?,
-                        total: row.get::<_, i64>(8)? as u64,
-                        cost_micro_usd: row.get::<_, i64>(9)? as u64,
-                        message_count: row.get::<_, i64>(10)? as u32,
-                    },
+                    row.get(2)?,
+                    row.get(3)?,
+                    row.get(4)?,
+                ))
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+        let mut emitted: std::collections::HashMap<(String, u8, u32), (String, u64)> = emitted
+            .into_iter()
+            .map(|(model, speed, bucket, fp, seq)| {
+                ((model, speed, bucket), (fp, seq.max(0) as u64))
+            })
+            .collect();
+
+        let mut stmt = conn.prepare(&format!(
+            "SELECT model, COALESCE(speed, 0), bucket_ts, {AGGREGATE_COLUMNS}
+             FROM usage_entries
+             WHERE session_id = ?1
+             GROUP BY model, COALESCE(speed, 0), bucket_ts",
+        ))?;
+        let aggregates: Vec<(String, u8, u32, BucketAggregate)> = stmt
+            .query_map(params![session_id], |row| {
+                Ok((
+                    row.get(0)?,
+                    row.get(1)?,
+                    row.get(2)?,
+                    read_aggregate(row, 3)?,
                 ))
             })?
             .collect::<Result<Vec<_>, _>>()?;
 
         let mut changed = Vec::new();
-        for (model, bucket, aggregate) in aggregates {
-            let last = emitted.remove(&(model.clone(), bucket));
+        for (model, speed, bucket, aggregate) in aggregates {
+            let last = emitted.remove(&(model.clone(), speed, bucket));
             let emit_seq = last.as_ref().map_or(0, |(_, seq)| *seq);
             if last.map(|(fp, _)| fp).as_deref() != Some(aggregate.fingerprint().as_str()) {
                 changed.push(ChangedBucket {
                     model,
+                    speed,
                     bucket_ts: bucket,
                     aggregate,
                     emit_seq,
@@ -628,11 +667,12 @@ impl TokenUsageDatabase {
         }
         // Buckets with emission state but no remaining entries: emptied, and
         // re-emitted as zero unless zero was already emitted.
-        for ((model, bucket), (fingerprint, emit_seq)) in emitted {
+        for ((model, speed, bucket), (fingerprint, emit_seq)) in emitted {
             let aggregate = BucketAggregate::default();
             if fingerprint != aggregate.fingerprint() {
                 changed.push(ChangedBucket {
                     model,
+                    speed,
                     bucket_ts: bucket,
                     aggregate,
                     emit_seq,
@@ -680,36 +720,18 @@ impl TokenUsageDatabase {
         &self,
         session_id: &str,
         model: &str,
+        speed: u8,
         bucket: u32,
     ) -> Result<BucketAggregate, GitAiError> {
         Ok(self.lock().query_row(
-            "SELECT COALESCE(SUM(input_tokens), 0),
-                    COALESCE(SUM(output_tokens), 0),
-                    COALESCE(SUM(cache_read_tokens), 0),
-                    COALESCE(SUM(cache_write_tokens), 0),
-                    COUNT(reasoning_output_tokens),
-                    COALESCE(SUM(reasoning_output_tokens), 0),
-                    COALESCE(SUM(total_tokens), 0),
-                    COALESCE(SUM(cost_micro_usd), 0),
-                    COUNT(*)
-             FROM usage_entries
-             WHERE session_id = ?1 AND model = ?2 AND bucket_ts = ?3",
-            params![session_id, model, bucket],
-            |row| {
-                let reasoning_entries: i64 = row.get(4)?;
-                Ok(BucketAggregate {
-                    input: row.get::<_, i64>(0)? as u64,
-                    output: row.get::<_, i64>(1)? as u64,
-                    cache_read: row.get::<_, i64>(2)? as u64,
-                    cache_write: row.get::<_, i64>(3)? as u64,
-                    reasoning_output: (reasoning_entries > 0)
-                        .then(|| row.get::<_, i64>(5).map(|v| v as u64))
-                        .transpose()?,
-                    total: row.get::<_, i64>(6)? as u64,
-                    cost_micro_usd: row.get::<_, i64>(7)? as u64,
-                    message_count: row.get::<_, i64>(8)? as u32,
-                })
-            },
+            &format!(
+                "SELECT {AGGREGATE_COLUMNS}
+                 FROM usage_entries
+                 WHERE session_id = ?1 AND model = ?2 AND COALESCE(speed, 0) = ?3
+                   AND bucket_ts = ?4"
+            ),
+            params![session_id, model, speed, bucket],
+            |row| read_aggregate(row, 0),
         )?)
     }
 
@@ -718,14 +740,15 @@ impl TokenUsageDatabase {
         &self,
         session_id: &str,
         model: &str,
+        speed: u8,
         bucket: u32,
     ) -> Result<Option<String>, GitAiError> {
         Ok(self
             .lock()
             .query_row(
                 "SELECT emitted_fingerprint FROM bucket_state
-                 WHERE session_id = ?1 AND model = ?2 AND bucket_ts = ?3",
-                params![session_id, model, bucket],
+                 WHERE session_id = ?1 AND model = ?2 AND speed = ?3 AND bucket_ts = ?4",
+                params![session_id, model, speed, bucket],
                 |row| row.get(0),
             )
             .optional()?)
@@ -741,17 +764,17 @@ impl TokenUsageDatabase {
     pub fn reserve_emit_seqs(
         &self,
         session_id: &str,
-        reservations: &[(String, u32, u64)],
+        reservations: &[(String, u8, u32, u64)],
     ) -> Result<(), GitAiError> {
         let mut conn = self.lock();
         let tx = conn.transaction()?;
-        for (model, bucket, emit_seq) in reservations {
+        for (model, speed, bucket, emit_seq) in reservations {
             tx.execute(
-                "INSERT INTO bucket_state (session_id, model, bucket_ts, emitted_fingerprint, emit_seq, last_emitted_at)
-                 VALUES (?1, ?2, ?3, '', ?4, 0)
-                 ON CONFLICT(session_id, model, bucket_ts)
-                 DO UPDATE SET emit_seq = ?4",
-                params![session_id, model, bucket, to_db_i64(*emit_seq)],
+                "INSERT INTO bucket_state (session_id, model, speed, bucket_ts, emitted_fingerprint, emit_seq, last_emitted_at)
+                 VALUES (?1, ?2, ?3, ?4, '', ?5, 0)
+                 ON CONFLICT(session_id, model, speed, bucket_ts)
+                 DO UPDATE SET emit_seq = ?5",
+                params![session_id, model, speed, bucket, to_db_i64(*emit_seq)],
             )?;
         }
         tx.commit()?;
@@ -760,23 +783,26 @@ impl TokenUsageDatabase {
 
     /// Record that the bucket's current aggregate was handed to the metrics
     /// pipeline as revision `emit_seq`.
+    #[allow(clippy::too_many_arguments)]
     pub fn mark_emitted(
         &self,
         session_id: &str,
         model: &str,
+        speed: u8,
         bucket: u32,
         fingerprint: &str,
         emit_seq: u64,
         now_ts: i64,
     ) -> Result<(), GitAiError> {
         self.lock().execute(
-            "INSERT INTO bucket_state (session_id, model, bucket_ts, emitted_fingerprint, emit_seq, last_emitted_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6)
-             ON CONFLICT(session_id, model, bucket_ts)
-             DO UPDATE SET emitted_fingerprint = ?4, emit_seq = ?5, last_emitted_at = ?6",
+            "INSERT INTO bucket_state (session_id, model, speed, bucket_ts, emitted_fingerprint, emit_seq, last_emitted_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+             ON CONFLICT(session_id, model, speed, bucket_ts)
+             DO UPDATE SET emitted_fingerprint = ?5, emit_seq = ?6, last_emitted_at = ?7",
             params![
                 session_id,
                 model,
+                speed,
                 bucket,
                 fingerprint,
                 to_db_i64(emit_seq),
@@ -804,6 +830,57 @@ impl TokenUsageDatabase {
         tx.commit()?;
         Ok(entries)
     }
+}
+
+/// The SELECT list producing one [`BucketAggregate`], shared by the
+/// reconciliation sweep and the single-bucket lookup so the two can never
+/// disagree on a fingerprint. `long_context` marks entries whose request
+/// selected the long-context tier, so the CASE sums split every token class
+/// by billing tier.
+const AGGREGATE_COLUMNS: &str = "
+    COALESCE(SUM(input_tokens), 0),
+    COALESCE(SUM(output_tokens), 0),
+    COALESCE(SUM(cache_read_tokens), 0),
+    COALESCE(SUM(cache_write_tokens), 0),
+    COALESCE(SUM(cache_write_1h_tokens), 0),
+    COUNT(reasoning_output_tokens),
+    COALESCE(SUM(reasoning_output_tokens), 0),
+    COALESCE(SUM(total_tokens), 0),
+    COALESCE(SUM(cost_micro_usd), 0),
+    COALESCE(SUM(transcript_cost_micro_usd), 0),
+    COUNT(*),
+    COALESCE(MAX(speed_inferred), 0),
+    COALESCE(SUM(CASE WHEN long_context THEN input_tokens ELSE 0 END), 0),
+    COALESCE(SUM(CASE WHEN long_context THEN output_tokens ELSE 0 END), 0),
+    COALESCE(SUM(CASE WHEN long_context THEN cache_read_tokens ELSE 0 END), 0),
+    COALESCE(SUM(CASE WHEN long_context THEN cache_write_tokens ELSE 0 END), 0),
+    COALESCE(SUM(CASE WHEN long_context THEN cache_write_1h_tokens ELSE 0 END), 0),
+    MAX(pricing_catalog)";
+
+/// Read the [`AGGREGATE_COLUMNS`] starting at column `base`.
+fn read_aggregate(row: &rusqlite::Row<'_>, base: usize) -> rusqlite::Result<BucketAggregate> {
+    let reasoning_entries: i64 = row.get(base + 5)?;
+    Ok(BucketAggregate {
+        input: row.get::<_, i64>(base)? as u64,
+        output: row.get::<_, i64>(base + 1)? as u64,
+        cache_read: row.get::<_, i64>(base + 2)? as u64,
+        cache_write: row.get::<_, i64>(base + 3)? as u64,
+        cache_write_1h: row.get::<_, i64>(base + 4)? as u64,
+        reasoning_output: (reasoning_entries > 0)
+            .then(|| row.get::<_, i64>(base + 6).map(|v| v as u64))
+            .transpose()?,
+        total: row.get::<_, i64>(base + 7)? as u64,
+        cost_micro_usd: row.get::<_, i64>(base + 8)? as u64,
+        transcript_cost_micro_usd: row.get::<_, i64>(base + 9)? as u64,
+        message_count: row.get::<_, i64>(base + 10)? as u32,
+        speed_inferred: row.get(base + 11)?,
+        long_context_input: row.get::<_, i64>(base + 12)? as u64,
+        long_context_output: row.get::<_, i64>(base + 13)? as u64,
+        long_context_cache_read: row.get::<_, i64>(base + 14)? as u64,
+        long_context_cache_write: row.get::<_, i64>(base + 15)? as u64,
+        long_context_cache_write_1h: row.get::<_, i64>(base + 16)? as u64,
+        pricing_catalog: row.get(base + 17)?,
+    })
 }
 
 /// A stored entry's dedup-relevant fields.
@@ -1068,10 +1145,10 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("token-usage-db");
         let db = TokenUsageDatabase::open(&path).unwrap();
-        assert_eq!(db.schema_version().unwrap(), 3);
+        assert_eq!(db.schema_version().unwrap(), 4);
         drop(db);
         let db = TokenUsageDatabase::open(&path).unwrap();
-        assert_eq!(db.schema_version().unwrap(), 3);
+        assert_eq!(db.schema_version().unwrap(), 4);
     }
 
     #[test]
@@ -1132,7 +1209,7 @@ mod tests {
         assert_eq!(changed[0].model, "claude-sonnet-4-5-20250929");
         assert_eq!(changed[0].bucket_ts, 600);
         assert_eq!(changed[0].emit_seq, 0);
-        let agg = changed[0].aggregate;
+        let agg = changed[0].aggregate.clone();
         assert_eq!(agg.input, 10);
         assert_eq!(agg.output, 5);
         assert_eq!(agg.message_count, 1);
@@ -1151,13 +1228,13 @@ mod tests {
         assert!(db.sessions_needing_reconcile().unwrap().is_empty());
         // The entry stays attributed to the first-seen session.
         assert_eq!(
-            db.aggregate_bucket("s1", "claude-sonnet-4-5-20250929", 600)
+            db.aggregate_bucket("s1", "claude-sonnet-4-5-20250929", 0, 600)
                 .unwrap()
                 .message_count,
             1
         );
         assert_eq!(
-            db.aggregate_bucket("s2", "claude-sonnet-4-5-20250929", 600)
+            db.aggregate_bucket("s2", "claude-sonnet-4-5-20250929", 0, 600)
                 .unwrap()
                 .message_count,
             0
@@ -1190,13 +1267,13 @@ mod tests {
         db.clear_needs_reconcile("s1").unwrap();
         assert!(db.sessions_needing_reconcile().unwrap().is_empty());
         assert_eq!(
-            db.aggregate_bucket("s1", "claude-sonnet-4-5-20250929", 600)
+            db.aggregate_bucket("s1", "claude-sonnet-4-5-20250929", 0, 600)
                 .unwrap()
                 .message_count,
             0
         );
         assert_eq!(
-            db.aggregate_bucket("s2", "claude-sonnet-4-5-20250929", 600)
+            db.aggregate_bucket("s2", "claude-sonnet-4-5-20250929", 0, 600)
                 .unwrap()
                 .output,
             50
@@ -1209,11 +1286,11 @@ mod tests {
         let e = entry("m1|r1", Some("m1"), 600, tokens(10, 5));
         commit(&db, std::slice::from_ref(&e));
         let model = "claude-sonnet-4-5-20250929";
-        let before = db.aggregate_bucket("s1", model, 600).unwrap();
+        let before = db.aggregate_bucket("s1", model, 0, 600).unwrap();
         // Identical replay: policy keeps the existing row, aggregate (and
         // therefore the emission fingerprint) is unchanged.
         commit(&db, &[e]);
-        assert_eq!(db.aggregate_bucket("s1", model, 600).unwrap(), before);
+        assert_eq!(db.aggregate_bucket("s1", model, 0, 600).unwrap(), before);
         assert_eq!(before.message_count, 1);
     }
 
@@ -1223,14 +1300,14 @@ mod tests {
         commit(&db, &[entry("m1|r1", Some("m1"), 600, tokens(10, 5))]);
         commit(&db, &[entry("m1|r1", Some("m1"), 600, tokens(10, 50))]);
         let agg = db
-            .aggregate_bucket("s1", "claude-sonnet-4-5-20250929", 600)
+            .aggregate_bucket("s1", "claude-sonnet-4-5-20250929", 0, 600)
             .unwrap();
         assert_eq!(agg.output, 50);
         assert_eq!(agg.message_count, 1);
         // Smaller totals never replace.
         commit(&db, &[entry("m1|r1", Some("m1"), 600, tokens(1, 1))]);
         assert_eq!(
-            db.aggregate_bucket("s1", "claude-sonnet-4-5-20250929", 600)
+            db.aggregate_bucket("s1", "claude-sonnet-4-5-20250929", 0, 600)
                 .unwrap(),
             agg
         );
@@ -1246,7 +1323,7 @@ mod tests {
         // loses to it despite larger totals.
         commit(&db, &[replay]);
         let agg = db
-            .aggregate_bucket("s1", "claude-sonnet-4-5-20250929", 600)
+            .aggregate_bucket("s1", "claude-sonnet-4-5-20250929", 0, 600)
             .unwrap();
         assert_eq!(agg.input, 10);
         assert_eq!(agg.message_count, 1);
@@ -1260,7 +1337,7 @@ mod tests {
         commit(&db, &[replay]);
         commit(&db, &[entry("m1|r1", Some("m1"), 600, tokens(10, 5))]);
         let agg = db
-            .aggregate_bucket("s1", "claude-sonnet-4-5-20250929", 600)
+            .aggregate_bucket("s1", "claude-sonnet-4-5-20250929", 0, 600)
             .unwrap();
         assert_eq!(agg.input, 10);
         assert_eq!(agg.message_count, 1);
@@ -1268,7 +1345,7 @@ mod tests {
         // parent entry again leaves the aggregate untouched.
         commit(&db, &[entry("m1|r1", Some("m1"), 600, tokens(10, 5))]);
         assert_eq!(
-            db.aggregate_bucket("s1", "claude-sonnet-4-5-20250929", 600)
+            db.aggregate_bucket("s1", "claude-sonnet-4-5-20250929", 0, 600)
                 .unwrap(),
             agg
         );
@@ -1282,7 +1359,7 @@ mod tests {
         commit(&db, &[entry("m1|r1", Some("m1"), 600, tokens(10, 5))]);
         commit(&db, &[entry("m1|r2", Some("m1"), 600, tokens(7, 3))]);
         let agg = db
-            .aggregate_bucket("s1", "claude-sonnet-4-5-20250929", 600)
+            .aggregate_bucket("s1", "claude-sonnet-4-5-20250929", 0, 600)
             .unwrap();
         assert_eq!(agg.message_count, 2);
         assert_eq!(agg.input, 17);
@@ -1298,6 +1375,7 @@ mod tests {
         db.mark_emitted(
             "s1",
             model,
+            0,
             600,
             &changed[0].aggregate.fingerprint(),
             changed[0].emit_seq + 1,
@@ -1324,6 +1402,7 @@ mod tests {
         db.mark_emitted(
             "s1",
             model,
+            0,
             600,
             &BucketAggregate::default().fingerprint(),
             2,
@@ -1389,12 +1468,12 @@ mod tests {
         }
 
         let db = TokenUsageDatabase::open(&path).unwrap();
-        assert_eq!(db.schema_version().unwrap(), 3);
+        assert_eq!(db.schema_version().unwrap(), 4);
         // Rebuilt empty: no legacy rows, cursors, or reconcile flags survive.
         assert!(db.all_files().unwrap().is_empty());
         assert!(db.sessions_needing_reconcile().unwrap().is_empty());
         assert_eq!(
-            db.aggregate_bucket("s1", "claude-sonnet-4-5-20250929", 600)
+            db.aggregate_bucket("s1", "claude-sonnet-4-5-20250929", 0, 600)
                 .unwrap()
                 .message_count,
             0
@@ -1406,7 +1485,7 @@ mod tests {
             &[entry("m1|r1", Some("m1"), 600, tokens(10, 50))],
         );
         assert_eq!(
-            db.aggregate_bucket("s2", "claude-sonnet-4-5-20250929", 600)
+            db.aggregate_bucket("s2", "claude-sonnet-4-5-20250929", 0, 600)
                 .unwrap()
                 .output,
             50
@@ -1423,7 +1502,7 @@ mod tests {
         commit(&db, &[entry("m1|r1", Some("m1"), 600, tokens(10, 5))]);
         let changed = db.changed_buckets("s1").unwrap();
         assert_eq!(changed[0].emit_seq, 0);
-        db.reserve_emit_seqs("s1", &[(model.to_string(), 600, 1)])
+        db.reserve_emit_seqs("s1", &[(model.to_string(), 0, 600, 1)])
             .unwrap();
 
         // Fingerprint untouched by the reservation: the bucket still
@@ -1433,24 +1512,95 @@ mod tests {
         assert_eq!(changed[0].emit_seq, 1);
 
         // Success path completes the emission; nothing left to reconcile.
-        db.reserve_emit_seqs("s1", &[(model.to_string(), 600, 2)])
+        db.reserve_emit_seqs("s1", &[(model.to_string(), 0, 600, 2)])
             .unwrap();
-        db.mark_emitted("s1", model, 600, &changed[0].aggregate.fingerprint(), 2, 9)
-            .unwrap();
+        db.mark_emitted(
+            "s1",
+            model,
+            0,
+            600,
+            &changed[0].aggregate.fingerprint(),
+            2,
+            9,
+        )
+        .unwrap();
         assert!(db.changed_buckets("s1").unwrap().is_empty());
     }
 
     #[test]
+    fn buckets_split_by_speed_and_carry_the_tier_sums() {
+        let (_dir, db) = db();
+        let mut fast = entry("k1", None, 600, tokens(10, 5));
+        fast.speed = Some(Speed::Fast);
+        let standard = entry("k2", None, 630, tokens(20, 5));
+        // Unmarked and catalog-priced, over the sonnet 200K threshold: joins
+        // the standard bucket and fills the long-context sums.
+        let mut unmarked_long = entry(
+            "k3",
+            None,
+            660,
+            TokenCounts {
+                input: 300_000,
+                output: 1,
+                total: 300_001,
+                ..Default::default()
+            },
+        );
+        unmarked_long.transcript_cost_micro_usd = None;
+        commit_for(&db, "s1", &[fast, standard, unmarked_long.clone()]);
+
+        let mut changed = db.changed_buckets("s1").unwrap();
+        changed.sort_by_key(|bucket| bucket.speed);
+        assert_eq!(changed.len(), 2, "one bucket per speed, same model+ts");
+        let standard_bucket = &changed[0];
+        assert_eq!(standard_bucket.speed, 0);
+        assert_eq!(standard_bucket.aggregate.input, 300_020);
+        assert_eq!(standard_bucket.aggregate.message_count, 2);
+        assert_eq!(standard_bucket.aggregate.long_context_input, 300_000);
+        assert_eq!(standard_bucket.aggregate.long_context_output, 1);
+        // Only k2's cost came from the transcript; k3 was catalog-priced.
+        assert_eq!(standard_bucket.aggregate.transcript_cost_micro_usd, 1_000);
+        assert_eq!(
+            standard_bucket.aggregate.cost_micro_usd,
+            1_000 + price_entry(&unmarked_long).cost_micro_usd.unwrap()
+        );
+        assert_eq!(
+            standard_bucket.aggregate.pricing_catalog.as_deref(),
+            Some(crate::metrics::model_pricing::pricing_catalog_id())
+        );
+        let fast_bucket = &changed[1];
+        assert_eq!(fast_bucket.speed, 1);
+        assert_eq!(fast_bucket.aggregate.input, 10);
+        assert_eq!(fast_bucket.aggregate.message_count, 1);
+        assert_eq!(fast_bucket.aggregate.long_context_input, 0);
+        assert_eq!(fast_bucket.aggregate.pricing_catalog, None);
+        assert_eq!(fast_bucket.bucket_ts, standard_bucket.bucket_ts);
+        assert_eq!(fast_bucket.model, standard_bucket.model);
+    }
+
+    #[test]
     fn fingerprint_covers_every_emitted_field() {
+        // Every emitted *value* must reach the fingerprint (pricing_catalog
+        // rides the attributes and is deliberately excluded: a catalog-id
+        // change without any numeric change means identical rates).
         let base = BucketAggregate {
             input: 1,
             output: 2,
             cache_read: 3,
             cache_write: 4,
+            cache_write_1h: 2,
             reasoning_output: None,
             total: 10,
             cost_micro_usd: 5,
+            transcript_cost_micro_usd: 2,
             message_count: 6,
+            speed_inferred: false,
+            long_context_input: 1,
+            long_context_output: 1,
+            long_context_cache_read: 1,
+            long_context_cache_write: 1,
+            long_context_cache_write_1h: 1,
+            pricing_catalog: None,
         };
         let mut seen = HashSet::from([base.fingerprint()]);
         for mutate in [
@@ -1458,12 +1608,20 @@ mod tests {
             |a| a.output += 1,
             |a| a.cache_read += 1,
             |a| a.cache_write += 1,
+            |a| a.cache_write_1h += 1,
             |a| a.reasoning_output = Some(0),
             |a| a.total += 1,
             |a| a.cost_micro_usd += 1,
+            |a| a.transcript_cost_micro_usd += 1,
             |a| a.message_count += 1,
+            |a| a.speed_inferred = true,
+            |a| a.long_context_input += 1,
+            |a| a.long_context_output += 1,
+            |a| a.long_context_cache_read += 1,
+            |a| a.long_context_cache_write += 1,
+            |a| a.long_context_cache_write_1h += 1,
         ] {
-            let mut variant = base;
+            let mut variant = base.clone();
             mutate(&mut variant);
             assert!(seen.insert(variant.fingerprint()), "fingerprint collision");
         }
@@ -1477,7 +1635,7 @@ mod tests {
         codex.transcript_cost_micro_usd = None;
         codex.model = "gpt-5".to_string();
         commit(&db, &[codex]);
-        let agg = db.aggregate_bucket("s1", "gpt-5", 600).unwrap();
+        let agg = db.aggregate_bucket("s1", "gpt-5", 0, 600).unwrap();
         assert_eq!(agg.reasoning_output, Some(4));
         // Cost falls back to the pricing catalog (gpt-5 is in the snapshot).
         assert!(agg.cost_micro_usd > 0);
@@ -1497,7 +1655,7 @@ mod tests {
             commit(&db, &[e]);
         }
         let agg = db
-            .aggregate_bucket("s1", "claude-sonnet-4-5-20250929", 600)
+            .aggregate_bucket("s1", "claude-sonnet-4-5-20250929", 0, 600)
             .unwrap();
         assert_eq!(agg.input, 2 * TOKEN_VALUE_CEILING);
         assert_eq!(agg.total, 2 * TOKEN_VALUE_CEILING);
@@ -1580,13 +1738,15 @@ mod tests {
             ],
         );
         let model = "claude-sonnet-4-5-20250929";
-        db.mark_emitted("s1", model, 600, "fp", 1, 1).unwrap();
+        db.mark_emitted("s1", model, 0, 600, "fp", 1, 1).unwrap();
         assert_eq!(db.prune_buckets_before(999_000).unwrap(), 1);
         assert_eq!(
-            db.aggregate_bucket("s1", model, 600).unwrap().message_count,
+            db.aggregate_bucket("s1", model, 0, 600)
+                .unwrap()
+                .message_count,
             0
         );
-        assert_eq!(db.emitted_fingerprint("s1", model, 600).unwrap(), None);
+        assert_eq!(db.emitted_fingerprint("s1", model, 0, 600).unwrap(), None);
         // No orphan bucket_state row: the emptied old bucket is NOT a
         // reconciliation candidate after the prune.
         let changed = db.changed_buckets("s1").unwrap();

--- a/src/token_usage/db.rs
+++ b/src/token_usage/db.rs
@@ -206,8 +206,14 @@ const MIGRATIONS: &[&str] = &[
     "#,
     // Version 4: buckets gain the speed dimension (fast and standard usage
     // of one model bill at different rates, so they must never share a
-    // bucket identity on the server). Pre-release reset like v3.
+    // bucket identity on the server). Pre-release reset like v3. The
+    // expression index matches the reconciliation GROUP BY exactly —
+    // grouping by COALESCE(speed, 0) over the plain bucket index would
+    // otherwise sort every session aggregate through a temp B-tree.
     r#"
+    CREATE INDEX idx_usage_entries_bucket_speed
+        ON usage_entries(session_id, model, COALESCE(speed, 0), bucket_ts);
+
     DROP TABLE bucket_state;
 
     CREATE TABLE bucket_state (

--- a/src/token_usage/db.rs
+++ b/src/token_usage/db.rs
@@ -209,10 +209,13 @@ const MIGRATIONS: &[&str] = &[
     // bucket identity on the server). Pre-release reset like v3. The
     // expression index matches the reconciliation GROUP BY exactly —
     // grouping by COALESCE(speed, 0) over the plain bucket index would
-    // otherwise sort every session aggregate through a temp B-tree.
+    // otherwise sort every session aggregate through a temp B-tree — and
+    // fully supersedes v3's plain bucket index, which no remaining query
+    // uses, so that one is dropped rather than maintained on every write.
     r#"
     CREATE INDEX idx_usage_entries_bucket_speed
         ON usage_entries(session_id, model, COALESCE(speed, 0), bucket_ts);
+    DROP INDEX IF EXISTS idx_usage_entries_bucket;
 
     DROP TABLE bucket_state;
 

--- a/tests/integration/token_usage.rs
+++ b/tests/integration/token_usage.rs
@@ -421,11 +421,11 @@ fn fast_long_context_codex_usage_emits_tier_and_speed_fields() {
         Some((expected_usd * 1_000_000.0).round() as u64)
     );
     let attrs = EventAttributes::from_sparse(&event.attrs);
-    let custom = attrs
-        .custom_attributes
+    let catalog = attrs
+        .pricing_catalog
         .flatten()
         .expect("catalog-priced buckets carry the pricing catalog id");
-    assert!(custom.contains("pricing_catalog"), "{custom}");
+    assert!(catalog.starts_with("embedded:"), "{catalog}");
 }
 
 #[test]

--- a/tests/integration/token_usage.rs
+++ b/tests/integration/token_usage.rs
@@ -332,8 +332,15 @@ fn codex_transcript_emits_deltas_with_reasoning_tokens() {
 #[test]
 fn fast_long_context_codex_usage_emits_tier_and_speed_fields() {
     let (_metrics_db_dir, metrics_db_path) = isolated_metrics_db_path();
-    let repo =
-        TestRepo::new_with_daemon_env(&[("GIT_AI_TEST_METRICS_DB_PATH", metrics_db_path.as_str())]);
+    let repo = TestRepo::new_with_daemon_env(&[
+        ("GIT_AI_TEST_METRICS_DB_PATH", metrics_db_path.as_str()),
+        // The org-configured attribute map must ride token-usage events
+        // like every other event type.
+        (
+            "GIT_AI_TEST_CONFIG_PATCH",
+            r#"{"custom_attributes":{"team":"platform"}}"#,
+        ),
+    ]);
     repo.git(&["commit", "--allow-empty", "-m", "initial"])
         .expect("initial commit should succeed");
     let repo_root = repo.canonical_path();
@@ -426,6 +433,11 @@ fn fast_long_context_codex_usage_emits_tier_and_speed_fields() {
         .flatten()
         .expect("catalog-priced buckets carry the pricing catalog id");
     assert!(catalog.starts_with("embedded:"), "{catalog}");
+    let custom = attrs
+        .custom_attributes
+        .flatten()
+        .expect("org-configured attributes ride token-usage events");
+    assert_eq!(custom, r#"{"team":"platform"}"#);
 }
 
 #[test]

--- a/tests/integration/token_usage.rs
+++ b/tests/integration/token_usage.rs
@@ -404,12 +404,21 @@ fn fast_long_context_codex_usage_emits_tier_and_speed_fields() {
         value_u64(event, token_usage_pos::TRANSCRIPT_COST_MICRO_USD),
         Some(0)
     );
-    // Whole request at the 272K+ rates (8/30 input/output, 0.8 cache read
-    // per million), doubled by the fast multiplier:
-    // (0.28*8 + 0.02*0.8 + 0.001*30) * 2 = $4.572.
+    // Whole request at the above-threshold rates times the fast multiplier.
+    // Derived from the embedded snapshot (the daemon subprocess and this
+    // process both run with GIT_AI_TEST_DB_PATH set, pinning it) so the
+    // weekly snapshot refresh cannot break this assertion; e.g. at 8/30
+    // input/output and 0.8 cache read: (0.28*8 + 0.02*0.8 + 0.001*30) * 2 =
+    // $4.572.
+    let pricing = git_ai::metrics::model_pricing::pricing_for("gpt-5.6-sol")
+        .expect("gpt-5.6-sol must be in the embedded snapshot");
+    let expected_usd = (0.28 * pricing.input_above.unwrap()
+        + 0.02 * pricing.cache_read_above.unwrap()
+        + 0.001 * pricing.output_above.unwrap())
+        * pricing.fast_multiplier;
     assert_eq!(
         value_u64(event, token_usage_pos::EST_COST_MICRO_USD),
-        Some(4_572_000)
+        Some((expected_usd * 1_000_000.0).round() as u64)
     );
     let attrs = EventAttributes::from_sparse(&event.attrs);
     let custom = attrs

--- a/tests/integration/token_usage.rs
+++ b/tests/integration/token_usage.rs
@@ -330,6 +330,96 @@ fn codex_transcript_emits_deltas_with_reasoning_tokens() {
 }
 
 #[test]
+fn fast_long_context_codex_usage_emits_tier_and_speed_fields() {
+    let (_metrics_db_dir, metrics_db_path) = isolated_metrics_db_path();
+    let repo =
+        TestRepo::new_with_daemon_env(&[("GIT_AI_TEST_METRICS_DB_PATH", metrics_db_path.as_str())]);
+    repo.git(&["commit", "--allow-empty", "-m", "initial"])
+        .expect("initial commit should succeed");
+    let repo_root = repo.canonical_path();
+
+    // A recorded fast tier and one turn whose raw input (300K, cached
+    // included) crosses gpt-5.6-sol's 272K long-context threshold.
+    let transcript_path = repo_root.join("codex-fast-session.jsonl");
+    fs::write(
+        &transcript_path,
+        format!(
+            "{}\n{}\n{}\n{}\n",
+            json!({"timestamp": "2026-01-01T00:00:00Z", "type": "session_meta", "payload": {"id": "sess-fast-codex"}}),
+            json!({"timestamp": "2026-01-01T00:00:10Z", "type": "turn_context", "payload": {"model": "gpt-5.6-sol"}}),
+            json!({"timestamp": "2026-01-01T00:00:20Z", "type": "event_msg", "payload": {"type": "thread_settings_applied", "thread_settings": {"service_tier": "fast"}}}),
+            json!({
+                "timestamp": recent_ts(1, 0),
+                "type": "event_msg",
+                "payload": {"type": "token_count", "info": {"total_token_usage": {
+                    "input_tokens": 300_000u64,
+                    "cached_input_tokens": 20_000u64,
+                    "output_tokens": 1_000u64,
+                    "reasoning_output_tokens": 100u64,
+                    "total_tokens": 301_000u64
+                }}}
+            }),
+        ),
+    )
+    .unwrap();
+
+    let file_path = repo_root.join("main.rs");
+    fs::write(&file_path, "fn main() {}\n").unwrap();
+    checkpoint_with_transcript(
+        &repo,
+        "codex",
+        "sess-fast-codex",
+        &transcript_path,
+        &file_path,
+        "fn main() {}\nfn added() {}\n",
+    );
+    sync_token_usage_pipeline(&repo);
+
+    let events = token_usage_events(&metrics_db_path);
+    assert_eq!(events.len(), 1);
+    let event = &events[0];
+    assert_eq!(value_u64(event, token_usage_pos::SPEED), Some(1));
+    assert_eq!(
+        value_u64(event, token_usage_pos::SPEED_INFERRED),
+        Some(0),
+        "the tier was recorded in the transcript"
+    );
+    assert_eq!(
+        value_u64(event, token_usage_pos::INPUT_TOKENS),
+        Some(280_000)
+    );
+    assert_eq!(
+        value_u64(event, token_usage_pos::LONG_CONTEXT_INPUT_TOKENS),
+        Some(280_000)
+    );
+    assert_eq!(
+        value_u64(event, token_usage_pos::LONG_CONTEXT_CACHE_READ_TOKENS),
+        Some(20_000)
+    );
+    assert_eq!(
+        value_u64(event, token_usage_pos::LONG_CONTEXT_OUTPUT_TOKENS),
+        Some(1_000)
+    );
+    assert_eq!(
+        value_u64(event, token_usage_pos::TRANSCRIPT_COST_MICRO_USD),
+        Some(0)
+    );
+    // Whole request at the 272K+ rates (8/30 input/output, 0.8 cache read
+    // per million), doubled by the fast multiplier:
+    // (0.28*8 + 0.02*0.8 + 0.001*30) * 2 = $4.572.
+    assert_eq!(
+        value_u64(event, token_usage_pos::EST_COST_MICRO_USD),
+        Some(4_572_000)
+    );
+    let attrs = EventAttributes::from_sparse(&event.attrs);
+    let custom = attrs
+        .custom_attributes
+        .flatten()
+        .expect("catalog-priced buckets carry the pricing catalog id");
+    assert!(custom.contains("pricing_catalog"), "{custom}");
+}
+
+#[test]
 fn appended_transcript_lines_update_existing_buckets() {
     let (_metrics_db_dir, metrics_db_path) = isolated_metrics_db_path();
     let repo =


### PR DESCRIPTION
Fast and standard usage of one model bill at different rates, so speed
(0 standard, 1 fast) joins the bucket identity: bucket_state is keyed by
(session_id, model, speed, bucket_ts) (schema v4 rebuilds just that
table; entries and cursors survive) and aggregation groups by the
entry's speed, with unmarked entries falling into the standard bucket.

TokenUsage events gain positions 11-19 so the server can recompute a
bucket's cost under a different pricing sheet: speed and whether it was
inferred from configuration, the 1h cache-write split, the long-context
token splits per class (tokens of requests that selected their model's
long-context tier; whole-request selection already applied client-side,
base-tier tokens are the totals minus these), and the transcript-priced
portion of the cost, which is fixed under repricing (its tokens remain
in the totals, so such buckets reprice approximately). The pricing
catalog id rides custom_attributes on catalog-priced buckets.

The bucket fingerprint covers every new emitted value, so any split
changing re-emits the bucket at a higher revision; the catalog id alone
is deliberately excluded (an id change without numeric change means
identical rates). The spec's value table, bucket identity, and pricing
sections are updated accordingly.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
