### PR TITLE
feat(token-usage): match forked Codex sessions against their parent's usage prefix

### DIFF
--- a/docs/token-usage-events-spec.md
+++ b/docs/token-usage-events-spec.md
@@ -167,11 +167,18 @@ TokenUsage events are the authoritative dollars.
 Claude subagent transcripts roll up to their parent session (matching
 ccusage's session semantics), which also lets sidechain replays of parent
 messages deduplicate against the parent's entries across files. Codex
-sessions are per rollout file; forked rollouts skip their replayed prefix via
-the rewritten-burst heuristic, and a fork whose transcript ends with its
-first usage event still parked is released by an end-of-file flush once the
-burst window has passed in wall-clock time (see `src/token_usage/codex.rs`
-for the deviations from ccusage's parent-prefix matching).
+sessions are per rollout file; forked rollouts skip their replayed prefix by
+matching it against the parent rollout's pre-fork usage signatures (ccusage's
+parent-prefix matching): the worker resolves the parent — tracked files under
+the parent's external session id, else a bounded scan of the codex sessions
+tree, always confirmed against the candidate's recorded `session_meta` id —
+and the unmatched remainder persists in the extractor state, so the parent is
+read once per fork, never per pass. A parent that cannot be resolved falls
+back (without retry, like ccusage with an unavailable parent log) to the
+rewritten-burst heuristic: leading usage events spaced <= 1s apart are
+replayed history, and a fork whose transcript ends with its first usage event
+still parked is released by an end-of-file flush once the burst window has
+passed in wall-clock time.
 
 ## Accepted limitations
 
@@ -196,13 +203,14 @@ Reviewed decisions, accepted rather than accidental:
   replay.
 - **Sweep-discovered work sits outside the `git-ai await` drain barrier**
   (see Pipeline): backfill is eventual, matching stream-worker semantics.
-- **A fork burst split across passes can over-count one event.** The
-  end-of-file flush releases a parked first turn after the burst window
-  passes in wall clock. If Codex writes the replayed burst lines more than a
-  second apart (buffered/laggy serialization carrying sub-second recorded
-  timestamps) and a pass lands in the gap, the parked replay is released as
-  own usage. The flush leaves the skip machine armed at the released event's
-  timestamp, so the late-arriving remainder of the burst is still skipped —
-  the over-count is bounded to that single released event per fork, and the
-  race requires write lag upstream's post-hoc whole-file reads never
-  observe.
+- **A fork burst split across passes can over-count one event — on the
+  unresolvable-parent fallback path only.** With parent-prefix matching the
+  replayed history is identified by content, so this race is gone for any
+  fork whose parent rollout is resolvable. When it is not, the end-of-file
+  flush releases a parked first turn after the burst window passes in wall
+  clock; if Codex writes the replayed burst lines more than a second apart
+  (buffered/laggy serialization carrying sub-second recorded timestamps) and
+  a pass lands in the gap, the parked replay is released as own usage. The
+  flush leaves the skip machine armed at the released event's timestamp, so
+  the late-arriving remainder of the burst is still skipped — the over-count
+  is bounded to that single released event per fork.

--- a/src/daemon/token_usage_worker.rs
+++ b/src/daemon/token_usage_worker.rs
@@ -792,10 +792,10 @@ fn resolve_parent_prefix(
         .find(|path| records_session_id(path, &request.parent_id))
         .or_else(|| scan_sessions_tree(Path::new(child_path), &request.parent_id))?;
     let file = std::fs::File::open(&parent).ok()?;
-    Some(crate::token_usage::codex::collect_parent_prefix(
+    crate::token_usage::codex::collect_parent_prefix(
         BufReader::with_capacity(128 * 1024, file),
         request.fork_ts_ms,
-    ))
+    )
 }
 
 /// Whether the rollout's first line records `session_id` as its own id.
@@ -812,18 +812,35 @@ fn records_session_id(path: &Path, session_id: &str) -> bool {
 }
 
 /// Fallback parent discovery for rollouts the token database has not tracked
-/// (yet): walk the child's enclosing codex `sessions` tree — and its sibling
-/// `archived_sessions`, where Codex moves archived rollouts — for a filename
-/// carrying the parent id (codex rollout filenames embed the session uuid),
-/// confirming by the recorded `session_meta` id.
+/// (yet): walk the codex home's `sessions` and `archived_sessions` trees for
+/// a filename carrying the parent id (codex rollout filenames embed the
+/// session uuid), confirming by the recorded `session_meta` id. The home is
+/// resolved like `streams::model_extraction` (configured home, else the
+/// nearest `.codex` ancestor) so archived or custom-layout children resolve
+/// too; a `sessions`/`archived_sessions` ancestor is the fallback anchor.
 fn scan_sessions_tree(child_path: &Path, parent_id: &str) -> Option<PathBuf> {
-    let sessions_root = child_path
-        .ancestors()
-        .find(|dir| dir.file_name().and_then(|name| name.to_str()) == Some("sessions"))?;
-    let mut pending = vec![sessions_root.to_path_buf()];
-    if let Some(codex_home) = sessions_root.parent() {
-        pending.push(codex_home.join("archived_sessions"));
-    }
+    let roots: Vec<PathBuf> =
+        match crate::streams::model_extraction::codex_home_from_transcript_path(child_path) {
+            Some(home) => vec![home.join("sessions"), home.join("archived_sessions")],
+            None => {
+                let anchor = child_path.ancestors().find(|dir| {
+                    matches!(
+                        dir.file_name().and_then(|name| name.to_str()),
+                        Some("sessions" | "archived_sessions")
+                    )
+                })?;
+                let parent = anchor.parent();
+                vec![
+                    anchor.to_path_buf(),
+                    match parent {
+                        Some(dir) if anchor.ends_with("sessions") => dir.join("archived_sessions"),
+                        Some(dir) => dir.join("sessions"),
+                        None => return None,
+                    },
+                ]
+            }
+        };
+    let mut pending = roots;
     let mut visited = 0usize;
     while let Some(dir) = pending.pop() {
         let Ok(entries) = std::fs::read_dir(&dir) else {

--- a/src/daemon/token_usage_worker.rs
+++ b/src/daemon/token_usage_worker.rs
@@ -782,6 +782,14 @@ fn resolve_parent_prefix(
     child_path: &str,
     request: &ParentPrefixRequest,
 ) -> Option<Vec<UsageSignature>> {
+    // The trait hook is provider-neutral, but everything below is codex
+    // machinery (rollout layout, session_meta confirmation, codex delta
+    // parsing). Another tool's request resolves to "parent unavailable"
+    // (its burst fallback) instead of misparsing a foreign transcript as a
+    // rollout; extend with per-tool dispatch when a second tool needs it.
+    if tool != "codex" {
+        return None;
+    }
     let tracked = token_db
         .stream_paths_for_external_session(&request.parent_id, tool)
         .unwrap_or_default();
@@ -800,13 +808,20 @@ fn resolve_parent_prefix(
 
 /// Whether the rollout's first line records `session_id` as its own id.
 fn records_session_id(path: &Path, session_id: &str) -> bool {
+    use std::io::Read;
     let Ok(file) = std::fs::File::open(path) else {
         return false;
     };
+    // A rollout's session_meta line is small; a candidate whose first line
+    // is larger is not one, and must not be buffered wholly into memory
+    // (the scan feeds this any file whose name carries the parent id).
+    const MAX_FIRST_LINE_BYTES: u64 = 64 * 1024;
     let mut line = Vec::new();
-    if read_line_bytes(&mut BufReader::new(file), &mut line).is_err() {
+    let mut reader = BufReader::new(file.take(MAX_FIRST_LINE_BYTES));
+    if read_line_bytes(&mut reader, &mut line).is_err() {
         return false;
     }
+    // A line truncated at the cap is not valid JSON and fails the id parse.
     crate::token_usage::codex::session_meta_id(&String::from_utf8_lossy(&line)).as_deref()
         == Some(session_id)
 }
@@ -859,7 +874,7 @@ fn scan_sessions_tree(child_path: &Path, parent_id: &str) -> Option<PathBuf> {
             } else if path
                 .file_name()
                 .and_then(|name| name.to_str())
-                .is_some_and(|name| name.contains(parent_id))
+                .is_some_and(|name| name.contains(parent_id) && name.ends_with(".jsonl"))
                 && path != child_path
                 && records_session_id(&path, parent_id)
             {

--- a/src/daemon/token_usage_worker.rs
+++ b/src/daemon/token_usage_worker.rs
@@ -55,6 +55,7 @@ use crate::error::GitAiError;
 use crate::metrics::{EventAttributes, MetricEvent, PosEncoded, TokenUsageValues};
 use crate::streams::db::{StreamRecord, StreamsDatabase};
 use crate::token_usage::db::{BatchCommit, TokenUsageDatabase, TrackedFile};
+use crate::token_usage::extractor::{ParentPrefixRequest, UsageSignature};
 use crate::token_usage::{Speed, extractor_for_tool};
 
 /// One raw JSONL line read as bytes: unlike UTF-8-strict `read_line`, a
@@ -761,6 +762,91 @@ fn codex_config_fallback_speed(stream_path: &Path) -> Option<Speed> {
     speed
 }
 
+/// Cap on directory entries visited when scanning the codex sessions tree
+/// for a fork's parent rollout — far above a real `sessions/YYYY/MM/DD`
+/// layout, so pathological trees can't wedge a pass.
+const PARENT_SCAN_MAX_ENTRIES: usize = 50_000;
+
+/// Locate and read a forked child's parent rollout, returning its pre-fork
+/// usage prefix. Candidates come from the token database (files tracked
+/// under the parent's external session id — which, for rolled-up children,
+/// includes the child itself) and a bounded scan of the codex sessions tree
+/// for filenames carrying the parent id; a candidate counts only when its
+/// first line is a `session_meta` recording that id (ccusage locates parents
+/// by recorded id, never by filename). `None` — the parent is unresolvable —
+/// sends the extractor to its rewritten-burst fallback, like ccusage with an
+/// unavailable parent log, and is not retried.
+fn resolve_parent_prefix(
+    token_db: &TokenUsageDatabase,
+    tool: &str,
+    child_path: &str,
+    request: &ParentPrefixRequest,
+) -> Option<Vec<UsageSignature>> {
+    let tracked = token_db
+        .stream_paths_for_external_session(&request.parent_id, tool)
+        .unwrap_or_default();
+    let parent = tracked
+        .into_iter()
+        .map(PathBuf::from)
+        .filter(|path| path != Path::new(child_path))
+        .find(|path| records_session_id(path, &request.parent_id))
+        .or_else(|| scan_sessions_tree(Path::new(child_path), &request.parent_id))?;
+    let file = std::fs::File::open(&parent).ok()?;
+    Some(crate::token_usage::codex::collect_parent_prefix(
+        BufReader::with_capacity(128 * 1024, file),
+        request.fork_ts_ms,
+    ))
+}
+
+/// Whether the rollout's first line records `session_id` as its own id.
+fn records_session_id(path: &Path, session_id: &str) -> bool {
+    let Ok(file) = std::fs::File::open(path) else {
+        return false;
+    };
+    let mut line = Vec::new();
+    if read_line_bytes(&mut BufReader::new(file), &mut line).is_err() {
+        return false;
+    }
+    crate::token_usage::codex::session_meta_id(&String::from_utf8_lossy(&line)).as_deref()
+        == Some(session_id)
+}
+
+/// Fallback parent discovery for rollouts the token database has not tracked
+/// (yet): walk the child's enclosing codex `sessions` tree for a filename
+/// carrying the parent id (codex rollout filenames embed the session uuid),
+/// confirming by the recorded `session_meta` id.
+fn scan_sessions_tree(child_path: &Path, parent_id: &str) -> Option<PathBuf> {
+    let sessions_root = child_path
+        .ancestors()
+        .find(|dir| dir.file_name().and_then(|name| name.to_str()) == Some("sessions"))?;
+    let mut pending = vec![sessions_root.to_path_buf()];
+    let mut visited = 0usize;
+    while let Some(dir) = pending.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            visited += 1;
+            if visited > PARENT_SCAN_MAX_ENTRIES {
+                return None;
+            }
+            let path = entry.path();
+            if path.is_dir() {
+                pending.push(path);
+            } else if path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.contains(parent_id))
+                && path != child_path
+                && records_session_id(&path, parent_id)
+            {
+                return Some(path);
+            }
+        }
+    }
+    None
+}
+
 /// Incrementally read one transcript file, persist deduplicated entries, and
 /// emit changed buckets through `sink`. Split out (with injectable repo
 /// resolution and sink) for direct testing without a daemon.
@@ -827,6 +913,22 @@ fn process_file(
         extractor.set_fallback_speed(codex_config_fallback_speed(Path::new(stream_path)));
     }
 
+    // Serve a fork's parent-prefix request as soon as it appears — after
+    // restoring persisted state here, and after every consumed line below —
+    // so the parent's replayed history is known before the next usage event
+    // is judged. A cheap no-op for everything but a freshly detected fork.
+    let serve_parent_request = |extractor: &mut Box<dyn crate::token_usage::UsageExtractor>| {
+        if let Some(request) = extractor.parent_request() {
+            extractor.provide_parent_prefix(resolve_parent_prefix(
+                token_db,
+                &identity.tool,
+                stream_path,
+                &request,
+            ));
+        }
+    };
+    serve_parent_request(&mut extractor);
+
     let file = std::fs::File::open(stream_path)?;
     let mut reader = BufReader::with_capacity(128 * 1024, file);
     reader.seek(SeekFrom::Start(offset))?;
@@ -864,6 +966,7 @@ fn process_file(
                         offset += bytes as u64;
                         if extractor.wants_line(trimmed) {
                             entries.extend(extractor.extract_line(trimmed));
+                            serve_parent_request(&mut extractor);
                         }
                     }
                     reached_end = true;
@@ -876,6 +979,7 @@ fn process_file(
                     let trimmed = text.trim_end();
                     if extractor.wants_line(trimmed) {
                         entries.extend(extractor.extract_line(trimmed));
+                        serve_parent_request(&mut extractor);
                     }
                     if entries.len() >= BATCH_MAX_ENTRIES || consumed >= BATCH_MAX_BYTES {
                         break;
@@ -1612,6 +1716,113 @@ mod tests {
         );
         let attrs = EventAttributes::from_sparse(&fast.attrs);
         assert!(attrs.pricing_catalog.flatten().is_none());
+    }
+
+    fn codex_meta_line(id: &str, forked_from: Option<&str>, ts: &str) -> String {
+        let fork = forked_from
+            .map(|parent| format!(r#","forked_from_id":"{parent}""#))
+            .unwrap_or_default();
+        format!(r#"{{"timestamp":"{ts}","type":"session_meta","payload":{{"id":"{id}"{fork}}}}}"#)
+    }
+
+    fn codex_usage_line(ts: &str, totals: (u64, u64, u64, u64, u64)) -> String {
+        format!(
+            r#"{{"timestamp":"{ts}","type":"event_msg","payload":{{"type":"token_count","info":{{"total_token_usage":{{"input_tokens":{},"cached_input_tokens":{},"output_tokens":{},"reasoning_output_tokens":{},"total_tokens":{}}}}}}}}}"#,
+            totals.0, totals.1, totals.2, totals.3, totals.4
+        )
+    }
+
+    #[test]
+    fn forked_codex_replay_is_skipped_via_the_tracked_parent() {
+        // The child's leading event replays the parent's history with a
+        // rewritten timestamp and its own turn follows 30s later — far past
+        // the burst window, so only parent-prefix matching can tell the
+        // replay apart (and the rewritten timestamp gives it a fresh
+        // content-derived key, so dedup alone would double count).
+        let (dir, db, _) = setup();
+        let identity = SessionIdentity {
+            tool: "codex".to_string(),
+            external_session_id: "parent-ext".to_string(),
+            ..identity()
+        };
+        let parent_path = dir.path().join("parent.jsonl");
+        fs::write(
+            &parent_path,
+            format!(
+                "{}\n{}\n",
+                codex_meta_line("parent-ext", None, &recent_ts(0, 30)),
+                codex_usage_line(&recent_ts(1, 0), (100, 40, 50, 10, 150)),
+            ),
+        )
+        .unwrap();
+        assert_eq!(run_as(&db, &identity, &parent_path).unwrap().len(), 1);
+
+        let child_path = dir.path().join("child.jsonl");
+        fs::write(
+            &child_path,
+            format!(
+                "{}\n{}\n{}\n",
+                codex_meta_line("child-ext", Some("parent-ext"), &recent_ts(2, 0)),
+                codex_usage_line(&recent_ts(2, 0), (100, 40, 50, 10, 150)),
+                codex_usage_line(&recent_ts(2, 30), (300, 140, 90, 30, 390)),
+            ),
+        )
+        .unwrap();
+        let events = run_as(&db, &identity, &child_path).unwrap();
+        assert_eq!(events.len(), 1);
+        // Parent's 60 + the child's own 100 — without the 60 the replayed
+        // copy would have re-added.
+        assert_eq!(
+            value_u64(&events[0], token_usage_pos::INPUT_TOKENS),
+            Some(160)
+        );
+        assert_eq!(
+            value_u64(&events[0], token_usage_pos::MESSAGE_COUNT),
+            Some(2)
+        );
+    }
+
+    #[test]
+    fn forked_codex_parent_is_found_by_scanning_the_sessions_tree() {
+        // The parent rollout exists on disk but was never tracked (the child
+        // is processed first): resolution falls back to scanning the codex
+        // sessions tree and confirming the recorded session id.
+        let (dir, db, _) = setup();
+        let day_dir = dir.path().join("sessions/2026/01/09");
+        fs::create_dir_all(&day_dir).unwrap();
+        fs::write(
+            day_dir.join("rollout-parent-ext.jsonl"),
+            format!(
+                "{}\n{}\n",
+                codex_meta_line("parent-ext", None, &recent_ts(0, 30)),
+                codex_usage_line(&recent_ts(1, 0), (100, 40, 50, 10, 150)),
+            ),
+        )
+        .unwrap();
+        let child_path = day_dir.join("rollout-child-ext.jsonl");
+        fs::write(
+            &child_path,
+            format!(
+                "{}\n{}\n{}\n",
+                codex_meta_line("child-ext", Some("parent-ext"), &recent_ts(2, 0)),
+                codex_usage_line(&recent_ts(2, 0), (100, 40, 50, 10, 150)),
+                codex_usage_line(&recent_ts(2, 30), (300, 140, 90, 30, 390)),
+            ),
+        )
+        .unwrap();
+
+        let identity = SessionIdentity {
+            tool: "codex".to_string(),
+            external_session_id: "parent-ext".to_string(),
+            ..identity()
+        };
+        let events = run_as(&db, &identity, &child_path).unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            value_u64(&events[0], token_usage_pos::INPUT_TOKENS),
+            Some(100),
+            "only the child's own delta counts"
+        );
     }
 
     #[test]

--- a/src/daemon/token_usage_worker.rs
+++ b/src/daemon/token_usage_worker.rs
@@ -812,7 +812,8 @@ fn records_session_id(path: &Path, session_id: &str) -> bool {
 }
 
 /// Fallback parent discovery for rollouts the token database has not tracked
-/// (yet): walk the child's enclosing codex `sessions` tree for a filename
+/// (yet): walk the child's enclosing codex `sessions` tree — and its sibling
+/// `archived_sessions`, where Codex moves archived rollouts — for a filename
 /// carrying the parent id (codex rollout filenames embed the session uuid),
 /// confirming by the recorded `session_meta` id.
 fn scan_sessions_tree(child_path: &Path, parent_id: &str) -> Option<PathBuf> {
@@ -820,6 +821,9 @@ fn scan_sessions_tree(child_path: &Path, parent_id: &str) -> Option<PathBuf> {
         .ancestors()
         .find(|dir| dir.file_name().and_then(|name| name.to_str()) == Some("sessions"))?;
     let mut pending = vec![sessions_root.to_path_buf()];
+    if let Some(codex_home) = sessions_root.parent() {
+        pending.push(codex_home.join("archived_sessions"));
+    }
     let mut visited = 0usize;
     while let Some(dir) = pending.pop() {
         let Ok(entries) = std::fs::read_dir(&dir) else {
@@ -831,7 +835,9 @@ fn scan_sessions_tree(child_path: &Path, parent_id: &str) -> Option<PathBuf> {
                 return None;
             }
             let path = entry.path();
-            if path.is_dir() {
+            // file_type() is free on the readdir result, unlike a stat per
+            // entry; symlinked directories are deliberately not followed.
+            if entry.file_type().is_ok_and(|kind| kind.is_dir()) {
                 pending.push(path);
             } else if path
                 .file_name()
@@ -1826,6 +1832,51 @@ mod tests {
     }
 
     #[test]
+    fn forked_codex_parent_is_found_under_archived_sessions() {
+        // Codex moves archived rollouts to `archived_sessions`, a sibling of
+        // `sessions`: a fork whose parent was archived must still resolve
+        // instead of falling back to the burst heuristic.
+        let (dir, db, _) = setup();
+        let archived_dir = dir.path().join("archived_sessions/2026/01/08");
+        fs::create_dir_all(&archived_dir).unwrap();
+        fs::write(
+            archived_dir.join("rollout-parent-ext.jsonl"),
+            format!(
+                "{}\n{}\n",
+                codex_meta_line("parent-ext", None, &recent_ts(0, 30)),
+                codex_usage_line(&recent_ts(1, 0), (100, 40, 50, 10, 150)),
+            ),
+        )
+        .unwrap();
+        let day_dir = dir.path().join("sessions/2026/01/09");
+        fs::create_dir_all(&day_dir).unwrap();
+        let child_path = day_dir.join("rollout-child-ext.jsonl");
+        fs::write(
+            &child_path,
+            format!(
+                "{}\n{}\n{}\n",
+                codex_meta_line("child-ext", Some("parent-ext"), &recent_ts(2, 0)),
+                codex_usage_line(&recent_ts(2, 0), (100, 40, 50, 10, 150)),
+                codex_usage_line(&recent_ts(2, 30), (300, 140, 90, 30, 390)),
+            ),
+        )
+        .unwrap();
+
+        let identity = SessionIdentity {
+            tool: "codex".to_string(),
+            external_session_id: "parent-ext".to_string(),
+            ..identity()
+        };
+        let events = run_as(&db, &identity, &child_path).unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            value_u64(&events[0], token_usage_pos::INPUT_TOKENS),
+            Some(100),
+            "only the child's own delta counts"
+        );
+    }
+
+    #[test]
     fn codex_config_service_tier_is_the_fallback_for_unmarked_entries() {
         // A rollout under a codex home whose config.toml requests the fast
         // tier: unmarked entries resolve to fast (inferred), while a recorded
@@ -1839,24 +1890,13 @@ mod tests {
         )
         .unwrap();
         let transcript = codex_home.join("sessions").join("rollout-test.jsonl");
-        let usage = |minute: u32, totals: (u64, u64, u64, u64, u64)| {
-            format!(
-                r#"{{"timestamp":"{}","type":"event_msg","payload":{{"type":"token_count","info":{{"total_token_usage":{{"input_tokens":{},"cached_input_tokens":{},"output_tokens":{},"reasoning_output_tokens":{},"total_tokens":{}}}}}}}}}"#,
-                recent_ts(minute, 0),
-                totals.0,
-                totals.1,
-                totals.2,
-                totals.3,
-                totals.4
-            )
-        };
         fs::write(
             &transcript,
             format!(
                 "{}\n{}\n{}\n",
-                usage(1, (100, 40, 50, 10, 150)),
+                codex_usage_line(&recent_ts(1, 0), (100, 40, 50, 10, 150)),
                 r#"{"timestamp":"2026-01-01T00:02:00Z","type":"event_msg","payload":{"type":"thread_settings_applied","thread_settings":{"service_tier":"standard"}}}"#,
-                usage(3, (300, 140, 90, 30, 390)),
+                codex_usage_line(&recent_ts(3, 0), (300, 140, 90, 30, 390)),
             ),
         )
         .unwrap();

--- a/src/daemon/token_usage_worker.rs
+++ b/src/daemon/token_usage_worker.rs
@@ -812,10 +812,12 @@ fn records_session_id(path: &Path, session_id: &str) -> bool {
     let Ok(file) = std::fs::File::open(path) else {
         return false;
     };
-    // A rollout's session_meta line is small; a candidate whose first line
-    // is larger is not one, and must not be buffered wholly into memory
-    // (the scan feeds this any file whose name carries the parent id).
-    const MAX_FIRST_LINE_BYTES: u64 = 64 * 1024;
+    // A candidate whose first line is larger than any real session_meta
+    // must not be buffered wholly into memory (the scan feeds this any
+    // .jsonl whose name carries the parent id). The cap is generous:
+    // session_meta embeds the session's instructions (AGENTS.md contents),
+    // which can reach hundreds of KiB.
+    const MAX_FIRST_LINE_BYTES: u64 = 1024 * 1024;
     let mut line = Vec::new();
     let mut reader = BufReader::new(file.take(MAX_FIRST_LINE_BYTES));
     if read_line_bytes(&mut reader, &mut line).is_err() {

--- a/src/token_usage/codex.rs
+++ b/src/token_usage/codex.rs
@@ -203,7 +203,15 @@ impl UsageExtractor for CodexUsageExtractor {
         };
         match raw.entry_type.as_deref() {
             Some("session_meta") => {
-                if let Some(parent_id) = raw.payload.as_ref().and_then(fork_parent_id) {
+                // A fork marker arms replay matching only from the pristine
+                // state (real rollouts carry session_meta as line 1): once
+                // matching started or any usage was counted, a repeated
+                // marker must not discard that progress, re-trigger parent
+                // resolution, or mis-skip genuine usage as replayed history.
+                if matches!(self.state.replay, ReplayState::Done)
+                    && self.state.prev_totals.is_none()
+                    && let Some(parent_id) = raw.payload.as_ref().and_then(fork_parent_id)
+                {
                     self.state.replay = ReplayState::AwaitingParent {
                         parent_id,
                         fork_ts_ms: timestamp_millis(raw.timestamp.as_ref()).unwrap_or(i64::MAX),
@@ -587,8 +595,12 @@ pub fn collect_parent_prefix(
     let mut line: Vec<u8> = Vec::new();
     loop {
         line.clear();
+        // A mid-read I/O error means the prefix is unknown, not complete: a
+        // truncated (possibly empty) prefix would verify as the whole
+        // replayed history and double-count the rest. Unresolvable — the
+        // burst-heuristic fallback — like a parent that failed to open.
         let Ok(bytes) = reader.read_until(b'\n', &mut line) else {
-            return Some(prefix);
+            return None;
         };
         if bytes == 0 {
             return Some(prefix);
@@ -1475,6 +1487,57 @@ mod tests {
             (300, 140, 90, 30, 390),
         ));
         assert_eq!(second.len(), 1);
+    }
+
+    #[test]
+    fn a_parent_read_error_means_the_prefix_is_unknown_not_empty() {
+        // An I/O error mid-read must not verify a truncated prefix as the
+        // whole replayed history (which would double-count the rest): the
+        // parent is unresolvable, like one that failed to open.
+        struct FailingReader;
+        impl std::io::Read for FailingReader {
+            fn read(&mut self, _: &mut [u8]) -> std::io::Result<usize> {
+                Err(std::io::Error::other("stale handle"))
+            }
+        }
+        let prefix = collect_parent_prefix(std::io::BufReader::new(FailingReader), i64::MAX);
+        assert_eq!(prefix, None);
+    }
+
+    #[test]
+    fn a_repeated_fork_marker_does_not_rearm_replay_matching() {
+        // Real rollouts carry session_meta as line 1; a repeated marker in a
+        // corrupt or crafted file must not discard matching progress or
+        // mis-skip genuine usage as replayed history.
+        let mut e = CodexUsageExtractor::default();
+        e.extract_line(forked_child_line());
+        e.provide_parent_prefix(Some(vec![sig(100, 40, 50, 10, 150)]));
+        // The replayed head is skipped.
+        assert!(
+            e.extract_line(&token_count_line(
+                "2026-01-09T02:16:39Z",
+                (100, 40, 50, 10, 150),
+            ))
+            .is_empty()
+        );
+        // A second marker after genuine usage was counted stays inert.
+        let own = e.extract_line(&token_count_line(
+            "2026-01-09T02:16:40Z",
+            (300, 140, 90, 30, 390),
+        ));
+        assert_eq!(own.len(), 1);
+        e.extract_line(forked_child_line());
+        assert!(matches!(e.state.replay, ReplayState::Done));
+        assert_eq!(e.parent_request(), None);
+        let after = e.extract_line(&token_count_line(
+            "2026-01-09T02:16:41Z",
+            (500, 220, 150, 50, 650),
+        ));
+        assert_eq!(
+            after.len(),
+            1,
+            "usage after the spurious marker still counts"
+        );
     }
 
     #[test]

--- a/src/token_usage/codex.rs
+++ b/src/token_usage/codex.rs
@@ -267,8 +267,12 @@ impl UsageExtractor for CodexUsageExtractor {
             return;
         }
         self.state.replay = match prefix {
-            // An empty prefix behaves like ccusage's: the first event
-            // mismatches with nothing matched and takes the burst fallback.
+            // A successfully read parent with zero pre-fork usage proves
+            // nothing was replayed: every child event is its own. (Deviation
+            // from ccusage, whose empty prefix falls through to the burst
+            // heuristic and can park — and drop — a child's real first turns
+            // when they arrive within a second of each other.)
+            Some(prefix) if prefix.is_empty() => ReplayState::Done,
             Some(prefix) => ReplayState::MatchingParent {
                 remaining: prefix.into(),
                 matched: false,
@@ -554,8 +558,16 @@ fn signature_of(delta: &CodexTotals) -> UsageSignature {
     }
 }
 
+/// Longest parent prefix worth matching: forks replay the parent's whole
+/// history, so a cap this size is only reachable for pathological rollouts —
+/// and the unmatched remainder persists in the extractor state per batch, so
+/// an unbounded prefix would bloat every state_json write. Over the cap the
+/// parent counts as unresolvable (burst-heuristic fallback).
+pub const MAX_PARENT_PREFIX_EVENTS: usize = 50_000;
+
 /// The parent rollout's non-zero usage deltas up to the fork instant, in
-/// file order (ccusage `read_parent_usage` with its `forked_at` truncation).
+/// file order (ccusage `read_parent_usage` with its `forked_at` truncation),
+/// or `None` when the prefix exceeds [`MAX_PARENT_PREFIX_EVENTS`].
 /// Runs the same delta pipeline as extraction over a fresh cursor — with no
 /// replay filtering, so a prefix the parent itself replayed from *its*
 /// parent stays included, exactly as the child's copy contains it. Events
@@ -569,17 +581,17 @@ fn signature_of(delta: &CodexTotals) -> UsageSignature {
 pub fn collect_parent_prefix(
     mut reader: impl std::io::BufRead,
     fork_ts_ms: i64,
-) -> Vec<UsageSignature> {
+) -> Option<Vec<UsageSignature>> {
     let mut prefix = Vec::new();
     let mut prev_totals: Option<CodexTotals> = None;
     let mut line: Vec<u8> = Vec::new();
     loop {
         line.clear();
         let Ok(bytes) = reader.read_until(b'\n', &mut line) else {
-            return prefix;
+            return Some(prefix);
         };
         if bytes == 0 {
-            return prefix;
+            return Some(prefix);
         }
         let text = String::from_utf8_lossy(&line);
         let trimmed = text.trim();
@@ -602,9 +614,12 @@ pub fn collect_parent_prefix(
             continue;
         };
         if ts_ms > fork_ts_ms {
-            return prefix;
+            return Some(prefix);
         }
         if let Some(Some(delta)) = usage_delta(payload.info.as_ref(), &mut prev_totals) {
+            if prefix.len() >= MAX_PARENT_PREFIX_EVENTS {
+                return None;
+            }
             prefix.push(signature_of(&delta));
         }
     }
@@ -1438,8 +1453,28 @@ mod tests {
         let prefix = collect_parent_prefix(parent.as_bytes(), 1_767_925_000_000);
         assert_eq!(
             prefix,
-            vec![sig(100, 40, 50, 10, 150), sig(200, 100, 40, 20, 240)]
+            Some(vec![sig(100, 40, 50, 10, 150), sig(200, 100, 40, 20, 240)])
         );
+    }
+
+    #[test]
+    fn a_verified_empty_parent_prefix_means_nothing_was_replayed() {
+        // The parent was read successfully and had no pre-fork usage: every
+        // child event is its own, even back-to-back ones the burst heuristic
+        // would have parked and dropped.
+        let mut e = CodexUsageExtractor::default();
+        e.extract_line(forked_child_line());
+        e.provide_parent_prefix(Some(Vec::new()));
+        let first = e.extract_line(&token_count_line(
+            "2026-01-09T02:16:38.209Z",
+            (100, 40, 50, 10, 150),
+        ));
+        assert_eq!(first.len(), 1, "counted despite sub-second spacing");
+        let second = e.extract_line(&token_count_line(
+            "2026-01-09T02:16:38.230Z",
+            (300, 140, 90, 30, 390),
+        ));
+        assert_eq!(second.len(), 1);
     }
 
     #[test]

--- a/src/token_usage/codex.rs
+++ b/src/token_usage/codex.rs
@@ -559,10 +559,13 @@ fn signature_of(delta: &CodexTotals) -> UsageSignature {
 /// Runs the same delta pipeline as extraction over a fresh cursor — with no
 /// replay filtering, so a prefix the parent itself replayed from *its*
 /// parent stays included, exactly as the child's copy contains it. Events
-/// whose timestamps don't parse are dropped (extraction drops them on the
-/// child side too, so they can never need matching); collection stops at
-/// the first usage event past `fork_ts_ms` (usage the parent recorded after
-/// the fork was never replayed).
+/// whose timestamps don't parse are dropped, mirroring extraction (Codex
+/// never emits such lines; ccusage keeps a present-but-malformed timestamp's
+/// usage in the prefix — a deviation only reachable through corruption, and
+/// note the child's replayed *copy* of such an event is rewritten to the
+/// fork instant, so its delta would go unmatched either way here);
+/// collection stops at the first usage event past `fork_ts_ms` (usage the
+/// parent recorded after the fork was never replayed).
 pub fn collect_parent_prefix(
     mut reader: impl std::io::BufRead,
     fork_ts_ms: i64,

--- a/src/token_usage/codex.rs
+++ b/src/token_usage/codex.rs
@@ -16,11 +16,16 @@
 //!   repricing history when `~/.codex/config.toml` changes.
 //! - No `codex-auto-review` release-date fallback table; model ids price
 //!   through git-ai's catalog.
-//! - Fork replay: ccusage matches a forked session's leading usage against
-//!   the parent log's usage prefix, which requires reading other files. That
-//!   is not possible incrementally, so forks always take ccusage's fallback
-//!   for an unavailable parent log: the "rewritten burst" heuristic (leading
-//!   usage events spaced <= 1s apart are replayed history and are skipped).
+//! - Fork replay matches ccusage: a forked session's leading usage is
+//!   matched against the parent log's pre-fork usage prefix and skipped. The
+//!   whole-file read happens in the worker (the extractor can't read other
+//!   files incrementally): a fork parks in `AwaitingParent` until the worker
+//!   answers with the prefix, and the unmatched remainder persists in the
+//!   extractor state so the parent is never rescanned across passes or
+//!   restarts. A parent that cannot be resolved falls back — like ccusage
+//!   with an unavailable parent log — to the "rewritten burst" heuristic
+//!   (leading usage events spaced <= 1s apart are replayed history), and is
+//!   not retried.
 //! - Numeric token fields accept ccusage's aliases and string-encoded
 //!   numbers, but a line whose payload/info has an unexpected *shape* (e.g. a
 //!   scalar where an object belongs) is skipped whole, where ccusage's lossy
@@ -30,9 +35,11 @@
 //!   unless the catalog learns it); see `cost.rs` for the shared pricing
 //!   rules and deviations.
 
+use std::collections::VecDeque;
+
 use serde::{Deserialize, Serialize};
 
-use super::extractor::UsageExtractor;
+use super::extractor::{ParentPrefixRequest, UsageExtractor, UsageSignature};
 use super::types::{PricingShape, Speed, TokenCounts, UsageEntry};
 
 /// ccusage `CODEX_REWRITTEN_BURST_PAUSE_MS`: the longest pause tolerated
@@ -130,18 +137,32 @@ fn lossy_u64<'de, D: serde::Deserializer<'de>>(deserializer: D) -> Result<u64, D
         .unwrap_or(0))
 }
 
-/// Fork-replay filter state (ccusage `CodexReplayState`, minus the
-/// parent-prefix arm — see the module docs). Tracks every usage-carrying
-/// event's timestamp, matching ccusage's `detect_rewritten_burst`, which
-/// anchors on raw usage events even when they are cumulative repeats that
-/// produce no delta.
+/// Fork-replay filter state (ccusage `CodexReplayState`). The burst arms
+/// track every usage-carrying event's timestamp, matching ccusage's
+/// `detect_rewritten_burst`, which anchors on raw usage events even when
+/// they are cumulative repeats that produce no delta.
 #[derive(Debug, Default, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 enum ReplayState {
     /// Not a fork, or past the replayed history.
     #[default]
     Done,
-    /// Fork detected; no usage event seen yet.
+    /// Fork detected; waiting for the worker to resolve the parent's
+    /// pre-fork usage prefix (see `UsageExtractor::parent_request`).
+    /// `fork_ts_ms` is `i64::MAX` when the `session_meta` carried no usable
+    /// timestamp — ccusage then treats the parent's whole stream as replayed.
+    AwaitingParent { parent_id: String, fork_ts_ms: i64 },
+    /// Matching the child's leading usage against the parent's remaining
+    /// pre-fork signatures (ccusage `MatchingParent`); the front is consumed
+    /// as it matches, so persisted state shrinks with the replayed burst.
+    MatchingParent {
+        remaining: VecDeque<UsageSignature>,
+        /// At least one event matched: a later mismatch means the replayed
+        /// history ended (count from there) rather than that the parent
+        /// stream cannot anchor the replay (burst-heuristic fallback).
+        matched: bool,
+    },
+    /// Unavailable-parent fallback: fork detected, no usage event seen yet.
     AwaitingFirst,
     /// One usage event seen (its delta, if any, is buffered): whether it was
     /// replayed history depends on how soon the next one follows.
@@ -182,8 +203,11 @@ impl UsageExtractor for CodexUsageExtractor {
         };
         match raw.entry_type.as_deref() {
             Some("session_meta") => {
-                if raw.payload.as_ref().is_some_and(is_forked_session) {
-                    self.state.replay = ReplayState::AwaitingFirst;
+                if let Some(parent_id) = raw.payload.as_ref().and_then(fork_parent_id) {
+                    self.state.replay = ReplayState::AwaitingParent {
+                        parent_id,
+                        fork_ts_ms: timestamp_millis(raw.timestamp.as_ref()).unwrap_or(i64::MAX),
+                    };
                 }
                 // session_meta names the model too (matching
                 // streams::model_extraction, so usage prices under the same
@@ -223,6 +247,34 @@ impl UsageExtractor for CodexUsageExtractor {
 
     fn set_fallback_speed(&mut self, speed: Option<Speed>) {
         self.fallback_speed = speed;
+    }
+
+    fn parent_request(&self) -> Option<ParentPrefixRequest> {
+        match &self.state.replay {
+            ReplayState::AwaitingParent {
+                parent_id,
+                fork_ts_ms,
+            } => Some(ParentPrefixRequest {
+                parent_id: parent_id.clone(),
+                fork_ts_ms: *fork_ts_ms,
+            }),
+            _ => None,
+        }
+    }
+
+    fn provide_parent_prefix(&mut self, prefix: Option<Vec<UsageSignature>>) {
+        if !matches!(self.state.replay, ReplayState::AwaitingParent { .. }) {
+            return;
+        }
+        self.state.replay = match prefix {
+            // An empty prefix behaves like ccusage's: the first event
+            // mismatches with nothing matched and takes the burst fallback.
+            Some(prefix) => ReplayState::MatchingParent {
+                remaining: prefix.into(),
+                matched: false,
+            },
+            None => ReplayState::AwaitingFirst,
+        };
     }
 
     fn has_pending(&self) -> bool {
@@ -297,33 +349,10 @@ impl CodexUsageExtractor {
             return Vec::new();
         };
 
-        // Delta computation (ccusage `visit_codex_session_entry`): skip
-        // repeats of an unchanged cumulative total, prefer the recorded
-        // per-turn usage, else subtract the previous cumulative total.
         let info = payload.info.as_ref();
-        let total_usage = info
-            .and_then(|info| info.total_token_usage)
-            .map(CodexTotals::normalized);
-        let last_usage = info
-            .and_then(|info| info.last_token_usage)
-            .map(CodexTotals::normalized);
-        if total_usage.is_none() && last_usage.is_none() {
+        let Some(delta) = usage_delta(info, &mut self.state.prev_totals) else {
             return Vec::new();
-        }
-        let cumulative_advanced =
-            total_usage.is_none_or(|totals| self.state.prev_totals != Some(totals));
-        let delta = last_usage
-            .filter(|_| cumulative_advanced)
-            .or_else(|| total_usage.map(|totals| subtract_totals(totals, self.state.prev_totals)));
-        if let Some(totals) = total_usage {
-            self.state.prev_totals = Some(totals);
-        }
-        let delta = delta.filter(|delta| {
-            delta.input_tokens != 0
-                || delta.cached_input_tokens != 0
-                || delta.output_tokens != 0
-                || delta.reasoning_output_tokens != 0
-        });
+        };
 
         let event = delta.map(|delta| {
             let parsed_model = payload_model(payload).or_else(|| info.and_then(info_model));
@@ -359,12 +388,60 @@ impl CodexUsageExtractor {
             |anchor_ts_ms: i64| (0..=REWRITTEN_BURST_PAUSE_MS).contains(&(ts_ms - anchor_ts_ms));
         match std::mem::take(&mut self.state.replay) {
             ReplayState::Done => event.map(|e| vec![make_entry(e)]).unwrap_or_default(),
-            ReplayState::AwaitingFirst => {
+            // A usage event while the parent request is still unanswered can
+            // only mean no worker resolution ran (direct extractor use):
+            // take the unavailable-parent fallback, parking this event as
+            // the burst heuristic's first.
+            ReplayState::AwaitingParent { .. } | ReplayState::AwaitingFirst => {
                 self.state.replay = ReplayState::AwaitingSecond {
                     first_ts_ms: ts_ms,
                     pending: event,
                 };
                 Vec::new()
+            }
+            ReplayState::MatchingParent {
+                mut remaining,
+                matched,
+            } => {
+                let Some(event) = event else {
+                    // Zero-delta repeats carry no identity to match, and the
+                    // prefix holds only delta-producing events: pass through
+                    // without consuming anything (ccusage's replay filter
+                    // never sees them).
+                    self.state.replay = ReplayState::MatchingParent { remaining, matched };
+                    return Vec::new();
+                };
+                if remaining.front() == Some(&signature_of(&event.delta)) {
+                    remaining.pop_front();
+                    // A fully consumed prefix is done: ccusage reaches the
+                    // same outcome one event later (the next event mismatches
+                    // past the prefix end with matched history behind it).
+                    self.state.replay = if remaining.is_empty() {
+                        ReplayState::Done
+                    } else {
+                        ReplayState::MatchingParent {
+                            remaining,
+                            matched: true,
+                        }
+                    };
+                    return Vec::new();
+                }
+                if matched {
+                    // Past the replayed history: this and everything after
+                    // is the child's own usage.
+                    self.state.replay = ReplayState::Done;
+                    vec![make_entry(event)]
+                } else {
+                    // Nothing matched, so the parent stream cannot anchor
+                    // this replay (the log rewrote the copied history). Fall
+                    // back to the rewritten-burst heuristic with this event
+                    // as its first (ccusage `detect_rewritten_burst`).
+                    self.state.replay = ReplayState::AwaitingSecond {
+                        first_ts_ms: ts_ms,
+                        pending: Some(event),
+                    };
+                    Vec::new()
+                }
             }
             ReplayState::AwaitingSecond {
                 first_ts_ms,
@@ -430,6 +507,116 @@ fn make_entry(event: PendingEvent) -> UsageEntry {
         speed_inferred,
         pricing_shape: PricingShape::Codex,
     }
+}
+
+/// Delta computation for one `token_count` payload (ccusage
+/// `visit_codex_session_entry`): skip repeats of an unchanged cumulative
+/// total, prefer the recorded per-turn usage, else subtract the previous
+/// cumulative total. `None` when the payload carries no usage at all;
+/// `Some(None)` for a usage event whose delta is zero (it still marks
+/// activity for the replay filter's burst arms).
+fn usage_delta(
+    info: Option<&RawInfo>,
+    prev_totals: &mut Option<CodexTotals>,
+) -> Option<Option<CodexTotals>> {
+    let total_usage = info
+        .and_then(|info| info.total_token_usage)
+        .map(CodexTotals::normalized);
+    let last_usage = info
+        .and_then(|info| info.last_token_usage)
+        .map(CodexTotals::normalized);
+    if total_usage.is_none() && last_usage.is_none() {
+        return None;
+    }
+    let cumulative_advanced = total_usage.is_none_or(|totals| *prev_totals != Some(totals));
+    let delta = last_usage
+        .filter(|_| cumulative_advanced)
+        .or_else(|| total_usage.map(|totals| subtract_totals(totals, *prev_totals)));
+    if let Some(totals) = total_usage {
+        *prev_totals = Some(totals);
+    }
+    Some(delta.filter(|delta| {
+        delta.input_tokens != 0
+            || delta.cached_input_tokens != 0
+            || delta.output_tokens != 0
+            || delta.reasoning_output_tokens != 0
+    }))
+}
+
+/// The matching identity of one usage delta (see [`UsageSignature`]).
+fn signature_of(delta: &CodexTotals) -> UsageSignature {
+    UsageSignature {
+        input: delta.input_tokens,
+        cached_input: delta.cached_input_tokens,
+        output: delta.output_tokens,
+        reasoning_output: delta.reasoning_output_tokens,
+        total: delta.total_tokens,
+    }
+}
+
+/// The parent rollout's non-zero usage deltas up to the fork instant, in
+/// file order (ccusage `read_parent_usage` with its `forked_at` truncation).
+/// Runs the same delta pipeline as extraction over a fresh cursor — with no
+/// replay filtering, so a prefix the parent itself replayed from *its*
+/// parent stays included, exactly as the child's copy contains it. Events
+/// whose timestamps don't parse are dropped (extraction drops them on the
+/// child side too, so they can never need matching); collection stops at
+/// the first usage event past `fork_ts_ms` (usage the parent recorded after
+/// the fork was never replayed).
+pub fn collect_parent_prefix(
+    mut reader: impl std::io::BufRead,
+    fork_ts_ms: i64,
+) -> Vec<UsageSignature> {
+    let mut prefix = Vec::new();
+    let mut prev_totals: Option<CodexTotals> = None;
+    let mut line: Vec<u8> = Vec::new();
+    loop {
+        line.clear();
+        let Ok(bytes) = reader.read_until(b'\n', &mut line) else {
+            return prefix;
+        };
+        if bytes == 0 {
+            return prefix;
+        }
+        let text = String::from_utf8_lossy(&line);
+        let trimmed = text.trim();
+        if !trimmed.contains("token_count") {
+            continue;
+        }
+        let Ok(raw) = serde_json::from_str::<RawLine>(trimmed) else {
+            continue;
+        };
+        if raw.entry_type.as_deref() != Some("event_msg") {
+            continue;
+        }
+        let Some(payload) = raw.payload.as_ref() else {
+            continue;
+        };
+        if payload.payload_type.as_deref() != Some("token_count") {
+            continue;
+        }
+        let Some(ts_ms) = timestamp_millis(raw.timestamp.as_ref()) else {
+            continue;
+        };
+        if ts_ms > fork_ts_ms {
+            return prefix;
+        }
+        if let Some(Some(delta)) = usage_delta(payload.info.as_ref(), &mut prev_totals) {
+            prefix.push(signature_of(&delta));
+        }
+    }
+}
+
+/// The `session_meta` id recorded on a rollout's first line, used to confirm
+/// a parent candidate really is the session the fork names (ccusage
+/// `read_codex_session_metadata` locates parents by recorded id, never by
+/// filename).
+pub fn session_meta_id(first_line: &str) -> Option<String> {
+    let raw = serde_json::from_str::<RawLine>(first_line.trim()).ok()?;
+    if raw.entry_type.as_deref() != Some("session_meta") {
+        return None;
+    }
+    raw.payload?.id
 }
 
 /// The speed a recorded or configured service-tier value maps to (ccusage
@@ -532,20 +719,26 @@ struct RawMetadata {
     model: Option<String>,
 }
 
-/// Fork markers from ccusage `read_codex_session_metadata`. A session that
-/// lists itself as its own parent is not a fork (ccusage guards this too: it
-/// would match the whole stream and drop every event).
-fn is_forked_session(payload: &RawPayload) -> bool {
+/// Fork markers from ccusage `read_codex_session_metadata`, returning the
+/// parent session id. A session that lists itself as its own parent is not a
+/// fork (ccusage guards this too: it would match the whole stream and drop
+/// every event).
+fn fork_parent_id(payload: &RawPayload) -> Option<String> {
     let own_id = payload.id.as_deref();
-    let is_parent = |value: Option<&str>| value.is_some_and(|v| !v.is_empty() && Some(v) != own_id);
-    is_parent(payload.forked_from_id.as_deref())
-        || is_parent(
+    let parent = |value: Option<&str>| {
+        value
+            .filter(|v| !v.is_empty() && Some(*v) != own_id)
+            .map(str::to_string)
+    };
+    parent(payload.forked_from_id.as_deref()).or_else(|| {
+        parent(
             payload
                 .source
                 .as_ref()
                 .and_then(|source| source.pointer("/subagent/thread_spawn/parent_thread_id"))
                 .and_then(|value| value.as_str()),
         )
+    })
 }
 
 fn payload_model(payload: &RawPayload) -> Option<String> {
@@ -1020,13 +1213,261 @@ mod tests {
         assert_eq!(entries[1].tokens.input, 10);
     }
 
+    fn sig(input: u64, cached: u64, output: u64, reasoning: u64, total: u64) -> UsageSignature {
+        UsageSignature {
+            input,
+            cached_input: cached,
+            output,
+            reasoning_output: reasoning,
+            total,
+        }
+    }
+
+    fn forked_child_line() -> &'static str {
+        r#"{"timestamp":"2026-01-09T02:16:38Z","type":"session_meta","payload":{"id":"child","forked_from_id":"parent"}}"#
+    }
+
+    #[test]
+    fn parent_prefix_matching_skips_the_replayed_history() {
+        // The real-world incident this exists for: the child's first event
+        // replays the parent's 16,508-token history with a rewritten
+        // timestamp, and its own first turn follows 6.975s later — far past
+        // the burst window, so the heuristic alone counts the replay.
+        let replayed = token_count_line("2026-01-09T02:16:38.209Z", (16262, 9984, 246, 86, 16508));
+        let own = token_count_line("2026-01-09T02:16:45.184Z", (16385, 10084, 266, 92, 16651));
+
+        let mut e = CodexUsageExtractor::default();
+        e.extract_line(forked_child_line());
+        e.provide_parent_prefix(Some(vec![sig(16262, 9984, 246, 86, 16508)]));
+        assert!(e.extract_line(&replayed).is_empty(), "replayed history");
+        let entries = e.extract_line(&own);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].tokens.input, 23); // (16385-16262) - (10084-9984)
+        assert_eq!(entries[0].tokens.cache_read, 100);
+        assert_eq!(entries[0].tokens.total, 143);
+
+        // Companion: with the parent unavailable, the burst heuristic has to
+        // release the parked replay after the real pause — the overcount the
+        // prefix matching eliminates.
+        let mut fallback = CodexUsageExtractor::default();
+        fallback.extract_line(forked_child_line());
+        fallback.provide_parent_prefix(None);
+        assert!(fallback.extract_line(&replayed).is_empty());
+        let entries = fallback.extract_line(&own);
+        assert_eq!(entries.len(), 2, "heuristic counts the replayed event");
+        assert_eq!(entries[0].tokens.total, 16508);
+    }
+
+    #[test]
+    fn mid_prefix_mismatch_means_the_replayed_history_ended() {
+        // A fork taken mid-conversation replays only part of the parent's
+        // stream; the first non-matching event is the child's own turn even
+        // when signatures further down the prefix would match it.
+        let mut e = CodexUsageExtractor::default();
+        e.extract_line(forked_child_line());
+        e.provide_parent_prefix(Some(vec![
+            sig(100, 40, 50, 10, 150),
+            sig(200, 100, 40, 20, 240),
+        ]));
+        assert!(
+            e.extract_line(&token_count_line(
+                "2026-01-09T02:16:38.209Z",
+                (100, 40, 50, 10, 150)
+            ))
+            .is_empty()
+        );
+        // Cumulative totals diverge from the parent's second event.
+        let entries = e.extract_line(&token_count_line(
+            "2026-01-09T02:16:38.220Z",
+            (150, 60, 70, 15, 220),
+        ));
+        assert_eq!(entries.len(), 1, "counted despite the sub-second spacing");
+        assert_eq!(entries[0].tokens.total, 70);
+        // And everything after is plainly the child's own usage.
+        let entries = e.extract_line(&token_count_line(
+            "2026-01-09T02:16:38.230Z",
+            (250, 100, 90, 20, 340),
+        ));
+        assert_eq!(entries.len(), 1);
+    }
+
+    #[test]
+    fn exhausted_prefix_counts_subsequent_events_even_within_the_burst_window() {
+        let mut e = CodexUsageExtractor::default();
+        e.extract_line(forked_child_line());
+        e.provide_parent_prefix(Some(vec![sig(100, 40, 50, 10, 150)]));
+        assert!(
+            e.extract_line(&token_count_line(
+                "2026-01-09T02:16:38.209Z",
+                (100, 40, 50, 10, 150)
+            ))
+            .is_empty()
+        );
+        // 11ms later — inside what the burst heuristic would skip.
+        let entries = e.extract_line(&token_count_line(
+            "2026-01-09T02:16:38.220Z",
+            (300, 140, 90, 30, 390),
+        ));
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].tokens.total, 240);
+    }
+
+    #[test]
+    fn unanchored_prefix_falls_back_to_the_burst_heuristic() {
+        // Nothing matches at index 0: the parent stream cannot anchor the
+        // replay, so the leading burst is skipped by timing instead — and a
+        // real pause before the first event means real usage, exactly as if
+        // the parent log were unavailable.
+        let mut e = CodexUsageExtractor::default();
+        e.extract_line(forked_child_line());
+        e.provide_parent_prefix(Some(vec![sig(999, 0, 999, 0, 1998)]));
+        assert!(
+            e.extract_line(&token_count_line(
+                "2026-01-09T02:16:38.209Z",
+                (100, 40, 50, 10, 150)
+            ))
+            .is_empty(),
+            "parked as the burst heuristic's first event"
+        );
+        assert!(
+            e.extract_line(&token_count_line(
+                "2026-01-09T02:16:38.230Z",
+                (300, 140, 90, 30, 390)
+            ))
+            .is_empty(),
+            "back-to-back events form a rewritten burst"
+        );
+        let entries = e.extract_line(&token_count_line(
+            "2026-01-09T02:16:45.184Z",
+            (400, 180, 120, 40, 520),
+        ));
+        assert_eq!(entries.len(), 1, "the pause ends the burst");
+    }
+
+    #[test]
+    fn zero_delta_repeats_do_not_consume_the_prefix() {
+        let mut e = CodexUsageExtractor::default();
+        e.extract_line(forked_child_line());
+        e.provide_parent_prefix(Some(vec![sig(100, 40, 50, 10, 150)]));
+        assert!(
+            e.extract_line(&token_count_line(
+                "2026-01-09T02:16:38.209Z",
+                (100, 40, 50, 10, 150)
+            ))
+            .is_empty()
+        );
+        // A cumulative repeat produces no delta and must not disturb the
+        // exhausted prefix's outcome (nor would it consume one mid-prefix).
+        assert!(
+            e.extract_line(&token_count_line(
+                "2026-01-09T02:16:38.215Z",
+                (100, 40, 50, 10, 150)
+            ))
+            .is_empty()
+        );
+        let entries = e.extract_line(&token_count_line(
+            "2026-01-09T02:16:38.230Z",
+            (300, 140, 90, 30, 390),
+        ));
+        assert_eq!(entries.len(), 1);
+    }
+
+    #[test]
+    fn matching_parent_state_roundtrips_and_shrinks() {
+        let mut e = CodexUsageExtractor::default();
+        e.extract_line(forked_child_line());
+        e.provide_parent_prefix(Some(vec![
+            sig(100, 40, 50, 10, 150),
+            sig(200, 100, 40, 20, 240),
+        ]));
+        assert!(
+            e.extract_line(&token_count_line(
+                "2026-01-09T02:16:38.209Z",
+                (100, 40, 50, 10, 150)
+            ))
+            .is_empty()
+        );
+
+        // Pass boundary: the remaining (shrunken) prefix persists, so the
+        // parent is never rescanned.
+        let state = e.state_json().unwrap();
+        assert!(state.contains("matching_parent"), "{state}");
+        let mut restored = CodexUsageExtractor::default();
+        assert!(restored.restore_state(&state));
+        assert!(restored.parent_request().is_none(), "no re-resolution");
+        assert!(
+            restored
+                .extract_line(&token_count_line(
+                    "2026-01-09T02:16:38.220Z",
+                    (300, 140, 90, 30, 390)
+                ))
+                .is_empty(),
+            "second prefix entry still matches after the roundtrip"
+        );
+        let entries = restored.extract_line(&token_count_line(
+            "2026-01-09T02:16:45.184Z",
+            (400, 180, 120, 40, 520),
+        ));
+        assert_eq!(entries.len(), 1);
+    }
+
+    #[test]
+    fn provide_parent_prefix_applies_only_while_awaiting() {
+        let mut e = CodexUsageExtractor::default();
+        e.extract_line(&token_count_line("2026-01-09T02:16:38Z", (10, 0, 5, 0, 15)));
+        e.provide_parent_prefix(Some(vec![sig(1, 0, 1, 0, 2)]));
+        assert!(matches!(e.state.replay, ReplayState::Done));
+    }
+
+    #[test]
+    fn collect_parent_prefix_keeps_pre_fork_deltas_only() {
+        let parent = format!(
+            "{}\n{}\n{}\n{}\n{}\nnot json\n{}\n",
+            r#"{"timestamp":"2026-01-09T02:00:00Z","type":"session_meta","payload":{"id":"parent"}}"#,
+            token_count_line("2026-01-09T02:10:00Z", (100, 40, 50, 10, 150)),
+            // Cumulative repeat: no delta, not part of the prefix.
+            token_count_line("2026-01-09T02:10:01Z", (100, 40, 50, 10, 150)),
+            token_count_line("2026-01-09T02:16:35Z", (300, 140, 90, 30, 390)),
+            // Recorded after the fork instant: never replayed.
+            token_count_line("2026-01-09T02:20:00Z", (400, 180, 120, 40, 520)),
+            token_count_line("2026-01-09T02:21:00Z", (500, 220, 150, 50, 650)),
+        );
+        let prefix = collect_parent_prefix(parent.as_bytes(), 1_767_925_000_000);
+        assert_eq!(
+            prefix,
+            vec![sig(100, 40, 50, 10, 150), sig(200, 100, 40, 20, 240)]
+        );
+    }
+
+    #[test]
+    fn session_meta_id_reads_the_first_line() {
+        assert_eq!(
+            session_meta_id(
+                r#"{"timestamp":"2026-01-09T02:00:00Z","type":"session_meta","payload":{"id":"parent"}}"#
+            )
+            .as_deref(),
+            Some("parent")
+        );
+        assert_eq!(
+            session_meta_id(r#"{"type":"turn_context","payload":{"model":"gpt-5.1"}}"#),
+            None
+        );
+        assert_eq!(session_meta_id("not json"), None);
+    }
+
     #[test]
     fn subagent_thread_spawn_counts_as_fork() {
         let mut e = CodexUsageExtractor::default();
         e.extract_line(
             r#"{"timestamp":"2026-01-01T00:00:00Z","type":"session_meta","payload":{"id":"child","source":{"subagent":{"thread_spawn":{"parent_thread_id":"parent"}}}}}"#,
         );
-        assert!(matches!(e.state.replay, ReplayState::AwaitingFirst));
+        assert_eq!(
+            e.parent_request(),
+            Some(ParentPrefixRequest {
+                parent_id: "parent".to_string(),
+                fork_ts_ms: 1_767_225_600_000,
+            })
+        );
     }
 
     #[test]

--- a/src/token_usage/db.rs
+++ b/src/token_usage/db.rs
@@ -606,6 +606,27 @@ impl TokenUsageDatabase {
         Ok(())
     }
 
+    /// Stream paths tracked under an external session id. The id is the
+    /// rollup root's (forked/subagent files roll up to their parent), so the
+    /// root's own rollout is among the results — alongside any rolled-up
+    /// children, which callers must tell apart by each file's recorded
+    /// `session_meta` id.
+    pub fn stream_paths_for_external_session(
+        &self,
+        external_session_id: &str,
+        tool: &str,
+    ) -> Result<Vec<String>, GitAiError> {
+        let conn = self.lock();
+        let mut stmt = conn.prepare(
+            "SELECT stream_path FROM tracked_files
+             WHERE external_session_id = ?1 AND tool = ?2",
+        )?;
+        let paths = stmt
+            .query_map(params![external_session_id, tool], |row| row.get(0))?
+            .collect::<Result<Vec<String>, _>>()?;
+        Ok(paths)
+    }
+
     /// Clear the reconcile flag after the session's buckets were reconciled.
     pub fn clear_needs_reconcile(&self, session_id: &str) -> Result<(), GitAiError> {
         self.lock().execute(

--- a/src/token_usage/extractor.rs
+++ b/src/token_usage/extractor.rs
@@ -1,6 +1,29 @@
 //! Per-agent usage extraction trait.
 
+use serde::{Deserialize, Serialize};
+
 use super::types::{Speed, UsageEntry};
+
+/// A forked session's request for its parent's pre-fork usage history: the
+/// parent's external session id, and the fork instant (the child's
+/// `session_meta` timestamp; parent usage past it was never replayed).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParentPrefixRequest {
+    pub parent_id: String,
+    pub fork_ts_ms: i64,
+}
+
+/// Raw per-event usage identity used to match a forked session's replayed
+/// leading events against its parent's history. Timestamps are excluded —
+/// Codex rewrites replayed history to the fork instant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UsageSignature {
+    pub input: u64,
+    pub cached_input: u64,
+    pub output: u64,
+    pub reasoning_output: u64,
+    pub total: u64,
+}
 
 /// Incremental, line-oriented extractor of token-usage entries from an agent
 /// transcript. Fed complete JSONL lines in file order; may keep per-session
@@ -18,6 +41,21 @@ pub trait UsageExtractor: Send {
     /// the worker once per pass, before any line is fed. No-op for agents
     /// without the concept.
     fn set_fallback_speed(&mut self, _speed: Option<Speed>) {}
+
+    /// The extractor found a fork and needs its parent's pre-fork usage
+    /// prefix before it can judge usage events (Codex). The worker answers
+    /// via [`UsageExtractor::provide_parent_prefix`] after every consumed
+    /// line and after restoring state, so the request is served before the
+    /// next usage event. `None` for extractors without the concept.
+    fn parent_request(&self) -> Option<ParentPrefixRequest> {
+        None
+    }
+
+    /// Answer a [`UsageExtractor::parent_request`]: `Some` carries the
+    /// parent's pre-fork usage signatures in file order; `None` means the
+    /// parent could not be resolved, and the extractor takes its
+    /// unavailable-parent fallback (never retried).
+    fn provide_parent_prefix(&mut self, _prefix: Option<Vec<UsageSignature>>) {}
 
     /// Serialized parser state to persist between incremental runs. `None`
     /// for stateless extractors.

--- a/tests/integration/token_usage.rs
+++ b/tests/integration/token_usage.rs
@@ -441,6 +441,92 @@ fn fast_long_context_codex_usage_emits_tier_and_speed_fields() {
 }
 
 #[test]
+fn forked_codex_session_counts_only_its_own_usage() {
+    let (_metrics_db_dir, metrics_db_path) = isolated_metrics_db_path();
+    let repo =
+        TestRepo::new_with_daemon_env(&[("GIT_AI_TEST_METRICS_DB_PATH", metrics_db_path.as_str())]);
+    repo.git(&["commit", "--allow-empty", "-m", "initial"])
+        .expect("initial commit should succeed");
+    let repo_root = repo.canonical_path();
+
+    // Codex-style sessions tree: the parent rollout is on disk but only the
+    // child is checkpointed, so the daemon resolves the parent by scanning.
+    let day_dir = repo_root.join("sessions/2026/01/09");
+    fs::create_dir_all(&day_dir).unwrap();
+    let usage = |ts: &str, input: u64, cached: u64, output: u64, total: u64| {
+        json!({
+            "timestamp": ts,
+            "type": "event_msg",
+            "payload": {"type": "token_count", "info": {"total_token_usage": {
+                "input_tokens": input,
+                "cached_input_tokens": cached,
+                "output_tokens": output,
+                "reasoning_output_tokens": 0,
+                "total_tokens": total
+            }}}
+        })
+        .to_string()
+    };
+    fs::write(
+        day_dir.join("rollout-fork-parent.jsonl"),
+        format!(
+            "{}\n{}\n{}\n",
+            json!({"timestamp": recent_ts(0, 30), "type": "session_meta", "payload": {"id": "fork-parent"}}),
+            json!({"timestamp": recent_ts(0, 40), "type": "turn_context", "payload": {"model": "gpt-5.1"}}),
+            usage(&recent_ts(1, 0), 16_262, 9_984, 246, 16_508),
+        ),
+    )
+    .unwrap();
+    // The child replays the parent's history with a rewritten timestamp; its
+    // own first turn follows ~7s later — past the burst window, so only
+    // parent-prefix matching keeps the replay out.
+    let child_path = day_dir.join("rollout-fork-child.jsonl");
+    fs::write(
+        &child_path,
+        format!(
+            "{}\n{}\n{}\n{}\n",
+            json!({"timestamp": recent_ts(2, 0), "type": "session_meta", "payload": {"id": "fork-child", "forked_from_id": "fork-parent"}}),
+            json!({"timestamp": recent_ts(2, 0), "type": "turn_context", "payload": {"model": "gpt-5.1"}}),
+            usage(&recent_ts(2, 0), 16_262, 9_984, 246, 16_508),
+            usage(&recent_ts(2, 7), 16_385, 10_084, 266, 16_651),
+        ),
+    )
+    .unwrap();
+
+    let file_path = repo_root.join("main.rs");
+    fs::write(&file_path, "fn main() {}\n").unwrap();
+    checkpoint_with_transcript(
+        &repo,
+        "codex",
+        "fork-child",
+        &child_path,
+        &file_path,
+        "fn main() {}\nfn added() {}\n",
+    );
+    sync_token_usage_pipeline(&repo);
+
+    let events = token_usage_events(&metrics_db_path);
+    assert_eq!(events.len(), 1);
+    // Only the child's own delta: (16385-16262) - (10084-9984) = 23 input.
+    assert_eq!(
+        value_u64(&events[0], token_usage_pos::INPUT_TOKENS),
+        Some(23)
+    );
+    assert_eq!(
+        value_u64(&events[0], token_usage_pos::CACHE_READ_TOKENS),
+        Some(100)
+    );
+    assert_eq!(
+        value_u64(&events[0], token_usage_pos::TOTAL_TOKENS),
+        Some(143)
+    );
+    assert_eq!(
+        value_u64(&events[0], token_usage_pos::MESSAGE_COUNT),
+        Some(1)
+    );
+}
+
+#[test]
 fn appended_transcript_lines_update_existing_buckets() {
     let (_metrics_db_dir, metrics_db_path) = isolated_metrics_db_path();
     let repo =


### PR DESCRIPTION
A forked rollout replays its parent's history with timestamps rewritten
to the fork instant. The rewritten-burst heuristic (skip leading events
spaced <= 1s apart) misidentifies a real fork whose own first turn
follows the replay after a longer pause — observed in the wild as a
16,508-token replayed event counted as genuine usage 6.975s before the
child's first own turn.

Port ccusage's parent-prefix matching into the incremental extractor:
a fork now parks in AwaitingParent until the worker resolves the parent
rollout and answers with its pre-fork usage signatures (per-event
deltas, timestamps excluded; collected without replay filtering so a
prefix the parent itself replayed stays included, truncated at the
child's session_meta timestamp). The child's leading events consume the
matching front of that prefix; a mismatch after any match means the
replayed history ended, and a mismatch with nothing matched — or an
unresolvable parent — falls back to the burst heuristic exactly as
before (never retried, matching ccusage's unavailable-parent path).
The unmatched remainder persists in the extractor state, so the parent
is read once per fork, not per pass or restart.

The worker serves prefix requests after restoring state and after every
consumed line. Parent resolution tries files tracked under the parent's
external session id, then a bounded scan of the codex sessions tree,
always confirming a candidate by its recorded session_meta id (ccusage
locates parents by id, never filename) — a bounded single-file read in
the async worker.

The spec's fork section is rewritten and the split-burst accepted
limitation narrows to the unresolvable-parent fallback path.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
