### PR TITLE
feat: emit squash-safe attribution fingerprints

### DIFF
--- a/docs/attribution-cookbook.md
+++ b/docs/attribution-cookbook.md
@@ -1,0 +1,85 @@
+# Attribution Cookbook: Surviving Squash Merges
+
+## Problem
+
+Sealed attribution notes identify AI-written line ranges by commit SHA.
+A hosting platform's squash merge creates a new commit that git-ai never
+observed, severing the pre-land commits and their notes from the landed
+commit's ancestry.
+
+## Opt-in content fingerprints
+
+Enable fingerprints with:
+
+```bash
+git-ai config set attribution_fingerprints true
+```
+
+Each hook and sink event then includes an `attributions` array:
+
+```json
+{
+  "schema_version": 2,
+  "commit_sha": "abc123",
+  "attributions": [
+    {
+      "file": "src/calc.py",
+      "session_id": "session-uuid",
+      "model": "claude-sonnet-4",
+      "tool": "cursor",
+      "line_ranges": [[10, 16], [40, 42]],
+      "fingerprints": ["a1b2c3d4e5f6", "..."],
+      "fingerprints_complete": true
+    }
+  ]
+}
+```
+
+### Permanent fingerprint contract
+
+```text
+fingerprint(line) =
+  hex(sha256(line with trailing "\n" and "\r" stripped))[:12]
+```
+
+Only newline characters are stripped. Spaces and tabs remain significant.
+Changing this normalization requires a `schema_version` bump.
+
+Fingerprints are computed from git-ai's checkpoint blob—the content the
+agent wrote—not from the committed file. If a human edits an AI-written
+line before commit, its checkpoint fingerprint will not match the landed
+line, so the line correctly drops out of AI attribution.
+
+For each attribution block, fingerprints follow ascending line order
+across the union of `line_ranges`:
+
+```text
+len(fingerprints) ==
+  sum(end - start + 1 for [start, end] in line_ranges)
+```
+
+If content is unavailable, `fingerprints_complete` is `false`; consumers
+must not interpret missing fingerprints as human authorship.
+
+## Consumer alignment
+
+For each `(commit, file, session)` block:
+
+```text
+S = emitted fingerprints in order
+L = fingerprints of the landed file's lines in order
+cursor = 0
+
+for fingerprint in S:
+  find the first unclaimed index j >= cursor where L[j] == fingerprint
+  if found:
+    attribute landed line j to this block
+    claim j
+    cursor = j + 1
+  otherwise:
+    treat the source line as edited or removed
+```
+
+Process blocks in commit-time order and share the claimed-line set across
+blocks. Do not use set membership: repeated lines are common, and ignoring
+order can attribute the wrong occurrence.

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -32,6 +32,7 @@ Each entry has the following fields:
 | `branch` | `string` | Current branch name (or `"unknown"`). |
 | `is_default_branch` | `bool` | Whether `branch` matches the remote's default branch. |
 | `note_content` | `string` | The full content of the sealed attribution note. |
+| `attributions` | `array?` | Ordered per-line fingerprints, present when `attribution_fingerprints` is enabled. |
 
 **Example payload:**
 
@@ -88,6 +89,11 @@ sinks** configured in `~/.git-ai/config.json`:
 
 Sinks receive the same `AttributionEvent` payload as shell hooks, in
 structured form. Failures are logged, never blocking.
+
+Set `attribution_fingerprints` to `true` to enrich hook and sink events
+with squash-safe line fingerprints. See the
+[attribution cookbook](attribution-cookbook.md) for the payload and
+consumer matching contract.
 
 | Sink type | Behavior |
 |---|---|

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -1,0 +1,99 @@
+# git-ai Hook: `post_notes_updated`
+
+## Overview
+
+When git-ai seals attribution notes on one or more commits, it fires the
+`post_notes_updated` hook. This is the primary integration point for
+exporting attribution data to external systems.
+
+## Configuration
+
+Register shell commands via `git-ai config`:
+
+```bash
+git-ai config --add git_ai_hooks.post_notes_updated "./my-hook.sh"
+```
+
+Multiple commands can be registered; they run in parallel.
+
+## Payload Schema (v2)
+
+The hook receives a **JSON array** of 1..N note entries on **stdin**.
+Each entry has the following fields:
+
+| Field | Type | Description |
+|---|---|---|
+| `schema_version` | `u32` | Schema version. Currently `2`. |
+| `commit_sha` | `string` | The commit SHA the note was sealed for. |
+| `repo_url` | `string` | Remote URL of the repository (from the default remote). |
+| `repo_name` | `string` | Short name derived from `repo_url` (last path segment, `.git` stripped). |
+| `repo_path` | `string?` | Absolute path to the working directory. Omitted for bare repos. |
+| `git_dir` | `string` | Absolute path to the `.git` directory. |
+| `branch` | `string` | Current branch name (or `"unknown"`). |
+| `is_default_branch` | `bool` | Whether `branch` matches the remote's default branch. |
+| `note_content` | `string` | The full content of the sealed attribution note. |
+
+**Example payload:**
+
+```json
+[
+  {
+    "schema_version": 2,
+    "commit_sha": "abc123def456",
+    "repo_url": "https://github.com/org/repo.git",
+    "repo_name": "repo",
+    "repo_path": "/home/user/projects/repo",
+    "git_dir": "/home/user/projects/repo/.git",
+    "branch": "main",
+    "is_default_branch": true,
+    "note_content": "..."
+  }
+]
+```
+
+## Execution Semantics
+
+- **Parallelism:** All registered commands start simultaneously.
+- **Timeout:** git-ai waits up to **3 seconds** for each command to
+  complete, then detaches any still-running commands into a background
+  thread. git-ai never blocks the commit path.
+- **Best-effort:** Hook failures are logged via `tracing::debug!` but
+  never propagated. Hooks are not retried.
+- **stdin:** The JSON payload is written to the command's stdin.
+- **stdout:** Discarded (`/dev/null`). Hooks are not a data channel back
+  into git-ai.
+- **stderr:** Captured and logged on non-zero exit for diagnostics.
+
+## Versioning Policy
+
+- **Additive changes** (new fields) keep the same `schema_version`.
+  Consumers should ignore unknown fields.
+- **Breaking changes** (field removal, type changes, semantic changes)
+  bump `schema_version`.
+
+## Attribution Sinks
+
+In addition to shell hooks, git-ai supports structured **attribution
+sinks** configured in `~/.git-ai/config.json`:
+
+```json
+{
+  "attribution_sinks": [
+    {"type": "stdout"},
+    {"type": "file", "path": "/var/log/git-ai/attributions.jsonl"},
+    {"type": "http", "url": "https://collector.internal/attribution", "headers": {"X-Team": "dx"}}
+  ]
+}
+```
+
+Sinks receive the same `AttributionEvent` payload as shell hooks, in
+structured form. Failures are logged, never blocking.
+
+| Sink type | Behavior |
+|---|---|
+| `stdout` | Prints the JSON array to stdout. |
+| `file` | Appends one JSON line per event to the configured path. |
+| `http` | POSTs the JSON array to the configured HTTPS URL with optional custom headers. |
+
+HTTP sinks require HTTPS by default. For local development only, set
+`"allow_insecure": true` on the sink to permit an `http://` URL.

--- a/src/authorship/attribution_sink.rs
+++ b/src/authorship/attribution_sink.rs
@@ -23,6 +23,20 @@ pub struct AttributionEvent {
     pub branch: String,
     pub is_default_branch: bool,
     pub note_content: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub attributions: Option<Vec<FileAttribution>>,
+}
+
+/// Per-file attribution with ordered fingerprints for squash-safe matching.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileAttribution {
+    pub file: String,
+    pub session_id: String,
+    pub model: String,
+    pub tool: String,
+    pub line_ranges: Vec<[u32; 2]>,
+    pub fingerprints: Vec<String>,
+    pub fingerprints_complete: bool,
 }
 
 /// Configuration for a single attribution sink.
@@ -186,6 +200,9 @@ pub fn events_from_hook_payload(payload: &[serde_json::Value]) -> Vec<Attributio
     payload
         .iter()
         .filter_map(|entry| {
+            let attributions = entry
+                .get("attributions")
+                .and_then(|value| serde_json::from_value(value.clone()).ok());
             Some(AttributionEvent {
                 schema_version: entry.get("schema_version")?.as_u64()? as u32,
                 commit_sha: entry.get("commit_sha")?.as_str()?.to_string(),
@@ -199,6 +216,7 @@ pub fn events_from_hook_payload(payload: &[serde_json::Value]) -> Vec<Attributio
                 branch: entry.get("branch")?.as_str()?.to_string(),
                 is_default_branch: entry.get("is_default_branch")?.as_bool()?,
                 note_content: entry.get("note_content")?.as_str()?.to_string(),
+                attributions,
             })
         })
         .collect()
@@ -231,6 +249,7 @@ mod tests {
             branch: "main".to_string(),
             is_default_branch: true,
             note_content: "test note".to_string(),
+            attributions: None,
         }
     }
 

--- a/src/authorship/attribution_sink.rs
+++ b/src/authorship/attribution_sink.rs
@@ -1,0 +1,309 @@
+use std::collections::HashMap;
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::GitAiError;
+
+/// A single attribution event emitted when a note is sealed.
+///
+/// Matches the JSON schema (v2) sent to `post_notes_updated` hooks,
+/// extended with structured `attributions` when fingerprinting is enabled.
+#[derive(Debug, Clone, Serialize)]
+pub struct AttributionEvent {
+    pub schema_version: u32,
+    pub commit_sha: String,
+    pub repo_url: String,
+    pub repo_name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repo_path: Option<String>,
+    pub git_dir: String,
+    pub branch: String,
+    pub is_default_branch: bool,
+    pub note_content: String,
+}
+
+/// Configuration for a single attribution sink.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum SinkConfig {
+    Stdout,
+    File {
+        path: String,
+    },
+    Http {
+        url: String,
+        #[serde(default)]
+        headers: HashMap<String, String>,
+        #[serde(default)]
+        allow_insecure: bool,
+    },
+}
+
+/// Trait for pluggable attribution delivery.
+///
+/// Implementations are best-effort: failures are logged but never block
+/// the git commit path. git-ai takes no transport opinion — routing to
+/// a specific system (Kafka, AIFX, etc.) is the consumer's adapter
+/// behind `http` or the shell hook.
+pub trait AttributionSink {
+    fn emit(&self, events: &[AttributionEvent]) -> Result<(), GitAiError>;
+}
+
+pub struct StdoutSink;
+
+impl AttributionSink for StdoutSink {
+    fn emit(&self, events: &[AttributionEvent]) -> Result<(), GitAiError> {
+        let json = serde_json::to_string(events).map_err(GitAiError::JsonError)?;
+        println!("{}", json);
+        Ok(())
+    }
+}
+
+pub struct FileSink {
+    path: PathBuf,
+}
+
+impl FileSink {
+    pub fn new(path: &str) -> Self {
+        Self {
+            path: PathBuf::from(path),
+        }
+    }
+}
+
+impl AttributionSink for FileSink {
+    fn emit(&self, events: &[AttributionEvent]) -> Result<(), GitAiError> {
+        if let Some(parent) = self.path.parent() {
+            std::fs::create_dir_all(parent).map_err(GitAiError::IoError)?;
+        }
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.path)
+            .map_err(GitAiError::IoError)?;
+        for event in events {
+            let json = serde_json::to_string(event).map_err(GitAiError::JsonError)?;
+            writeln!(file, "{}", json).map_err(GitAiError::IoError)?;
+        }
+        Ok(())
+    }
+}
+
+pub struct HttpSink {
+    url: String,
+    headers: HashMap<String, String>,
+    allow_insecure: bool,
+}
+
+impl HttpSink {
+    pub fn new(url: &str, headers: HashMap<String, String>, allow_insecure: bool) -> Self {
+        Self {
+            url: url.to_string(),
+            headers,
+            allow_insecure,
+        }
+    }
+}
+
+impl AttributionSink for HttpSink {
+    fn emit(&self, events: &[AttributionEvent]) -> Result<(), GitAiError> {
+        if !self.allow_insecure && !self.url.starts_with("https://") {
+            return Err(GitAiError::Generic(format!(
+                "HTTP attribution sink requires an https:// URL; set allow_insecure=true only for local development: {}",
+                self.url
+            )));
+        }
+        let json = serde_json::to_string(events).map_err(GitAiError::JsonError)?;
+        let agent = crate::http::build_agent(Some(10));
+        let mut request = agent.post(&self.url);
+        for (key, value) in &self.headers {
+            request = request.header(key.as_str(), value.as_str());
+        }
+        request = request.header("Content-Type", "application/json");
+        match crate::http::send_with_body(request, &json) {
+            Ok(resp) if resp.status_code >= 400 => {
+                tracing::debug!(
+                    "[attribution_sink] HTTP sink POST to {} returned status {}",
+                    self.url,
+                    resp.status_code
+                );
+            }
+            Err(e) => {
+                tracing::debug!(
+                    "[attribution_sink] HTTP sink POST to {} failed: {}",
+                    self.url,
+                    e
+                );
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+}
+
+/// Build sink instances from config.
+pub fn build_sinks(configs: &[SinkConfig]) -> Vec<Box<dyn AttributionSink + Send>> {
+    configs
+        .iter()
+        .filter_map(|cfg| -> Option<Box<dyn AttributionSink + Send>> {
+            match cfg {
+                SinkConfig::Stdout => Some(Box::new(StdoutSink)),
+                SinkConfig::File { path } => Some(Box::new(FileSink::new(path))),
+                SinkConfig::Http {
+                    url,
+                    headers,
+                    allow_insecure,
+                } => Some(Box::new(HttpSink::new(
+                    url,
+                    headers.clone(),
+                    *allow_insecure,
+                ))),
+            }
+        })
+        .collect()
+}
+
+/// Dispatch attribution events to all configured sinks. Failures are logged,
+/// never propagated — the commit path must not be blocked.
+pub fn dispatch_to_sinks(events: &[AttributionEvent]) {
+    let sink_configs = Config::get().attribution_sinks().clone();
+    if sink_configs.is_empty() {
+        return;
+    }
+    let sinks = build_sinks(&sink_configs);
+    for sink in &sinks {
+        if let Err(e) = sink.emit(events) {
+            tracing::debug!("[attribution_sink] Sink dispatch failed: {}", e);
+        }
+    }
+}
+
+/// Build `AttributionEvent` structs from the same data used for shell hooks.
+pub fn events_from_hook_payload(payload: &[serde_json::Value]) -> Vec<AttributionEvent> {
+    payload
+        .iter()
+        .filter_map(|entry| {
+            Some(AttributionEvent {
+                schema_version: entry.get("schema_version")?.as_u64()? as u32,
+                commit_sha: entry.get("commit_sha")?.as_str()?.to_string(),
+                repo_url: entry.get("repo_url")?.as_str()?.to_string(),
+                repo_name: entry.get("repo_name")?.as_str()?.to_string(),
+                repo_path: entry
+                    .get("repo_path")
+                    .and_then(|v| v.as_str())
+                    .map(String::from),
+                git_dir: entry.get("git_dir")?.as_str()?.to_string(),
+                branch: entry.get("branch")?.as_str()?.to_string(),
+                is_default_branch: entry.get("is_default_branch")?.as_bool()?,
+                note_content: entry.get("note_content")?.as_str()?.to_string(),
+            })
+        })
+        .collect()
+}
+
+use crate::config::Config;
+
+/// Get the configured attribution sink path (if a file sink is the first configured sink).
+/// Used internally for testing.
+pub fn configured_file_sink_path() -> Option<PathBuf> {
+    let configs = Config::get().attribution_sinks().clone();
+    configs.into_iter().find_map(|c| match c {
+        SinkConfig::File { path } => Some(PathBuf::from(path)),
+        _ => None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_event() -> AttributionEvent {
+        AttributionEvent {
+            schema_version: 2,
+            commit_sha: "abc123".to_string(),
+            repo_url: "https://github.com/org/repo.git".to_string(),
+            repo_name: "repo".to_string(),
+            repo_path: Some("/home/user/repo".to_string()),
+            git_dir: "/home/user/repo/.git".to_string(),
+            branch: "main".to_string(),
+            is_default_branch: true,
+            note_content: "test note".to_string(),
+        }
+    }
+
+    #[test]
+    fn test_event_serialization_includes_all_fields() {
+        let event = sample_event();
+        let json = serde_json::to_string(&event).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["schema_version"], 2);
+        assert_eq!(parsed["commit_sha"], "abc123");
+        assert_eq!(parsed["repo_path"], "/home/user/repo");
+        assert_eq!(parsed["git_dir"], "/home/user/repo/.git");
+    }
+
+    #[test]
+    fn test_event_serialization_omits_none_fields() {
+        let mut event = sample_event();
+        event.repo_path = None;
+        let json = serde_json::to_string(&event).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert!(parsed.get("repo_path").is_none());
+    }
+
+    #[test]
+    fn test_file_sink_writes_jsonl() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.jsonl");
+        let sink = FileSink::new(path.to_str().unwrap());
+        let events = vec![sample_event(), sample_event()];
+        sink.emit(&events).unwrap();
+        let content = std::fs::read_to_string(&path).unwrap();
+        let lines: Vec<&str> = content.lines().collect();
+        assert_eq!(lines.len(), 2);
+        let parsed: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+        assert_eq!(parsed["schema_version"], 2);
+    }
+
+    #[test]
+    fn test_events_from_hook_payload() {
+        let payload = vec![serde_json::json!({
+            "schema_version": 2,
+            "commit_sha": "abc",
+            "repo_url": "url",
+            "repo_name": "name",
+            "repo_path": "/path",
+            "git_dir": "/path/.git",
+            "branch": "main",
+            "is_default_branch": true,
+            "note_content": "note"
+        })];
+        let events = events_from_hook_payload(&payload);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].commit_sha, "abc");
+        assert_eq!(events[0].repo_path, Some("/path".to_string()));
+    }
+
+    #[test]
+    fn test_sink_config_deserialization() {
+        let json = r#"[
+            {"type": "stdout"},
+            {"type": "file", "path": "/tmp/test.jsonl"},
+            {"type": "http", "url": "https://example.com", "headers": {"X-Key": "val"}}
+        ]"#;
+        let configs: Vec<SinkConfig> = serde_json::from_str(json).unwrap();
+        assert_eq!(configs.len(), 3);
+        let sinks = build_sinks(&configs);
+        assert_eq!(sinks.len(), 3);
+    }
+
+    #[test]
+    fn test_http_sink_rejects_insecure_url_by_default() {
+        let sink = HttpSink::new("http://example.com", HashMap::new(), false);
+        let error = sink.emit(&[sample_event()]).unwrap_err();
+        assert!(error.to_string().contains("requires an https:// URL"));
+    }
+}

--- a/src/authorship/fingerprint.rs
+++ b/src/authorship/fingerprint.rs
@@ -1,0 +1,234 @@
+use std::collections::HashMap;
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
+
+use sha2::{Digest, Sha256};
+
+use crate::authorship::attribution_sink::FileAttribution;
+use crate::authorship::attribution_tracker::LineAttribution;
+use crate::authorship::working_log::{Checkpoint, WorkingLogEntry};
+use crate::daemon::checkpoint::is_ai_author_id;
+
+/// Compute the content fingerprint for a single line.
+///
+/// This is a permanent API contract:
+/// `hex(sha256(line with trailing "\n" and "\r" stripped))[:12]`.
+///
+/// Only newline characters are stripped. Changing normalization requires a
+/// hook schema version bump.
+pub fn fingerprint_line(line: &str) -> String {
+    fingerprint_line_bytes(line.as_bytes())
+}
+
+/// Compute a content fingerprint without requiring UTF-8 input.
+pub fn fingerprint_line_bytes(line: &[u8]) -> String {
+    let stripped = line
+        .strip_suffix(b"\r\n")
+        .or_else(|| line.strip_suffix(b"\n"))
+        .or_else(|| line.strip_suffix(b"\r"))
+        .unwrap_or(line);
+    let digest = Sha256::digest(stripped);
+    let mut fingerprint = String::with_capacity(12);
+    for byte in &digest[..6] {
+        let _ = write!(fingerprint, "{byte:02x}");
+    }
+    fingerprint
+}
+
+/// Build per-file fingerprint entries from the latest working-log checkpoint.
+///
+/// Fingerprints come from checkpoint blobs rather than committed files. A
+/// human edit after the checkpoint therefore does not match downstream.
+pub fn build_file_attributions(
+    working_log_dir: &Path,
+    checkpoints: &[Checkpoint],
+) -> Vec<FileAttribution> {
+    let latest_entries = resolve_latest_entries(checkpoints);
+    let blobs_dir = working_log_dir.join("blobs");
+    let mut results = Vec::new();
+
+    for (file_path, (entry, checkpoint)) in latest_entries {
+        let line_ranges = collect_ai_line_ranges(&entry.line_attributions);
+        if line_ranges.is_empty() {
+            continue;
+        }
+
+        let blob = std::fs::read(blobs_dir.join(&entry.blob_sha));
+        let (fingerprints, fingerprints_complete) = match blob {
+            Ok(content) => fingerprints_for_ranges(&content, &line_ranges),
+            Err(_) => (Vec::new(), false),
+        };
+
+        results.push(FileAttribution {
+            file: file_path,
+            session_id: checkpoint
+                .agent_id
+                .as_ref()
+                .map(|agent| agent.id.clone())
+                .unwrap_or_default(),
+            model: checkpoint
+                .agent_id
+                .as_ref()
+                .map(|agent| agent.model.clone())
+                .unwrap_or_default(),
+            tool: checkpoint
+                .agent_id
+                .as_ref()
+                .map(|agent| agent.tool.clone())
+                .unwrap_or_default(),
+            line_ranges: line_ranges
+                .iter()
+                .map(|&(start, end)| [start, end])
+                .collect(),
+            fingerprints,
+            fingerprints_complete,
+        });
+    }
+
+    results.sort_by(|left, right| left.file.cmp(&right.file));
+    results
+}
+
+fn fingerprints_for_ranges(content: &[u8], ranges: &[(u32, u32)]) -> (Vec<String>, bool) {
+    let lines: Vec<&[u8]> = content.split(|byte| *byte == b'\n').collect();
+    let mut fingerprints = Vec::new();
+    let mut complete = true;
+
+    for &(start, end) in ranges {
+        for line_number in start..=end {
+            match lines.get((line_number - 1) as usize) {
+                Some(line) => fingerprints.push(fingerprint_line_bytes(line)),
+                None => complete = false,
+            }
+        }
+    }
+
+    (fingerprints, complete)
+}
+
+type LatestEntryMap<'a> = HashMap<String, (&'a WorkingLogEntry, &'a Checkpoint)>;
+
+fn resolve_latest_entries(checkpoints: &[Checkpoint]) -> LatestEntryMap<'_> {
+    let mut latest = HashMap::new();
+    for checkpoint in checkpoints {
+        for entry in &checkpoint.entries {
+            latest.insert(entry.file.clone(), (entry, checkpoint));
+        }
+    }
+    latest
+}
+
+fn collect_ai_line_ranges(line_attributions: &[LineAttribution]) -> Vec<(u32, u32)> {
+    let mut ranges: Vec<_> = line_attributions
+        .iter()
+        .filter(|attribution| is_ai_author_id(&attribution.author_id))
+        .map(|attribution| (attribution.start_line, attribution.end_line))
+        .collect();
+    ranges.sort_by_key(|range| range.0);
+    ranges
+}
+
+/// Find a working log before or after post-commit archival.
+pub fn find_working_log_dir(git_dir: &Path, parent_sha: &str) -> Option<PathBuf> {
+    let working_logs = git_dir.join("ai").join("working_logs");
+    [parent_sha.to_string(), format!("old-{parent_sha}")]
+        .into_iter()
+        .map(|name| working_logs.join(name))
+        .find(|path| path.is_dir())
+}
+
+/// Read all checkpoints from a working log.
+pub fn read_checkpoints(working_log_dir: &Path) -> Result<Vec<Checkpoint>, String> {
+    let content = std::fs::read_to_string(working_log_dir.join("checkpoints.jsonl"))
+        .map_err(|error| format!("failed to read checkpoints: {error}"))?;
+    content
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| {
+            serde_json::from_str(line)
+                .map_err(|error| format!("failed to parse checkpoint: {error}"))
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::authorship::working_log::{
+        AgentId, CheckpointKind, CheckpointLineStats, WorkingLogEntry,
+    };
+
+    #[test]
+    fn fingerprint_normalizes_only_line_endings() {
+        let expected = fingerprint_line("hello");
+        assert_eq!(fingerprint_line("hello\n"), expected);
+        assert_eq!(fingerprint_line("hello\r\n"), expected);
+        assert_ne!(fingerprint_line("hello "), expected);
+    }
+
+    #[test]
+    fn fingerprint_is_stable_twelve_character_hex() {
+        assert_eq!(fingerprint_line("hello"), "2cf24dba5fb0");
+    }
+
+    #[test]
+    fn range_fingerprints_preserve_order_and_duplicates() {
+        let (fingerprints, complete) =
+            fingerprints_for_ranges(b"same\nmiddle\nsame\n", &[(1, 1), (3, 3)]);
+        assert!(complete);
+        assert_eq!(
+            fingerprints,
+            vec![fingerprint_line("same"), fingerprint_line("same")]
+        );
+    }
+
+    #[test]
+    fn missing_line_marks_fingerprints_incomplete() {
+        let (fingerprints, complete) = fingerprints_for_ranges(b"one\n", &[(1, 3)]);
+        assert!(!complete);
+        assert_eq!(fingerprints.len(), 2);
+    }
+
+    #[test]
+    fn builds_attributions_from_checkpoint_blob() {
+        let directory = tempfile::tempdir().unwrap();
+        let blobs = directory.path().join("blobs");
+        std::fs::create_dir(&blobs).unwrap();
+        std::fs::write(blobs.join("blob-sha"), b"human\nai one\nai two\n").unwrap();
+
+        let checkpoint = Checkpoint {
+            kind: CheckpointKind::AiAgent,
+            diff: String::new(),
+            author: "agent".to_string(),
+            entries: vec![WorkingLogEntry::new(
+                "src/example.rs".to_string(),
+                "blob-sha".to_string(),
+                Vec::new(),
+                vec![LineAttribution::new(2, 3, "agent".to_string(), None)],
+            )],
+            timestamp: 1,
+            agent_id: Some(AgentId {
+                tool: "cursor".to_string(),
+                id: "session-id".to_string(),
+                model: "model-id".to_string(),
+            }),
+            agent_metadata: None,
+            line_stats: CheckpointLineStats::default(),
+            api_version: String::new(),
+            git_ai_version: None,
+            known_human_metadata: None,
+            trace_id: None,
+        };
+
+        let result = build_file_attributions(directory.path(), &[checkpoint]);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].file, "src/example.rs");
+        assert_eq!(result[0].line_ranges, vec![[2, 3]]);
+        assert_eq!(
+            result[0].fingerprints,
+            vec![fingerprint_line("ai one"), fingerprint_line("ai two")]
+        );
+        assert!(result[0].fingerprints_complete);
+        assert_eq!(result[0].session_id, "session-id");
+    }
+}

--- a/src/authorship/git_ai_hooks.rs
+++ b/src/authorship/git_ai_hooks.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
 
@@ -12,9 +13,14 @@ const POST_NOTES_UPDATED_HOOK: &str = "post_notes_updated";
 const HOOK_WAIT_TIMEOUT: Duration = Duration::from_secs(3);
 const HOOK_POLL_INTERVAL: Duration = Duration::from_millis(25);
 
+/// Schema version for the hook payload JSON. Bump on breaking changes.
+pub const HOOK_SCHEMA_VERSION: u32 = 2;
+
 struct RepoHookContext {
     repo_url: String,
     repo_name: String,
+    repo_path: Option<PathBuf>,
+    git_dir: PathBuf,
     branch: String,
     is_default_branch: bool,
 }
@@ -42,29 +48,39 @@ pub(crate) fn post_notes_updated_refs<'a>(
         return;
     }
 
-    let hook_commands = Config::get()
+    let config = Config::get();
+    let hook_commands = config
         .git_ai_hook_commands(POST_NOTES_UPDATED_HOOK)
         .cloned()
         .unwrap_or_default();
-    if hook_commands.is_empty() {
+    let has_sinks = !config.attribution_sinks().is_empty();
+    if hook_commands.is_empty() && !has_sinks {
         return;
     }
 
     let context = build_repo_hook_context(repo);
     let repo_url = context.repo_url;
     let repo_name = context.repo_name;
+    let repo_path = context.repo_path.map(|p| p.to_string_lossy().into_owned());
+    let git_dir = context.git_dir.to_string_lossy().into_owned();
     let branch = context.branch;
     let is_default_branch = context.is_default_branch;
     let payload = notes
         .map(|(commit_sha, note_content)| {
-            serde_json::json!({
+            let mut entry = serde_json::json!({
+                "schema_version": HOOK_SCHEMA_VERSION,
                 "commit_sha": commit_sha,
                 "repo_url": repo_url.as_str(),
                 "repo_name": repo_name.as_str(),
+                "git_dir": git_dir.as_str(),
                 "branch": branch.as_str(),
                 "is_default_branch": is_default_branch,
                 "note_content": note_content,
-            })
+            });
+            if let Some(ref path) = repo_path {
+                entry["repo_path"] = serde_json::Value::String(path.clone());
+            }
+            entry
         })
         .collect::<Vec<_>>();
     let payload_json = match serde_json::to_string(&payload) {
@@ -78,49 +94,89 @@ pub(crate) fn post_notes_updated_refs<'a>(
         }
     };
 
-    let mut running_children = Vec::new();
-    for hook_command in hook_commands {
-        let mut child = match spawn_shell_command(&hook_command) {
-            Ok(child) => child,
-            Err(e) => {
-                tracing::debug!(
-                    "[git_ai_hooks] Failed to spawn post_notes_updated hook '{}': {}",
-                    hook_command,
-                    e
-                );
-                continue;
-            }
-        };
-
-        if let Some(mut stdin) = child.stdin.take() {
-            let payload_for_stdin = payload_json.clone();
-            let command_for_log = hook_command.clone();
-            std::thread::spawn(move || {
-                use std::io::Write;
-                if let Err(e) = stdin.write_all(payload_for_stdin.as_bytes()) {
+    if !hook_commands.is_empty() {
+        let mut running_children = Vec::new();
+        for hook_command in hook_commands {
+            let mut child = match spawn_shell_command(&hook_command) {
+                Ok(child) => child,
+                Err(e) => {
                     tracing::debug!(
-                        "[git_ai_hooks] Failed to write post_notes_updated stdin for '{}': {}",
-                        command_for_log,
+                        "[git_ai_hooks] Failed to spawn post_notes_updated hook '{}': {}",
+                        hook_command,
                         e
                     );
+                    continue;
                 }
-            });
-        } else {
-            tracing::debug!(
-                "[git_ai_hooks] Hook '{}' was spawned without a stdin pipe",
-                hook_command
-            );
+            };
+
+            if let Some(mut stdin) = child.stdin.take() {
+                let payload_for_stdin = payload_json.clone();
+                let command_for_log = hook_command.clone();
+                std::thread::spawn(move || {
+                    use std::io::Write;
+                    if let Err(e) = stdin.write_all(payload_for_stdin.as_bytes()) {
+                        tracing::debug!(
+                            "[git_ai_hooks] Failed to write post_notes_updated stdin for '{}': {}",
+                            command_for_log,
+                            e
+                        );
+                    }
+                });
+            } else {
+                tracing::debug!(
+                    "[git_ai_hooks] Hook '{}' was spawned without a stdin pipe",
+                    hook_command
+                );
+            }
+
+            running_children.push((hook_command, child));
         }
 
-        running_children.push((hook_command, child));
+        wait_for_hooks_or_detach(running_children);
     }
 
-    wait_for_hooks_or_detach(running_children);
+    if has_sinks {
+        let events = super::attribution_sink::events_from_hook_payload(&payload);
+        std::thread::spawn(move || {
+            super::attribution_sink::dispatch_to_sinks(&events);
+        });
+    }
 }
 
 pub fn post_notes_updated_single(repo: &Repository, commit_sha: &str, note_content: &str) {
     let note_batch = vec![(commit_sha.to_string(), note_content.to_string())];
     post_notes_updated(repo, &note_batch);
+}
+
+fn collect_stderr(child: &mut Child) -> String {
+    child
+        .stderr
+        .take()
+        .and_then(|mut stderr| {
+            use std::io::Read;
+            let mut buf = String::new();
+            stderr.read_to_string(&mut buf).ok()?;
+            if buf.is_empty() { None } else { Some(buf) }
+        })
+        .unwrap_or_default()
+}
+
+fn log_hook_failure(command: &str, status: &std::process::ExitStatus, child: &mut Child) {
+    let stderr = collect_stderr(child);
+    if stderr.is_empty() {
+        tracing::debug!(
+            "[git_ai_hooks] Hook '{}' exited with status {}",
+            command,
+            status
+        );
+    } else {
+        tracing::debug!(
+            "[git_ai_hooks] Hook '{}' exited with status {}: {}",
+            command,
+            status,
+            stderr.trim()
+        );
+    }
 }
 
 fn wait_for_hooks_or_detach(mut children: Vec<(String, Child)>) {
@@ -136,11 +192,7 @@ fn wait_for_hooks_or_detach(mut children: Vec<(String, Child)>) {
             match child.try_wait() {
                 Ok(Some(status)) => {
                     if !status.success() {
-                        tracing::debug!(
-                            "[git_ai_hooks] Hook '{}' exited with status {}",
-                            command,
-                            status
-                        );
+                        log_hook_failure(&command, &status, &mut child);
                     }
                 }
                 Ok(None) => still_running.push((command, child)),
@@ -166,11 +218,7 @@ fn wait_for_hooks_or_detach(mut children: Vec<(String, Child)>) {
                     match child.wait() {
                         Ok(status) => {
                             if !status.success() {
-                                tracing::debug!(
-                                    "[git_ai_hooks] Detached hook '{}' exited with status {}",
-                                    command,
-                                    status
-                                );
+                                log_hook_failure(&command, &status, &mut child);
                             }
                         }
                         Err(e) => {
@@ -213,7 +261,7 @@ fn spawn_shell_command(command: &str) -> std::io::Result<Child> {
     }
     cmd.stdin(Stdio::piped())
         .stdout(Stdio::null())
-        .stderr(Stdio::null())
+        .stderr(Stdio::piped())
         .spawn()
 }
 
@@ -239,6 +287,9 @@ fn build_repo_hook_context(repo: &Repository) -> RepoHookContext {
         .trim_end_matches(".git")
         .to_string();
 
+    let repo_path = repo.workdir().ok();
+    let git_dir = repo.path().to_path_buf();
+
     let branch = repo
         .head()
         .ok()
@@ -261,7 +312,111 @@ fn build_repo_hook_context(repo: &Repository) -> RepoHookContext {
     RepoHookContext {
         repo_url,
         repo_name,
+        repo_path,
+        git_dir,
         branch: branch.clone(),
         is_default_branch: branch == default_branch,
+    }
+}
+
+/// Build a v2 hook payload entry from explicit values (for testing and sink construction).
+pub fn build_payload_entry(
+    commit_sha: &str,
+    repo_url: &str,
+    repo_name: &str,
+    repo_path: Option<&str>,
+    git_dir: &str,
+    branch: &str,
+    is_default_branch: bool,
+    note_content: &str,
+) -> serde_json::Value {
+    let mut entry = serde_json::json!({
+        "schema_version": HOOK_SCHEMA_VERSION,
+        "commit_sha": commit_sha,
+        "repo_url": repo_url,
+        "repo_name": repo_name,
+        "git_dir": git_dir,
+        "branch": branch,
+        "is_default_branch": is_default_branch,
+        "note_content": note_content,
+    });
+    if let Some(path) = repo_path {
+        entry["repo_path"] = serde_json::Value::String(path.to_string());
+    }
+    entry
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_payload_entry_contains_v2_fields() {
+        let entry = build_payload_entry(
+            "abc123",
+            "https://github.com/org/repo.git",
+            "repo",
+            Some("/home/user/repo"),
+            "/home/user/repo/.git",
+            "main",
+            true,
+            "note body",
+        );
+        assert_eq!(entry["schema_version"], HOOK_SCHEMA_VERSION);
+        assert_eq!(entry["commit_sha"], "abc123");
+        assert_eq!(entry["repo_path"], "/home/user/repo");
+        assert_eq!(entry["git_dir"], "/home/user/repo/.git");
+        assert_eq!(entry["repo_url"], "https://github.com/org/repo.git");
+        assert_eq!(entry["repo_name"], "repo");
+        assert_eq!(entry["branch"], "main");
+        assert_eq!(entry["is_default_branch"], true);
+        assert_eq!(entry["note_content"], "note body");
+    }
+
+    #[test]
+    fn test_payload_entry_bare_repo_omits_repo_path() {
+        let entry = build_payload_entry("abc123", "", "", None, "/srv/repo.git", "main", true, "");
+        assert!(entry.get("repo_path").is_none());
+        assert_eq!(entry["git_dir"], "/srv/repo.git");
+        assert_eq!(entry["schema_version"], HOOK_SCHEMA_VERSION);
+    }
+
+    #[test]
+    fn test_payload_batch_serialization() {
+        let entries: Vec<serde_json::Value> = (0..3)
+            .map(|i| {
+                build_payload_entry(
+                    &format!("sha{}", i),
+                    "https://github.com/org/repo.git",
+                    "repo",
+                    Some("/repo"),
+                    "/repo/.git",
+                    "main",
+                    true,
+                    &format!("note {}", i),
+                )
+            })
+            .collect();
+        let json = serde_json::to_string(&entries).unwrap();
+        let parsed: Vec<serde_json::Value> = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.len(), 3);
+        assert_eq!(parsed[2]["commit_sha"], "sha2");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_payload_entry_windows_paths() {
+        let entry = build_payload_entry(
+            "abc123",
+            "",
+            "",
+            Some("C:\\Users\\dev\\repo"),
+            "C:\\Users\\dev\\repo\\.git",
+            "main",
+            true,
+            "",
+        );
+        assert_eq!(entry["repo_path"], "C:\\Users\\dev\\repo");
+        assert_eq!(entry["git_dir"], "C:\\Users\\dev\\repo\\.git");
     }
 }

--- a/src/authorship/git_ai_hooks.rs
+++ b/src/authorship/git_ai_hooks.rs
@@ -65,7 +65,7 @@ pub(crate) fn post_notes_updated_refs<'a>(
     let git_dir = context.git_dir.to_string_lossy().into_owned();
     let branch = context.branch;
     let is_default_branch = context.is_default_branch;
-    let payload = notes
+    let mut payload = notes
         .map(|(commit_sha, note_content)| {
             let mut entry = serde_json::json!({
                 "schema_version": HOOK_SCHEMA_VERSION,
@@ -83,6 +83,9 @@ pub(crate) fn post_notes_updated_refs<'a>(
             entry
         })
         .collect::<Vec<_>>();
+    if config.attribution_fingerprints() {
+        enrich_payload_with_fingerprints(repo, &mut payload);
+    }
     let payload_json = match serde_json::to_string(&payload) {
         Ok(json) => json,
         Err(e) => {
@@ -140,6 +143,38 @@ pub(crate) fn post_notes_updated_refs<'a>(
         std::thread::spawn(move || {
             super::attribution_sink::dispatch_to_sinks(&events);
         });
+    }
+}
+
+fn enrich_payload_with_fingerprints(repo: &Repository, payload: &mut [serde_json::Value]) {
+    use super::fingerprint::{build_file_attributions, find_working_log_dir, read_checkpoints};
+
+    for entry in payload {
+        let Some(commit_sha) = entry.get("commit_sha").and_then(serde_json::Value::as_str) else {
+            continue;
+        };
+        let parent_sha = repo
+            .revparse_single(&format!("{commit_sha}^"))
+            .map(|object| object.id())
+            .unwrap_or_else(|_| "initial".to_string());
+        let Some(working_log_dir) = find_working_log_dir(repo.path(), &parent_sha) else {
+            continue;
+        };
+        let checkpoints = match read_checkpoints(&working_log_dir) {
+            Ok(checkpoints) => checkpoints,
+            Err(error) => {
+                tracing::debug!(
+                    "[git_ai_hooks] Failed to read checkpoints for {}: {}",
+                    commit_sha,
+                    error
+                );
+                continue;
+            }
+        };
+        let attributions = build_file_attributions(&working_log_dir, &checkpoints);
+        if !attributions.is_empty() {
+            entry["attributions"] = serde_json::json!(attributions);
+        }
     }
 }
 

--- a/src/authorship/mod.rs
+++ b/src/authorship/mod.rs
@@ -1,5 +1,6 @@
 pub mod agent_detection;
 pub mod attribution_recovery;
+pub mod attribution_sink;
 pub mod attribution_tracker;
 pub mod authorship_log;
 pub mod authorship_log_serialization;

--- a/src/authorship/mod.rs
+++ b/src/authorship/mod.rs
@@ -8,6 +8,7 @@ pub mod background_agent;
 pub mod conflict_resolution;
 pub mod diff_ai_accepted;
 pub(crate) mod diff_base;
+pub mod fingerprint;
 pub mod git_ai_hooks;
 pub mod hunk_shift;
 pub mod ignore;

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -126,6 +126,7 @@ fn print_config_help() {
     println!("  custom_attributes            Custom telemetry attributes, string->string (object)");
     println!("  git_ai_hooks                 Hook name -> shell commands map (object)");
     println!("  attribution_sinks            Attribution delivery sinks (array)");
+    println!("  attribution_fingerprints     Emit squash-safe content fingerprints (bool)");
     println!("  codex_hooks_format           Codex hook install format (config_toml/hooks_json)");
     println!("  notes_backend.kind           Notes backend kind (git_notes/http)");
     println!("  notes_backend.backend_url    Notes backend base URL. Required when kind=http.");
@@ -156,6 +157,7 @@ fn print_config_help() {
     println!("  git-ai config --add feature_flags.my_flag true");
     println!("  git-ai config --add git_ai_hooks.post_notes_updated \"./my-hook.sh\"");
     println!("  git-ai config set attribution_sinks '[{{\"type\":\"stdout\"}}]'");
+    println!("  git-ai config set attribution_fingerprints true");
     println!("  git-ai config set codex_hooks_format hooks_json");
     println!("  git-ai config set allow_superuser true");
     println!("  git-ai config set transcript_streaming_lookback_days 1");
@@ -368,6 +370,10 @@ fn show_all_config() -> Result<(), String> {
         serde_json::to_value(runtime_config.attribution_sinks())
             .unwrap_or_else(|_| Value::Array(Vec::new())),
     );
+    effective_config.insert(
+        "attribution_fingerprints".to_string(),
+        Value::Bool(runtime_config.attribution_fingerprints()),
+    );
 
     effective_config.insert(
         "codex_hooks_format".to_string(),
@@ -532,6 +538,7 @@ fn get_config_value(key: &str) -> Result<(), String> {
                 .unwrap_or_else(|_| Value::Object(serde_json::Map::new())),
             "attribution_sinks" => serde_json::to_value(runtime_config.attribution_sinks())
                 .unwrap_or_else(|_| Value::Array(Vec::new())),
+            "attribution_fingerprints" => Value::Bool(runtime_config.attribution_fingerprints()),
             "codex_hooks_format" => {
                 Value::String(runtime_config.codex_hooks_format().as_str().to_string())
             }
@@ -848,6 +855,12 @@ fn set_config_value(key: &str, value: &str, add_mode: bool) -> Result<(), String
                 file_config.attribution_sinks = Some(sinks);
                 crate::config::save_file_config(&file_config)?;
                 println!("[attribution_sinks]: {}", value);
+            }
+            "attribution_fingerprints" => {
+                let enabled = parse_bool(value)?;
+                file_config.attribution_fingerprints = Some(enabled);
+                crate::config::save_file_config(&file_config)?;
+                println!("[attribution_fingerprints]: {}", enabled);
             }
             "codex_hooks_format" => {
                 let format = parse_codex_hooks_format(value)?;
@@ -1245,6 +1258,13 @@ fn unset_config_value(key: &str) -> Result<(), String> {
                 crate::config::save_file_config(&file_config)?;
                 if let Some(v) = old_value {
                     println!("- [attribution_sinks]: {:?}", v);
+                }
+            }
+            "attribution_fingerprints" => {
+                let old_value = file_config.attribution_fingerprints.take();
+                crate::config::save_file_config(&file_config)?;
+                if let Some(v) = old_value {
+                    println!("- [attribution_fingerprints]: {}", v);
                 }
             }
             "codex_hooks_format" => {

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -125,6 +125,7 @@ fn print_config_help() {
     println!("  daemon_memory_limit_mb               Daemon peak-RSS limit in MiB");
     println!("  custom_attributes            Custom telemetry attributes, string->string (object)");
     println!("  git_ai_hooks                 Hook name -> shell commands map (object)");
+    println!("  attribution_sinks            Attribution delivery sinks (array)");
     println!("  codex_hooks_format           Codex hook install format (config_toml/hooks_json)");
     println!("  notes_backend.kind           Notes backend kind (git_notes/http)");
     println!("  notes_backend.backend_url    Notes backend base URL. Required when kind=http.");
@@ -154,6 +155,7 @@ fn print_config_help() {
     println!("  git-ai config --add allow_repositories ~/projects/my-repo");
     println!("  git-ai config --add feature_flags.my_flag true");
     println!("  git-ai config --add git_ai_hooks.post_notes_updated \"./my-hook.sh\"");
+    println!("  git-ai config set attribution_sinks '[{{\"type\":\"stdout\"}}]'");
     println!("  git-ai config set codex_hooks_format hooks_json");
     println!("  git-ai config set allow_superuser true");
     println!("  git-ai config set transcript_streaming_lookback_days 1");
@@ -361,6 +363,11 @@ fn show_all_config() -> Result<(), String> {
         serde_json::to_value(runtime_config.git_ai_hooks())
             .unwrap_or_else(|_| Value::Object(serde_json::Map::new())),
     );
+    effective_config.insert(
+        "attribution_sinks".to_string(),
+        serde_json::to_value(runtime_config.attribution_sinks())
+            .unwrap_or_else(|_| Value::Array(Vec::new())),
+    );
 
     effective_config.insert(
         "codex_hooks_format".to_string(),
@@ -523,6 +530,8 @@ fn get_config_value(key: &str) -> Result<(), String> {
                 .unwrap_or_else(|_| Value::Object(serde_json::Map::new())),
             "git_ai_hooks" => serde_json::to_value(runtime_config.git_ai_hooks())
                 .unwrap_or_else(|_| Value::Object(serde_json::Map::new())),
+            "attribution_sinks" => serde_json::to_value(runtime_config.attribution_sinks())
+                .unwrap_or_else(|_| Value::Array(Vec::new())),
             "codex_hooks_format" => {
                 Value::String(runtime_config.codex_hooks_format().as_str().to_string())
             }
@@ -826,6 +835,19 @@ fn set_config_value(key: &str, value: &str, add_mode: bool) -> Result<(), String
                 file_config.git_ai_hooks = Some(parse_git_ai_hooks_object(value)?);
                 crate::config::save_file_config(&file_config)?;
                 println!("[git_ai_hooks]: {}", value);
+            }
+            "attribution_sinks" => {
+                if add_mode {
+                    return Err(
+                        "Cannot use --add with attribution_sinks; set the complete JSON array"
+                            .to_string(),
+                    );
+                }
+                let sinks = serde_json::from_str(value)
+                    .map_err(|e| format!("Invalid JSON for attribution_sinks: {}", e))?;
+                file_config.attribution_sinks = Some(sinks);
+                crate::config::save_file_config(&file_config)?;
+                println!("[attribution_sinks]: {}", value);
             }
             "codex_hooks_format" => {
                 let format = parse_codex_hooks_format(value)?;
@@ -1216,6 +1238,13 @@ fn unset_config_value(key: &str) -> Result<(), String> {
                 crate::config::save_file_config(&file_config)?;
                 if let Some(v) = old_value {
                     println!("- [git_ai_hooks]: {:?}", v);
+                }
+            }
+            "attribution_sinks" => {
+                let old_value = file_config.attribution_sinks.take();
+                crate::config::save_file_config(&file_config)?;
+                if let Some(v) = old_value {
+                    println!("- [attribution_sinks]: {:?}", v);
                 }
             }
             "codex_hooks_format" => {

--- a/src/config.rs
+++ b/src/config.rs
@@ -191,6 +191,7 @@ pub struct Config {
     max_checkpoint_total_lines: usize,
     daemon_memory_limit_mb: Option<u64>,
     attribution_sinks: Vec<crate::authorship::attribution_sink::SinkConfig>,
+    attribution_fingerprints: bool,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default, Serialize)]
@@ -282,6 +283,8 @@ pub struct FileConfig {
     pub daemon_memory_limit_mb: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub attribution_sinks: Option<Vec<crate::authorship::attribution_sink::SinkConfig>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attribution_fingerprints: Option<bool>,
 }
 
 static CONFIG: OnceLock<Config> = OnceLock::new();
@@ -709,6 +712,10 @@ impl Config {
     /// Returns the configured attribution sinks.
     pub fn attribution_sinks(&self) -> &Vec<crate::authorship::attribution_sink::SinkConfig> {
         &self.attribution_sinks
+    }
+
+    pub fn attribution_fingerprints(&self) -> bool {
+        self.attribution_fingerprints
     }
 
     pub fn codex_hooks_format(&self) -> CodexHooksFormat {
@@ -1242,6 +1249,10 @@ fn build_config() -> Config {
         .as_ref()
         .and_then(|c| c.attribution_sinks.clone())
         .unwrap_or_default();
+    let attribution_fingerprints = file_cfg
+        .as_ref()
+        .and_then(|c| c.attribution_fingerprints)
+        .unwrap_or(false);
 
     #[cfg(any(test, feature = "test-support"))]
     {
@@ -1274,6 +1285,7 @@ fn build_config() -> Config {
             max_checkpoint_total_lines,
             daemon_memory_limit_mb,
             attribution_sinks: attribution_sinks.clone(),
+            attribution_fingerprints,
         };
         apply_test_config_patch(&mut config);
         config
@@ -1309,6 +1321,7 @@ fn build_config() -> Config {
         max_checkpoint_total_lines,
         daemon_memory_limit_mb,
         attribution_sinks,
+        attribution_fingerprints,
     }
 }
 
@@ -1830,6 +1843,7 @@ mod tests {
             max_checkpoint_total_lines: DEFAULT_MAX_CHECKPOINT_TOTAL_LINES,
             daemon_memory_limit_mb: None,
             attribution_sinks: Vec::new(),
+            attribution_fingerprints: false,
         }
     }
 
@@ -2077,6 +2091,7 @@ mod tests {
             max_checkpoint_total_lines: DEFAULT_MAX_CHECKPOINT_TOTAL_LINES,
             daemon_memory_limit_mb: None,
             attribution_sinks: Vec::new(),
+            attribution_fingerprints: false,
         }
     }
 
@@ -2227,6 +2242,7 @@ mod tests {
             max_checkpoint_total_lines: DEFAULT_MAX_CHECKPOINT_TOTAL_LINES,
             daemon_memory_limit_mb: None,
             attribution_sinks: Vec::new(),
+            attribution_fingerprints: false,
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -190,6 +190,7 @@ pub struct Config {
     max_checkpoint_total_size_bytes: usize,
     max_checkpoint_total_lines: usize,
     daemon_memory_limit_mb: Option<u64>,
+    attribution_sinks: Vec<crate::authorship::attribution_sink::SinkConfig>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default, Serialize)]
@@ -279,6 +280,8 @@ pub struct FileConfig {
     pub max_checkpoint_total_lines: Option<usize>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub daemon_memory_limit_mb: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attribution_sinks: Option<Vec<crate::authorship::attribution_sink::SinkConfig>>,
 }
 
 static CONFIG: OnceLock<Config> = OnceLock::new();
@@ -701,6 +704,11 @@ impl Config {
     /// Returns configured shell commands for a specific hook.
     pub fn git_ai_hook_commands(&self, hook_name: &str) -> Option<&Vec<String>> {
         self.git_ai_hooks.get(hook_name)
+    }
+
+    /// Returns the configured attribution sinks.
+    pub fn attribution_sinks(&self) -> &Vec<crate::authorship::attribution_sink::SinkConfig> {
+        &self.attribution_sinks
     }
 
     pub fn codex_hooks_format(&self) -> CodexHooksFormat {
@@ -1230,6 +1238,11 @@ fn build_config() -> Config {
         .and_then(|c| c.daemon_memory_limit_mb)
         .and_then(normalize_daemon_memory_limit_mb);
 
+    let attribution_sinks = file_cfg
+        .as_ref()
+        .and_then(|c| c.attribution_sinks.clone())
+        .unwrap_or_default();
+
     #[cfg(any(test, feature = "test-support"))]
     {
         let mut config = Config {
@@ -1260,6 +1273,7 @@ fn build_config() -> Config {
             max_checkpoint_total_size_bytes,
             max_checkpoint_total_lines,
             daemon_memory_limit_mb,
+            attribution_sinks: attribution_sinks.clone(),
         };
         apply_test_config_patch(&mut config);
         config
@@ -1294,6 +1308,7 @@ fn build_config() -> Config {
         max_checkpoint_total_size_bytes,
         max_checkpoint_total_lines,
         daemon_memory_limit_mb,
+        attribution_sinks,
     }
 }
 
@@ -1814,6 +1829,7 @@ mod tests {
             max_checkpoint_total_size_bytes: DEFAULT_MAX_CHECKPOINT_TOTAL_SIZE_BYTES,
             max_checkpoint_total_lines: DEFAULT_MAX_CHECKPOINT_TOTAL_LINES,
             daemon_memory_limit_mb: None,
+            attribution_sinks: Vec::new(),
         }
     }
 
@@ -2060,6 +2076,7 @@ mod tests {
             max_checkpoint_total_size_bytes: DEFAULT_MAX_CHECKPOINT_TOTAL_SIZE_BYTES,
             max_checkpoint_total_lines: DEFAULT_MAX_CHECKPOINT_TOTAL_LINES,
             daemon_memory_limit_mb: None,
+            attribution_sinks: Vec::new(),
         }
     }
 
@@ -2209,6 +2226,7 @@ mod tests {
             max_checkpoint_total_size_bytes: DEFAULT_MAX_CHECKPOINT_TOTAL_SIZE_BYTES,
             max_checkpoint_total_lines: DEFAULT_MAX_CHECKPOINT_TOTAL_LINES,
             daemon_memory_limit_mb: None,
+            attribution_sinks: Vec::new(),
         }
     }
 

--- a/tests/integration/config_cli_coverage.rs
+++ b/tests/integration/config_cli_coverage.rs
@@ -334,6 +334,7 @@ fn fully_populated_file_config() -> FileConfig {
         attribution_sinks: Some(vec![
             git_ai::authorship::attribution_sink::SinkConfig::Stdout,
         ]),
+        attribution_fingerprints: Some(true),
         codex_hooks_format: Some("config_toml".to_string()),
         notes_backend: Some(NotesBackendConfig::default()),
         transcript_streaming_lookback_days: Some(7),

--- a/tests/integration/config_cli_coverage.rs
+++ b/tests/integration/config_cli_coverage.rs
@@ -331,6 +331,9 @@ fn fully_populated_file_config() -> FileConfig {
         }),
         custom_attributes: Some(custom_attributes),
         git_ai_hooks: Some(git_ai_hooks),
+        attribution_sinks: Some(vec![
+            git_ai::authorship::attribution_sink::SinkConfig::Stdout,
+        ]),
         codex_hooks_format: Some("config_toml".to_string()),
         notes_backend: Some(NotesBackendConfig::default()),
         transcript_streaming_lookback_days: Some(7),


### PR DESCRIPTION
## Summary

Stacked on #2238. Adds an opt-in ordered per-line content fingerprint so line-level attribution can be recovered after a hosted squash merge, without moving the matching algorithm into git-ai.

**Please land #2238 first.** Until then, this PR’s diff vs `main` includes that branch. The unique commit here is `feat: emit squash-safe attribution fingerprints`.

Line *ranges* are keyed to a commit SHA. SubmitQueue / GitHub / GitLab squash that SHA into a new commit the daemon never observed, so ranges alone cannot answer "which lines of this landed PR were AI-written."

This PR emits `attribution_fingerprints` (opt-in) sourced from the checkpoint blob, not the committed file. A consumer re-hashes the landed file and aligns the two. Cookbook: `docs/attribution-cookbook.md`.

## Test plan

- [ ] Fingerprints are omitted unless `attribution_fingerprints` is enabled
- [ ] Fingerprints are computed from the checkpoint blob, not the committed file
- [ ] Human edits to an AI line before commit produce a mismatch and drop out of AI attribution
- [ ] Cookbook matcher recovers AI lines after a squash-merge of the source commit
- [ ] Builds on the versioned hook / sink path from #2238
