### PR TITLE
feat(token-usage): attribute subagent usage to the subagent's own session

### DIFF
--- a/docs/token-usage-events-spec.md
+++ b/docs/token-usage-events-spec.md
@@ -164,10 +164,17 @@ TokenUsage events are the authoritative dollars.
 
 ## Session identity
 
-Claude subagent transcripts roll up to their parent session (matching
-ccusage's session semantics), which also lets sidechain replays of parent
-messages deduplicate against the parent's entries across files. Codex
-sessions are per rollout file; forked rollouts skip their replayed prefix by
+Usage is leaf-attributed: every agent execution owns its own usage under its
+own session — Claude subagent (sidechain) transcripts and Codex fork/subagent
+rollouts included — with the parent carried as the
+`parent_session_id`/`external_parent_session_id` attributes, exactly like
+SessionEvents. The parent-inclusive total is a derived rollup over the parent
+relationship, never the stored identity, so per-agent cost stays visible.
+(Documented deviation from ccusage, which rolls Claude sidechains into the
+parent session: per-session Claude groupings differ, aggregate totals match.)
+Sidechain replays of parent messages still deduplicate against the parent's
+entries across files because entry dedup is global, not session-scoped.
+Forked Codex rollouts skip their replayed prefix by
 matching it against the parent rollout's pre-fork usage signatures (ccusage's
 parent-prefix matching): the worker resolves the parent — tracked files under
 the parent's external session id, else a bounded scan of the codex sessions

--- a/docs/token-usage-events-spec.md
+++ b/docs/token-usage-events-spec.md
@@ -166,9 +166,12 @@ TokenUsage events are the authoritative dollars.
 
 Usage is leaf-attributed: every agent execution owns its own usage under its
 own session — Claude subagent (sidechain) transcripts and Codex fork/subagent
-rollouts included — with the parent carried as the
+rollouts included — with subagent spawns carrying their parent as the
 `parent_session_id`/`external_parent_session_id` attributes, exactly like
-SessionEvents. The parent-inclusive total is a derived rollup over the parent
+SessionEvents. A plain user-initiated Codex fork (`forked_from_id` without a
+subagent `thread_source`) is a new top-level conversation, not a sub-task: it
+owns its usage with no parent linkage, so it stays visible in default session
+listings (its replayed prefix is still removed). The parent-inclusive total is a derived rollup over the parent
 relationship, never the stored identity, so per-agent cost stays visible.
 (Documented deviation from ccusage, which rolls Claude sidechains into the
 parent session: per-session Claude groupings differ, aggregate totals match.)

--- a/src/daemon/token_usage_worker.rs
+++ b/src/daemon/token_usage_worker.rs
@@ -23,10 +23,12 @@
 //!   error backoff so a permanently failing transcript is not re-read on
 //!   every trigger. The size/mtime quiet-skip snapshot is written only after
 //!   a fully successful pass.
-//! - Claude subagent transcripts roll up to their parent session (matching
-//!   ccusage), which also lets sidechain replays dedup against the parent's
-//!   entries. Entry dedup itself is global across sessions (resume/fork
-//!   copies); when a replacement moves an entry between sessions, the
+//! - Usage is leaf-attributed: subagent/fork transcripts own their usage
+//!   under their own session (like SessionEvents), carrying the parent as
+//!   the parent_session_id/external_parent_session_id attributes. Entry
+//!   dedup is global across sessions (resume/fork copies; sidechain replays
+//!   of parent messages dedup against the parent's entries wherever they
+//!   live); when a replacement moves an entry between sessions, the
 //!   previous owner's files are invalidated so its buckets re-reconcile on
 //!   the next pass with their own attributes.
 //! - The `token_usage_metrics` feature flag gates the worker at daemon
@@ -547,29 +549,26 @@ fn sweep_candidates(
     tasks
 }
 
-/// Rollup identity of the session a transcript belongs to: subagent
-/// transcripts attribute to their parent session (matching ccusage).
+/// Identity of the session a transcript belongs to: every agent execution
+/// owns its own usage, so subagent/fork transcripts attribute to their own
+/// session and carry the parent as a relationship — the same leaf identity
+/// SessionEvents use. (Deviation from ccusage, which rolls Claude sidechains
+/// into the parent session: totals still match, but git-ai groups every
+/// tool the same way and keeps the per-agent view; the parent-inclusive
+/// total stays derivable through the parent attributes.)
 struct SessionIdentity {
     session_id: String,
     external_session_id: String,
+    external_parent_session_id: Option<String>,
     tool: String,
 }
 
 impl SessionIdentity {
     fn from_stream(stream: &StreamRecord) -> Self {
-        let (session_id, external_session_id) = match &stream.external_parent_session_id {
-            Some(parent_ext) => (
-                generate_session_id(parent_ext, &stream.tool),
-                parent_ext.clone(),
-            ),
-            None => (
-                stream.session_id.clone(),
-                stream.external_session_id.clone(),
-            ),
-        };
         Self {
-            session_id,
-            external_session_id,
+            session_id: stream.session_id.clone(),
+            external_session_id: stream.external_session_id.clone(),
+            external_parent_session_id: stream.external_parent_session_id.clone(),
             tool: stream.tool.clone(),
         }
     }
@@ -722,6 +721,7 @@ fn reconcile_flagged_sessions(
         let identity = SessionIdentity {
             session_id: session.session_id.clone(),
             external_session_id: session.external_session_id,
+            external_parent_session_id: session.external_parent_session_id,
             tool: session.tool,
         };
         emit_changed_buckets(token_db, &identity, || session.repo_url, sink)?;
@@ -769,8 +769,8 @@ const PARENT_SCAN_MAX_ENTRIES: usize = 50_000;
 
 /// Locate and read a forked child's parent rollout, returning its pre-fork
 /// usage prefix. Candidates come from the token database (files tracked
-/// under the parent's external session id — which, for rolled-up children,
-/// includes the child itself) and a bounded scan of the codex sessions tree
+/// under the parent's own external session id) and a bounded scan of the
+/// codex sessions tree
 /// for filenames carrying the parent id; a candidate counts only when its
 /// first line is a `session_meta` recording that id (ccusage locates parents
 /// by recorded id, never by filename). `None` — the parent is unresolvable —
@@ -904,6 +904,7 @@ fn process_file(
         stream_path,
         &identity.tool,
         &identity.external_session_id,
+        identity.external_parent_session_id.as_deref(),
     )?;
     let now = now_secs();
 
@@ -1146,6 +1147,17 @@ fn emit_changed_buckets(
         if !identity.external_session_id.is_empty() {
             attrs = attrs.external_session_id(identity.external_session_id.clone());
         }
+        // Subagent/fork sessions carry their parent as a relationship (leaf
+        // attribution), exactly like SessionEvents.
+        if let Some(parent_ext) = identity
+            .external_parent_session_id
+            .as_deref()
+            .filter(|parent_ext| !parent_ext.is_empty())
+        {
+            attrs = attrs
+                .external_parent_session_id(parent_ext.to_string())
+                .parent_session_id(generate_session_id(parent_ext, &identity.tool));
+        }
         if let Some(url) = &repo_url {
             attrs = attrs.repo_url(url.clone());
         }
@@ -1183,6 +1195,7 @@ mod tests {
         SessionIdentity {
             session_id: "s_test".to_string(),
             external_session_id: "ext-test".to_string(),
+            external_parent_session_id: None,
             tool: "claude".to_string(),
         }
     }
@@ -1613,7 +1626,7 @@ mod tests {
         let events = run_as(&db, &identity, &transcript).unwrap();
         assert_eq!(events.len(), 1);
         assert_eq!(
-            db.ensure_file(&identity.session_id, &path, "claude", "ext-test")
+            db.ensure_file(&identity.session_id, &path, "claude", "ext-test", None)
                 .unwrap()
                 .processing_errors,
             0
@@ -1980,6 +1993,7 @@ mod tests {
         let identity_b = SessionIdentity {
             session_id: "s_resumed".to_string(),
             external_session_id: "ext-resumed".to_string(),
+            external_parent_session_id: None,
             tool: "claude".to_string(),
         };
         let transcript_b = dir.path().join("resumed.jsonl");
@@ -2036,6 +2050,7 @@ mod tests {
         let identity_b = SessionIdentity {
             session_id: "s_resumed".to_string(),
             external_session_id: "ext-resumed".to_string(),
+            external_parent_session_id: None,
             tool: "claude".to_string(),
         };
         let transcript_b = dir.path().join("resumed.jsonl");
@@ -2082,6 +2097,7 @@ mod tests {
         let identity_b = SessionIdentity {
             session_id: "s_resumed".to_string(),
             external_session_id: "ext-resumed".to_string(),
+            external_parent_session_id: None,
             tool: "claude".to_string(),
         };
         let transcript_b = dir.path().join("resumed.jsonl");
@@ -2204,7 +2220,7 @@ mod tests {
         // The settled file's snapshot matches its current metadata.
         let metadata = fs::metadata(&settled_path).unwrap();
         token_db
-            .ensure_file("s_settled", &settled_path, "claude", "s_settled-ext")
+            .ensure_file("s_settled", &settled_path, "claude", "s_settled-ext", None)
             .unwrap();
         token_db
             .update_file_metadata(
@@ -2268,9 +2284,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn processing_errors_are_recorded_under_the_rollup_session() {
-        // Subagent transcripts track under their parent session id, so error
-        // recording must use the same key or the UPDATE matches no row.
+    async fn processing_errors_are_recorded_under_the_leaf_session() {
+        // Subagent transcripts track under their own session id (leaf
+        // attribution), so error recording must use the same key or the
+        // UPDATE matches no row.
         let dir = tempfile::tempdir().unwrap();
         let streams_db =
             Arc::new(StreamsDatabase::open(dir.path().join("transcripts-db")).unwrap());
@@ -2296,9 +2313,14 @@ mod tests {
         );
         assert!(result.is_err());
 
-        let parent_session = generate_session_id("parent-ext", "claude");
         let tracked = token_db
-            .ensure_file(&parent_session, &missing, "claude", "parent-ext")
+            .ensure_file(
+                "s_child",
+                &missing,
+                "claude",
+                "child-ext",
+                Some("parent-ext"),
+            )
             .unwrap();
         assert_eq!(tracked.processing_errors, 1);
         assert!(tracked.last_error_at.is_some());
@@ -2306,21 +2328,25 @@ mod tests {
     }
 
     #[test]
-    fn subagent_stream_rolls_up_to_parent_session() {
+    fn subagent_stream_owns_its_usage_and_carries_the_parent() {
+        // Leaf attribution: the transcript's own session owns the usage;
+        // the parent is a relationship, not the owner (same identity model
+        // as SessionEvents).
         let mut stream = stream_record("s_child", "claude", "/tmp/child.jsonl");
         stream.external_session_id = "child-ext".to_string();
         stream.external_parent_session_id = Some("parent-ext".to_string());
         let identity = SessionIdentity::from_stream(&stream);
+        assert_eq!(identity.session_id, "s_child");
+        assert_eq!(identity.external_session_id, "child-ext");
         assert_eq!(
-            identity.session_id,
-            generate_session_id("parent-ext", "claude")
+            identity.external_parent_session_id.as_deref(),
+            Some("parent-ext")
         );
-        assert_eq!(identity.external_session_id, "parent-ext");
 
         stream.external_parent_session_id = None;
         let identity = SessionIdentity::from_stream(&stream);
         assert_eq!(identity.session_id, "s_child");
-        assert_eq!(identity.external_session_id, "child-ext");
+        assert_eq!(identity.external_parent_session_id, None);
     }
 
     #[test]
@@ -2525,7 +2551,7 @@ mod tests {
         .unwrap();
         assert!(collected.lock().unwrap().is_empty(), "turn stays parked");
         let tracked = token_db
-            .ensure_file("s_fork", &path_str, "codex", "s_fork-ext")
+            .ensure_file("s_fork", &path_str, "codex", "s_fork-ext", None)
             .unwrap();
         assert!(tracked.pending_flush);
         // The bytes have not changed, but the pending flush alone keeps the
@@ -2553,7 +2579,7 @@ mod tests {
             Some(15)
         );
         let tracked = token_db
-            .ensure_file("s_fork", &path_str, "codex", "s_fork-ext")
+            .ensure_file("s_fork", &path_str, "codex", "s_fork-ext", None)
             .unwrap();
         assert!(!tracked.pending_flush);
         assert!(sweep_candidates(&streams_db, &token_db).is_empty());

--- a/src/daemon/token_usage_worker.rs
+++ b/src/daemon/token_usage_worker.rs
@@ -667,8 +667,8 @@ fn process_task_blocking(
         throttle,
     );
     if let Err(e) = &result {
-        // Keyed by the rollup session id (subagent transcripts track under
-        // their parent), matching the row ensure_file created.
+        // Keyed by the transcript's own session id (leaf attribution),
+        // matching the row ensure_file created.
         let _ = token_db.record_error(
             &identity.session_id,
             &task.stream_path,

--- a/src/token_usage/claude.rs
+++ b/src/token_usage/claude.rs
@@ -13,6 +13,10 @@
 //!   remains the replacement tie-breaker.
 //! - Entries whose model is missing or `<synthetic>` are attributed to
 //!   [`UNKNOWN_MODEL`] instead of carrying no model, so tokens aren't lost.
+//! - Sidechain (subagent) usage is attributed to the sidechain's own session
+//!   with the parent as a relationship (leaf attribution, standardized
+//!   across tools); ccusage rolls it into the parent session. Cross-file
+//!   dedup of replayed parent messages is unaffected — it is global.
 
 use serde::Deserialize;
 

--- a/src/token_usage/db.rs
+++ b/src/token_usage/db.rs
@@ -232,11 +232,89 @@ const MIGRATIONS: &[&str] = &[
 
     INSERT INTO schema_version (version) VALUES (4);
     "#,
+    // Version 5: leaf session attribution. Usage is owned by the transcript's
+    // own session — subagent/fork transcripts no longer roll up into their
+    // parent — with the parent carried as a relationship
+    // (tracked_files.external_parent_session_id, emitted as the
+    // parent_session_id/external_parent_session_id attributes, matching
+    // SessionEvents). Pre-release reset like v3: existing rows are keyed by
+    // the rolled-up parent session and cannot be reassigned (they don't
+    // record their source rollout), so the tables are rebuilt and the next
+    // pass re-extracts everything under leaf identities.
+    r#"
+    DROP TABLE IF EXISTS tracked_files;
+    DROP TABLE IF EXISTS usage_entries;
+    DROP TABLE IF EXISTS bucket_state;
+
+    CREATE TABLE tracked_files (
+        session_id  TEXT NOT NULL,
+        stream_path TEXT NOT NULL,
+        tool        TEXT NOT NULL,
+        byte_offset INTEGER NOT NULL DEFAULT 0,
+        state_json  TEXT,
+        last_known_size INTEGER NOT NULL DEFAULT 0,
+        last_modified INTEGER,
+        processing_errors INTEGER NOT NULL DEFAULT 0,
+        last_error TEXT,
+        pending_flush INTEGER NOT NULL DEFAULT 0,
+        last_error_at INTEGER,
+        external_session_id TEXT NOT NULL DEFAULT '',
+        external_parent_session_id TEXT,
+        needs_reconcile INTEGER NOT NULL DEFAULT 0,
+        repo_url TEXT,
+        PRIMARY KEY (session_id, stream_path)
+    );
+
+    CREATE TABLE usage_entries (
+        session_id TEXT NOT NULL,
+        entry_key  TEXT NOT NULL,
+        message_id TEXT,
+        model      TEXT NOT NULL,
+        bucket_ts  INTEGER NOT NULL,
+        input_tokens INTEGER NOT NULL DEFAULT 0,
+        output_tokens INTEGER NOT NULL DEFAULT 0,
+        cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+        cache_write_tokens INTEGER NOT NULL DEFAULT 0,
+        cache_write_1h_tokens INTEGER NOT NULL DEFAULT 0,
+        reasoning_output_tokens INTEGER,
+        total_tokens INTEGER NOT NULL DEFAULT 0,
+        cost_micro_usd INTEGER,
+        transcript_cost_micro_usd INTEGER,
+        is_sidechain INTEGER NOT NULL DEFAULT 0,
+        speed INTEGER,
+        speed_inferred INTEGER NOT NULL DEFAULT 0,
+        long_context INTEGER NOT NULL DEFAULT 0,
+        pricing_catalog TEXT,
+        PRIMARY KEY (session_id, entry_key)
+    );
+
+    CREATE INDEX idx_usage_entries_bucket
+        ON usage_entries(session_id, model, bucket_ts);
+    CREATE INDEX idx_usage_entries_message
+        ON usage_entries(session_id, message_id) WHERE message_id IS NOT NULL;
+    CREATE UNIQUE INDEX idx_usage_entries_key
+        ON usage_entries(entry_key);
+    CREATE INDEX idx_usage_entries_message_global
+        ON usage_entries(message_id) WHERE message_id IS NOT NULL;
+
+    CREATE TABLE bucket_state (
+        session_id TEXT NOT NULL,
+        model      TEXT NOT NULL,
+        speed      INTEGER NOT NULL DEFAULT 0,
+        bucket_ts  INTEGER NOT NULL,
+        emitted_fingerprint TEXT NOT NULL,
+        last_emitted_at INTEGER NOT NULL,
+        emit_seq INTEGER NOT NULL DEFAULT 0,
+        PRIMARY KEY (session_id, model, speed, bucket_ts)
+    );
+
+    INSERT INTO schema_version (version) VALUES (5);
+    "#,
 ];
 
 const TRACKED_FILE_COLUMNS: &str = "session_id, stream_path, tool, byte_offset, state_json, \
      last_known_size, last_modified, processing_errors, last_error_at, pending_flush, \
-     external_session_id, needs_reconcile, repo_url";
+     external_session_id, external_parent_session_id, needs_reconcile, repo_url";
 
 /// A tracked transcript file: read cursor plus extractor state.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -253,9 +331,12 @@ pub struct TrackedFile {
     /// The extractor reported buffered entries at the end of the last pass;
     /// the file must be re-processed even if its bytes have not changed.
     pub pending_flush: bool,
-    /// External id of the rollup session (for emission attributes when the
+    /// The session's own external id (for emission attributes when the
     /// session is reconciled without reading any file).
     pub external_session_id: String,
+    /// External id of the parent session for subagent/fork transcripts;
+    /// emitted as the parent-relationship attributes.
+    pub external_parent_session_id: Option<String>,
     /// A cross-session replacement changed this session's buckets; it must
     /// be re-reconciled even if none of its files change (or still exist).
     pub needs_reconcile: bool,
@@ -277,8 +358,9 @@ fn read_tracked_file(row: &rusqlite::Row<'_>) -> rusqlite::Result<TrackedFile> {
         last_error_at: row.get(8)?,
         pending_flush: row.get(9)?,
         external_session_id: row.get(10)?,
-        needs_reconcile: row.get(11)?,
-        repo_url: row.get(12)?,
+        external_parent_session_id: row.get(11)?,
+        needs_reconcile: row.get(12)?,
+        repo_url: row.get(13)?,
     })
 }
 
@@ -367,6 +449,7 @@ pub struct ChangedBucket {
 pub struct ReconcileSession {
     pub session_id: String,
     pub external_session_id: String,
+    pub external_parent_session_id: Option<String>,
     pub tool: String,
     pub repo_url: Option<String>,
 }
@@ -494,8 +577,9 @@ impl TokenUsageDatabase {
     }
 
     /// Fetch the tracked file row, creating it with a zero cursor when new.
-    /// The rollup session's external id is recorded (or backfilled on rows
-    /// from before it was tracked) so the session can later be reconciled
+    /// The session's external identity (own id, and the parent id for
+    /// subagent/fork transcripts) is recorded — or backfilled on rows from
+    /// before it was tracked — so the session can later be reconciled
     /// without reading any file.
     pub fn ensure_file(
         &self,
@@ -503,17 +587,24 @@ impl TokenUsageDatabase {
         stream_path: &str,
         tool: &str,
         external_session_id: &str,
+        external_parent_session_id: Option<&str>,
     ) -> Result<TrackedFile, GitAiError> {
         let conn = self.lock();
         conn.execute(
-            "INSERT OR IGNORE INTO tracked_files (session_id, stream_path, tool, external_session_id)
-             VALUES (?1, ?2, ?3, ?4)",
-            params![session_id, stream_path, tool, external_session_id],
+            "INSERT OR IGNORE INTO tracked_files (session_id, stream_path, tool, external_session_id, external_parent_session_id)
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![session_id, stream_path, tool, external_session_id, external_parent_session_id],
         )?;
         conn.execute(
             "UPDATE tracked_files SET external_session_id = ?3
              WHERE session_id = ?1 AND stream_path = ?2 AND external_session_id = ''",
             params![session_id, stream_path, external_session_id],
+        )?;
+        conn.execute(
+            "UPDATE tracked_files SET external_parent_session_id = ?3
+             WHERE session_id = ?1 AND stream_path = ?2 AND external_parent_session_id IS NULL
+               AND ?3 IS NOT NULL",
+            params![session_id, stream_path, external_parent_session_id],
         )?;
         Ok(conn.query_row(
             &format!(
@@ -577,15 +668,17 @@ impl TokenUsageDatabase {
     pub fn sessions_needing_reconcile(&self) -> Result<Vec<ReconcileSession>, GitAiError> {
         let conn = self.lock();
         let mut stmt = conn.prepare(
-            "SELECT session_id, MAX(external_session_id), MAX(tool), MAX(repo_url)
+            "SELECT session_id, MAX(external_session_id), MAX(external_parent_session_id),
+                    MAX(tool), MAX(repo_url)
              FROM tracked_files WHERE needs_reconcile = 1 GROUP BY session_id",
         )?;
         let rows = stmt.query_map([], |row| {
             Ok(ReconcileSession {
                 session_id: row.get(0)?,
                 external_session_id: row.get(1)?,
-                tool: row.get(2)?,
-                repo_url: row.get(3)?,
+                external_parent_session_id: row.get(2)?,
+                tool: row.get(3)?,
+                repo_url: row.get(4)?,
             })
         })?;
         Ok(rows.collect::<Result<Vec<_>, _>>()?)
@@ -606,11 +699,9 @@ impl TokenUsageDatabase {
         Ok(())
     }
 
-    /// Stream paths tracked under an external session id. The id is the
-    /// rollup root's (forked/subagent files roll up to their parent), so the
-    /// root's own rollout is among the results — alongside any rolled-up
-    /// children, which callers must tell apart by each file's recorded
-    /// `session_meta` id.
+    /// Stream paths tracked under a session's own external id (usage is
+    /// leaf-attributed, so a parent id maps to the parent's own rollout);
+    /// callers still confirm by each file's recorded `session_meta` id.
     pub fn stream_paths_for_external_session(
         &self,
         external_session_id: &str,
@@ -1118,7 +1209,7 @@ mod tests {
 
     fn commit_for(db: &TokenUsageDatabase, session: &str, entries: &[UsageEntry]) {
         let path = format!("/{session}.jsonl");
-        db.ensure_file(session, &path, "claude", &format!("{session}-ext"))
+        db.ensure_file(session, &path, "claude", &format!("{session}-ext"), None)
             .unwrap();
         db.commit_batch(&BatchCommit {
             session_id: session,
@@ -1178,10 +1269,10 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("token-usage-db");
         let db = TokenUsageDatabase::open(&path).unwrap();
-        assert_eq!(db.schema_version().unwrap(), 4);
+        assert_eq!(db.schema_version().unwrap(), 5);
         drop(db);
         let db = TokenUsageDatabase::open(&path).unwrap();
-        assert_eq!(db.schema_version().unwrap(), 4);
+        assert_eq!(db.schema_version().unwrap(), 5);
     }
 
     #[test]
@@ -1210,7 +1301,7 @@ mod tests {
     fn ensure_file_creates_zero_cursor_and_is_stable() {
         let (_dir, db) = db();
         let file = db
-            .ensure_file("s1", "/t.jsonl", "claude", "s1-ext")
+            .ensure_file("s1", "/t.jsonl", "claude", "s1-ext", None)
             .unwrap();
         assert_eq!(file.byte_offset, 0);
         assert_eq!(file.state_json, None);
@@ -1226,7 +1317,7 @@ mod tests {
         })
         .unwrap();
         let file = db
-            .ensure_file("s1", "/t.jsonl", "claude", "s1-ext")
+            .ensure_file("s1", "/t.jsonl", "claude", "s1-ext", None)
             .unwrap();
         assert_eq!(file.byte_offset, 42);
         assert_eq!(file.state_json.as_deref(), Some("{\"x\":1}"));
@@ -1293,6 +1384,7 @@ mod tests {
             vec![ReconcileSession {
                 session_id: "s1".to_string(),
                 external_session_id: "s1-ext".to_string(),
+                external_parent_session_id: None,
                 tool: "claude".to_string(),
                 repo_url: None,
             }]
@@ -1450,7 +1542,7 @@ mod tests {
     #[test]
     fn entries_before_the_retention_cutoff_are_dropped_at_insert() {
         let (_dir, db) = db();
-        db.ensure_file("s1", "/t.jsonl", "claude", "s1-ext")
+        db.ensure_file("s1", "/t.jsonl", "claude", "s1-ext", None)
             .unwrap();
         db.commit_batch(&BatchCommit {
             session_id: "s1",
@@ -1501,7 +1593,7 @@ mod tests {
         }
 
         let db = TokenUsageDatabase::open(&path).unwrap();
-        assert_eq!(db.schema_version().unwrap(), 4);
+        assert_eq!(db.schema_version().unwrap(), 5);
         // Rebuilt empty: no legacy rows, cursors, or reconcile flags survive.
         assert!(db.all_files().unwrap().is_empty());
         assert!(db.sessions_needing_reconcile().unwrap().is_empty());
@@ -1698,13 +1790,13 @@ mod tests {
     #[test]
     fn record_error_tracks_and_commit_clears() {
         let (_dir, db) = db();
-        db.ensure_file("s1", "/t.jsonl", "claude", "s1-ext")
+        db.ensure_file("s1", "/t.jsonl", "claude", "s1-ext", None)
             .unwrap();
         db.record_error("s1", "/t.jsonl", "boom", 100).unwrap();
         db.record_error("s1", "/t.jsonl", "boom again", 200)
             .unwrap();
         let file = db
-            .ensure_file("s1", "/t.jsonl", "claude", "s1-ext")
+            .ensure_file("s1", "/t.jsonl", "claude", "s1-ext", None)
             .unwrap();
         assert_eq!(file.processing_errors, 2);
         assert_eq!(file.last_error_at, Some(200));
@@ -1719,7 +1811,7 @@ mod tests {
         })
         .unwrap();
         let file = db
-            .ensure_file("s1", "/t.jsonl", "claude", "s1-ext")
+            .ensure_file("s1", "/t.jsonl", "claude", "s1-ext", None)
             .unwrap();
         assert_eq!(file.processing_errors, 0);
         assert_eq!(file.last_error_at, None);
@@ -1749,12 +1841,12 @@ mod tests {
     #[test]
     fn file_metadata_roundtrip() {
         let (_dir, db) = db();
-        db.ensure_file("s1", "/t.jsonl", "claude", "s1-ext")
+        db.ensure_file("s1", "/t.jsonl", "claude", "s1-ext", None)
             .unwrap();
         db.update_file_metadata("s1", "/t.jsonl", 1234, Some(99))
             .unwrap();
         let file = db
-            .ensure_file("s1", "/t.jsonl", "claude", "s1-ext")
+            .ensure_file("s1", "/t.jsonl", "claude", "s1-ext", None)
             .unwrap();
         assert_eq!(file.last_known_size, 1234);
         assert_eq!(file.last_modified, Some(99));

--- a/src/token_usage/db.rs
+++ b/src/token_usage/db.rs
@@ -288,8 +288,8 @@ const MIGRATIONS: &[&str] = &[
         PRIMARY KEY (session_id, entry_key)
     );
 
-    CREATE INDEX idx_usage_entries_bucket
-        ON usage_entries(session_id, model, bucket_ts);
+    CREATE INDEX idx_usage_entries_bucket_speed
+        ON usage_entries(session_id, model, COALESCE(speed, 0), bucket_ts);
     CREATE INDEX idx_usage_entries_message
         ON usage_entries(session_id, message_id) WHERE message_id IS NOT NULL;
     CREATE UNIQUE INDEX idx_usage_entries_key

--- a/tests/integration/token_usage.rs
+++ b/tests/integration/token_usage.rs
@@ -711,7 +711,7 @@ fn resumed_session_through_the_daemon_does_not_double_count() {
 /// parent session through the real daemon, and a sidechain replay of a
 /// parent message dedups across the two files.
 #[test]
-fn subagent_transcript_rolls_up_to_the_parent_session() {
+fn subagent_transcript_owns_its_usage_and_links_to_the_parent() {
     let (_metrics_db_dir, metrics_db_path) = isolated_metrics_db_path();
     let repo =
         TestRepo::new_with_daemon_env(&[("GIT_AI_TEST_METRICS_DB_PATH", metrics_db_path.as_str())]);
@@ -769,9 +769,10 @@ fn subagent_transcript_rolls_up_to_the_parent_session() {
     sync_token_usage_pipeline(&repo);
 
     let events = token_usage_events(&metrics_db_path);
-    // The sidechain replay deduped against the parent's entry (no inflated
-    // re-emission of the first bucket); only the subagent's own turn emits,
-    // attributed to the PARENT session.
+    // The sidechain replay deduped against the parent's entry across files
+    // (dedup is global, not session-scoped); only the subagent's own turn
+    // emits, attributed to the SUBAGENT session with the parent carried as a
+    // relationship (leaf attribution, matching SessionEvents).
     assert_eq!(events.len(), 2);
     let subagent_event = &events[1];
     assert_eq!(
@@ -786,7 +787,15 @@ fn subagent_transcript_rolls_up_to_the_parent_session() {
     let attrs = EventAttributes::from_sparse(&subagent_event.attrs);
     assert_eq!(
         attrs.session_id,
+        Some(Some(generate_session_id("agent-1", "claude")))
+    );
+    assert_eq!(
+        attrs.parent_session_id,
         Some(Some(generate_session_id("sess-parent", "claude")))
+    );
+    assert_eq!(
+        attrs.external_parent_session_id,
+        Some(Some("sess-parent".to_string()))
     );
 }
 


### PR DESCRIPTION
Usage is now leaf-attributed for every tool: subagent and fork
transcripts own their usage under their own session, carrying the
parent as the parent_session_id/external_parent_session_id attributes
— the same identity model SessionEvents already use, so TokenUsage and
SessionEvents finally agree about which session a transcript is. The
parent-inclusive total becomes a derived rollup over the parent
relationship instead of the stored identity, keeping per-agent cost
visible; recording everything under the parent was lossy in the other
direction.

Previously the worker rolled every stream with an
external_parent_session_id into its parent. For Codex forks that
contradicted both the spec ("sessions are per rollout file") and
ccusage, hiding fork children entirely; for Claude sidechains it
matched ccusage but differed from git-ai's own SessionEvents. This is
now a single standardized rule, with the Claude difference from
ccusage documented (per-session groupings differ; aggregate totals
match). Cross-file dedup of sidechain replays is unaffected — entry
dedup is global, not session-scoped.

tracked_files persists the parent id so DB-only reconciliation carries
the same relationship attributes; schema v5 is a pre-release reset
(existing rows are keyed by the rolled-up parent and don't record
their source rollout, so they cannot be reassigned in place). The
server already ingests both parent attributes into
token_usage_v2_events columns; no wire change.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
