### PR TITLE
daemon: cap control/trace socket line size

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2607,13 +2607,53 @@ fn process_alive(pid: u32) -> bool {
     unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
 }
 
-fn read_json_line<R: BufRead>(reader: &mut R) -> Result<Option<String>, GitAiError> {
-    let mut line = String::new();
-    let read = reader.read_line(&mut line)?;
+/// Upper bound on a single control/trace socket line. Both sockets speak
+/// line-delimited JSON with bounded frames (trace2 events, control request
+/// headers; checkpoint bodies travel separately after the header line), but
+/// `read_line` is otherwise unbounded, so one runaway client line can
+/// balloon daemon RSS past the memory watchdog (#2244).
+const MAX_SOCKET_LINE_BYTES: u64 = 4 * 1024 * 1024;
+
+/// A line read from a daemon socket.
+enum SocketLine {
+    Line(String),
+    /// Line exceeded [`MAX_SOCKET_LINE_BYTES`]; the content was discarded and
+    /// the reader advanced past its newline. The control loop answers these
+    /// with an error response (a silently-eaten request would stall the
+    /// client until its socket timeout and then be resent forever); the trace
+    /// loop just keeps reading.
+    Oversized,
+}
+
+fn read_json_line<R: BufRead>(reader: &mut R) -> Result<Option<SocketLine>, GitAiError> {
+    // Byte-based read, not read_line: the cap can slice a multi-byte
+    // character, and read_line's UTF-8 validation would turn that into an
+    // InvalidData error (dropping the connection) instead of an Oversized
+    // classification.
+    let mut buf = Vec::new();
+    let read = reader
+        .by_ref()
+        .take(MAX_SOCKET_LINE_BYTES)
+        .read_until(b'\n', &mut buf)?;
     if read == 0 {
         return Ok(None);
     }
-    Ok(Some(line))
+    if buf.last() != Some(&b'\n') && read as u64 == MAX_SOCKET_LINE_BYTES {
+        drop(buf);
+        let skipped = reader.skip_until(b'\n')?;
+        tracing::warn!(
+            component = "daemon",
+            phase = "socket_read",
+            consumed_bytes = read as u64 + skipped as u64,
+            max_bytes = MAX_SOCKET_LINE_BYTES,
+            "skipping oversized socket line"
+        );
+        return Ok(Some(SocketLine::Oversized));
+    }
+    let line = String::from_utf8(buf).map_err(|error| {
+        GitAiError::IoError(std::io::Error::new(std::io::ErrorKind::InvalidData, error))
+    })?;
+    Ok(Some(SocketLine::Line(line)))
 }
 
 fn read_checkpoint_body<R: BufRead>(
@@ -7862,7 +7902,20 @@ fn handle_control_connection_actor_reader<R: ControlConnection>(
     let mut uses_idle_timeout = false;
     loop {
         let line = match read_json_line(reader) {
-            Ok(Some(line)) => line,
+            Ok(Some(SocketLine::Line(line))) => line,
+            Ok(Some(SocketLine::Oversized)) => {
+                // Answer instead of silently eating the request: an
+                // unanswered client blocks until its socket timeout, then
+                // reconnects and resends the same oversized request forever.
+                if let Err(error) = write_control_response(
+                    reader.get_mut(),
+                    &ControlResponse::err("control request exceeds the maximum line size"),
+                ) {
+                    tracing::warn!(%error, "failed responding to an oversized control request");
+                    break;
+                }
+                continue;
+            }
             Ok(None) => break,
             Err(error) if control_receive_timed_out(&error) => break,
             Err(error) => return Err(error),
@@ -8471,7 +8524,11 @@ fn handle_trace_connection_actor_reader<R: Read>(
     mut observed_roots: std::collections::BTreeSet<String>,
 ) -> Result<(), GitAiError> {
     let read_result = (|| {
-        while let Some(line) = read_json_line(&mut reader)? {
+        while let Some(socket_line) = read_json_line(&mut reader)? {
+            let line = match socket_line {
+                SocketLine::Line(line) => line,
+                SocketLine::Oversized => continue,
+            };
             if process_trace_connection_line(&line, coordinator.clone(), &mut observed_roots)?
                 .is_some_and(|outcome| !outcome.continue_reading)
             {

--- a/src/daemon/stream_worker.rs
+++ b/src/daemon/stream_worker.rs
@@ -1128,7 +1128,11 @@ impl StreamWorker {
             let batch_count = batch.events.len();
 
             let is_otel_stream = task.stream_kind == "otel_traces";
-            let metric_events: Vec<MetricEvent> = batch
+            // Serialize each event as it is built and let the MetricEvent
+            // (which still holds the redacted JSON tree) drop before the next
+            // one is constructed. Collecting Vec<MetricEvent> and serializing
+            // afterwards kept two full copies of the batch alive at once (#2244).
+            let metric_event_jsons: Vec<String> = batch
                 .events
                 .into_iter()
                 .enumerate()
@@ -1164,7 +1168,7 @@ impl StreamWorker {
 
                     let attrs_sparse = event_attrs.to_sparse();
                     let raw_event = redact_json_secrets(raw_event);
-                    Some(if is_otel_stream {
+                    let metric_event = if is_otel_stream {
                         MetricEvent::from_values_with_timestamp(
                             OtelTraceValues::with_ids(raw_event, eid, pid, tid),
                             attrs_sparse,
@@ -1176,11 +1180,18 @@ impl StreamWorker {
                             attrs_sparse,
                             Some(event_ts),
                         )
-                    })
+                    };
+                    match serde_json::to_string(&metric_event) {
+                        Ok(json) => Some(json),
+                        Err(e) => {
+                            tracing::warn!(%e, "telemetry: failed to serialize transcript metric event; dropping");
+                            None
+                        }
+                    }
                 })
                 .collect();
 
-            if let Err(e) = telemetry.persist_metrics_blocking(&metric_events) {
+            if let Err(e) = telemetry.persist_metric_jsons_blocking(&metric_event_jsons) {
                 tracing::warn!(%e, "telemetry: failed to persist transcript metrics locally");
             }
 

--- a/src/daemon/telemetry_worker.rs
+++ b/src/daemon/telemetry_worker.rs
@@ -435,6 +435,19 @@ impl DaemonTelemetryWorkerHandle {
         store_metrics_in_db(events)
     }
 
+    /// Persist pre-serialized metric-event JSON rows.
+    ///
+    /// Streaming variant of [`Self::persist_metrics_blocking`] for large
+    /// transcript batches: the caller serializes each event as it is built
+    /// and drops the event immediately, so a batch's `MetricEvent` trees and
+    /// their JSON copies are never all resident at the same time (#2244).
+    pub fn persist_metric_jsons_blocking(
+        &self,
+        event_jsons: &[String],
+    ) -> Result<Vec<i64>, GitAiError> {
+        store_metric_jsons_in_db(event_jsons)
+    }
+
     /// Submit telemetry envelopes synchronously (best-effort, non-blocking).
     ///
     /// Used by the daemon process's own `observability::log_*()` calls which
@@ -970,6 +983,10 @@ fn store_metrics_in_db(events: &[MetricEvent]) -> Result<Vec<i64>, GitAiError> {
         .map(serde_json::to_string)
         .collect::<Result<_, _>>()?;
 
+    store_metric_jsons_in_db(&event_jsons)
+}
+
+fn store_metric_jsons_in_db(event_jsons: &[String]) -> Result<Vec<i64>, GitAiError> {
     if event_jsons.is_empty() {
         return Ok(Vec::new());
     }
@@ -978,7 +995,7 @@ fn store_metrics_in_db(events: &[MetricEvent]) -> Result<Vec<i64>, GitAiError> {
     let mut db_lock = db
         .lock()
         .map_err(|_| GitAiError::Generic("metrics DB lock poisoned".to_string()))?;
-    db_lock.insert_events(&event_jsons)
+    db_lock.insert_events(event_jsons)
 }
 
 #[derive(Debug, Default, PartialEq, Eq)]

--- a/src/streams/agents/claude.rs
+++ b/src/streams/agents/claude.rs
@@ -186,6 +186,7 @@ impl Agent for ClaudeAgent {
 
         let batch_limit = self.batch_size_hint();
         let mut events = Vec::with_capacity(batch_limit);
+        let mut batch_bytes: usize = 0;
         let mut current_offset = start_offset;
         let mut line_number = 0;
 
@@ -202,6 +203,17 @@ impl Agent for ClaudeAgent {
                 crate::streams::types::JsonlLineState::Complete(bytes_read) => {
                     line_number += 1;
                     current_offset += bytes_read as u64;
+                }
+                crate::streams::types::JsonlLineState::Oversized(bytes_read) => {
+                    line_number += 1;
+                    current_offset += bytes_read as u64;
+                    tracing::warn!(
+                        line = line_number,
+                        path = %path.display(),
+                        max_bytes = crate::streams::types::MAX_JSONL_LINE_BYTES,
+                        "skipping oversized transcript line"
+                    );
+                    continue;
                 }
             }
 
@@ -222,8 +234,10 @@ impl Agent for ClaudeAgent {
                 }
             };
 
+            batch_bytes += line.len();
             events.push(entry);
-            if events.len() >= batch_limit {
+            if events.len() >= batch_limit || batch_bytes >= crate::streams::types::MAX_BATCH_BYTES
+            {
                 break;
             }
         }

--- a/src/streams/agents/codex.rs
+++ b/src/streams/agents/codex.rs
@@ -250,6 +250,7 @@ impl Agent for CodexAgent {
 
         let batch_limit = self.batch_size_hint();
         let mut events = Vec::with_capacity(batch_limit);
+        let mut batch_bytes: usize = 0;
         let mut current_offset = start_offset;
         let mut line_number = 0;
         let mut line = String::new();
@@ -266,6 +267,17 @@ impl Agent for CodexAgent {
                 crate::streams::types::JsonlLineState::Complete(bytes_read) => {
                     line_number += 1;
                     current_offset += bytes_read as u64;
+                }
+                crate::streams::types::JsonlLineState::Oversized(bytes_read) => {
+                    line_number += 1;
+                    current_offset += bytes_read as u64;
+                    tracing::warn!(
+                        line = line_number,
+                        path = %path.display(),
+                        max_bytes = crate::streams::types::MAX_JSONL_LINE_BYTES,
+                        "skipping oversized transcript line"
+                    );
+                    continue;
                 }
             }
 
@@ -286,8 +298,10 @@ impl Agent for CodexAgent {
                 }
             };
 
+            batch_bytes += line.len();
             events.push(entry);
-            if events.len() >= batch_limit {
+            if events.len() >= batch_limit || batch_bytes >= crate::streams::types::MAX_BATCH_BYTES
+            {
                 break;
             }
         }

--- a/src/streams/agents/copilot.rs
+++ b/src/streams/agents/copilot.rs
@@ -527,6 +527,7 @@ pub(super) fn read_event_stream(
         })?;
 
     let mut events = Vec::with_capacity(batch_limit);
+    let mut batch_bytes: usize = 0;
     let mut current_offset = start_offset;
     let mut line_number = 0;
 
@@ -544,6 +545,17 @@ pub(super) fn read_event_stream(
             crate::streams::types::JsonlLineState::Complete(bytes_read) => {
                 line_number += 1;
                 current_offset += bytes_read as u64;
+            }
+            crate::streams::types::JsonlLineState::Oversized(bytes_read) => {
+                line_number += 1;
+                current_offset += bytes_read as u64;
+                tracing::warn!(
+                    line = line_number,
+                    path = %path.display(),
+                    max_bytes = crate::streams::types::MAX_JSONL_LINE_BYTES,
+                    "skipping oversized transcript line"
+                );
+                continue;
             }
         }
 
@@ -564,8 +576,9 @@ pub(super) fn read_event_stream(
             }
         };
 
+        batch_bytes += line.len();
         events.push(entry);
-        if events.len() >= batch_limit {
+        if events.len() >= batch_limit || batch_bytes >= crate::streams::types::MAX_BATCH_BYTES {
             break;
         }
     }

--- a/src/streams/agents/cursor.rs
+++ b/src/streams/agents/cursor.rs
@@ -158,6 +158,7 @@ impl Agent for CursorAgent {
 
         let batch_limit = self.batch_size_hint();
         let mut events = Vec::with_capacity(batch_limit);
+        let mut batch_bytes: usize = 0;
         let mut current_offset = start_offset;
         let mut line_number = 0;
 
@@ -174,6 +175,17 @@ impl Agent for CursorAgent {
                 crate::streams::types::JsonlLineState::Complete(bytes_read) => {
                     line_number += 1;
                     current_offset += bytes_read as u64;
+                }
+                crate::streams::types::JsonlLineState::Oversized(bytes_read) => {
+                    line_number += 1;
+                    current_offset += bytes_read as u64;
+                    tracing::warn!(
+                        line = line_number,
+                        path = %path.display(),
+                        max_bytes = crate::streams::types::MAX_JSONL_LINE_BYTES,
+                        "skipping oversized transcript line"
+                    );
+                    continue;
                 }
             }
 
@@ -194,8 +206,10 @@ impl Agent for CursorAgent {
                 }
             };
 
+            batch_bytes += line.len();
             events.push(entry);
-            if events.len() >= batch_limit {
+            if events.len() >= batch_limit || batch_bytes >= crate::streams::types::MAX_BATCH_BYTES
+            {
                 break;
             }
         }

--- a/src/streams/agents/droid.rs
+++ b/src/streams/agents/droid.rs
@@ -165,6 +165,7 @@ impl Agent for DroidAgent {
 
         let batch_limit = self.batch_size_hint();
         let mut events = Vec::with_capacity(batch_limit);
+        let mut batch_bytes: usize = 0;
         let mut current_offset = start_offset;
         let mut line_number = 0;
         let mut latest_timestamp: Option<chrono::DateTime<chrono::Utc>> =
@@ -184,6 +185,17 @@ impl Agent for DroidAgent {
                 crate::streams::types::JsonlLineState::Complete(bytes_read) => {
                     line_number += 1;
                     current_offset += bytes_read as u64;
+                }
+                crate::streams::types::JsonlLineState::Oversized(bytes_read) => {
+                    line_number += 1;
+                    current_offset += bytes_read as u64;
+                    tracing::warn!(
+                        line = line_number,
+                        path = %path.display(),
+                        max_bytes = crate::streams::types::MAX_JSONL_LINE_BYTES,
+                        "skipping oversized transcript line"
+                    );
+                    continue;
                 }
             }
 
@@ -225,8 +237,10 @@ impl Agent for DroidAgent {
             }
 
             // Push raw JSON entry
+            batch_bytes += line.len();
             events.push(entry);
-            if events.len() >= batch_limit {
+            if events.len() >= batch_limit || batch_bytes >= crate::streams::types::MAX_BATCH_BYTES
+            {
                 break;
             }
         }

--- a/src/streams/agents/gemini.rs
+++ b/src/streams/agents/gemini.rs
@@ -160,6 +160,7 @@ impl Agent for GeminiAgent {
 
         let batch_limit = self.batch_size_hint();
         let mut events = Vec::with_capacity(batch_limit);
+        let mut batch_bytes: usize = 0;
         let mut current_offset = start_offset;
         let mut line_number = 0;
 
@@ -176,6 +177,17 @@ impl Agent for GeminiAgent {
                 crate::streams::types::JsonlLineState::Complete(bytes_read) => {
                     line_number += 1;
                     current_offset += bytes_read as u64;
+                }
+                crate::streams::types::JsonlLineState::Oversized(bytes_read) => {
+                    line_number += 1;
+                    current_offset += bytes_read as u64;
+                    tracing::warn!(
+                        line = line_number,
+                        path = %path.display(),
+                        max_bytes = crate::streams::types::MAX_JSONL_LINE_BYTES,
+                        "skipping oversized transcript line"
+                    );
+                    continue;
                 }
             }
 
@@ -196,8 +208,10 @@ impl Agent for GeminiAgent {
                 }
             };
 
+            batch_bytes += line.len();
             events.push(entry);
-            if events.len() >= batch_limit {
+            if events.len() >= batch_limit || batch_bytes >= crate::streams::types::MAX_BATCH_BYTES
+            {
                 break;
             }
         }

--- a/src/streams/agents/pi.rs
+++ b/src/streams/agents/pi.rs
@@ -91,6 +91,7 @@ impl Agent for PiAgent {
 
         let batch_limit = self.batch_size_hint();
         let mut events = Vec::with_capacity(batch_limit);
+        let mut batch_bytes: usize = 0;
         let mut current_offset = start_offset;
         let mut line_number = 0;
 
@@ -107,6 +108,17 @@ impl Agent for PiAgent {
                 crate::streams::types::JsonlLineState::Complete(bytes_read) => {
                     line_number += 1;
                     current_offset += bytes_read as u64;
+                }
+                crate::streams::types::JsonlLineState::Oversized(bytes_read) => {
+                    line_number += 1;
+                    current_offset += bytes_read as u64;
+                    tracing::warn!(
+                        line = line_number,
+                        path = %path.display(),
+                        max_bytes = crate::streams::types::MAX_JSONL_LINE_BYTES,
+                        "skipping oversized transcript line"
+                    );
+                    continue;
                 }
             }
 
@@ -127,8 +139,10 @@ impl Agent for PiAgent {
                 }
             };
 
+            batch_bytes += line.len();
             events.push(entry);
-            if events.len() >= batch_limit {
+            if events.len() >= batch_limit || batch_bytes >= crate::streams::types::MAX_BATCH_BYTES
+            {
                 break;
             }
         }

--- a/src/streams/agents/windsurf.rs
+++ b/src/streams/agents/windsurf.rs
@@ -91,6 +91,7 @@ impl Agent for WindsurfAgent {
 
         let batch_limit = self.batch_size_hint();
         let mut events = Vec::with_capacity(batch_limit);
+        let mut batch_bytes: usize = 0;
         let mut current_offset = start_offset;
         let mut line_number = 0;
 
@@ -107,6 +108,17 @@ impl Agent for WindsurfAgent {
                 crate::streams::types::JsonlLineState::Complete(bytes_read) => {
                     line_number += 1;
                     current_offset += bytes_read as u64;
+                }
+                crate::streams::types::JsonlLineState::Oversized(bytes_read) => {
+                    line_number += 1;
+                    current_offset += bytes_read as u64;
+                    tracing::warn!(
+                        line = line_number,
+                        path = %path.display(),
+                        max_bytes = crate::streams::types::MAX_JSONL_LINE_BYTES,
+                        "skipping oversized transcript line"
+                    );
+                    continue;
                 }
             }
 
@@ -127,8 +139,10 @@ impl Agent for WindsurfAgent {
                 }
             };
 
+            batch_bytes += line.len();
             events.push(entry);
-            if events.len() >= batch_limit {
+            if events.len() >= batch_limit || batch_bytes >= crate::streams::types::MAX_BATCH_BYTES
+            {
                 break;
             }
         }

--- a/src/streams/types.rs
+++ b/src/streams/types.rs
@@ -1,9 +1,24 @@
 //! Core types for transcript processing.
 
-use std::io::BufRead;
+use std::io::{BufRead, Read};
 use std::time::Duration;
 
+/// Upper bound on a single JSONL line. Lines beyond this are skipped rather
+/// than buffered: `read_line` is otherwise unbounded, and a single multi-hundred-MB
+/// transcript line can balloon daemon RSS past the memory watchdog's hard limit
+/// (git-ai#2244). 8 MiB comfortably fits any legitimate transcript event.
+pub const MAX_JSONL_LINE_BYTES: u64 = 8 * 1024 * 1024;
+
+/// Upper bound on the total raw bytes carried by one transcript batch.
+/// Batches were previously capped by event count only (1000), so a transcript
+/// whose events embed file contents could put hundreds of MB into a single
+/// batch — which downstream redaction + metrics conversion amplifies several
+/// times over (git-ai#2244). The batch loop stops early once this budget is
+/// spent; remaining events arrive in later batches.
+pub const MAX_BATCH_BYTES: usize = 8 * 1024 * 1024;
+
 /// Result of reading a single line from a JSONL reader.
+#[derive(Debug)]
 pub enum JsonlLineState {
     /// End of file reached.
     Eof,
@@ -11,21 +26,47 @@ pub enum JsonlLineState {
     Partial,
     /// Complete line ready for processing. Contains bytes read.
     Complete(usize),
+    /// Line exceeded [`MAX_JSONL_LINE_BYTES`] and was skipped without being
+    /// buffered. Contains total bytes consumed (cap + remainder up to and
+    /// including the newline) so callers can advance their watermark past it.
+    Oversized(usize),
 }
 
 /// Read a line from a BufReader, detecting partial writes from concurrent writers.
 ///
 /// Returns `Eof` if no more data, `Partial` if the line lacks a trailing newline,
-/// or `Complete(bytes)` on success.
+/// `Complete(bytes)` on success, or `Oversized(bytes)` when the line exceeded
+/// [`MAX_JSONL_LINE_BYTES`] (content is discarded, reader advanced past the newline).
 pub fn read_jsonl_line(
     reader: &mut impl BufRead,
     line: &mut String,
 ) -> std::io::Result<JsonlLineState> {
     line.clear();
-    let bytes_read = reader.read_line(line)?;
+    // Read raw bytes, not via read_line: the byte cap can slice a multi-byte
+    // character, and read_line's UTF-8 validation would then return
+    // InvalidData instead of letting us classify the line as Oversized —
+    // wedging the stream at a fixed watermark.
+    let mut buf = Vec::new();
+    let bytes_read = reader
+        .by_ref()
+        .take(MAX_JSONL_LINE_BYTES)
+        .read_until(b'\n', &mut buf)?;
     if bytes_read == 0 {
         return Ok(JsonlLineState::Eof);
     }
+    if buf.last() != Some(&b'\n') && bytes_read as u64 == MAX_JSONL_LINE_BYTES {
+        // The cap was hit mid-line: discard what we buffered (no UTF-8
+        // conversion is attempted on discarded content) and skip the rest of
+        // the physical line without storing it. If EOF arrives before the
+        // newline (giant line still being written), we still report
+        // Oversized — re-reading it later would OOM anyway.
+        drop(buf);
+        let skipped = reader.skip_until(b'\n')?;
+        return Ok(JsonlLineState::Oversized(bytes_read + skipped));
+    }
+    // Same contract as read_line: non-UTF-8 content is an InvalidData error.
+    *line = String::from_utf8(buf)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
     if !line.ends_with('\n') {
         return Ok(JsonlLineState::Partial);
     }
@@ -194,5 +235,72 @@ mod tests {
 
         let r2 = read_jsonl_line(&mut reader, &mut line).unwrap();
         assert!(matches!(r2, JsonlLineState::Partial));
+    }
+
+    #[test]
+    fn test_read_jsonl_line_oversized_is_skipped_and_reader_recovers() {
+        let big = "x".repeat(MAX_JSONL_LINE_BYTES as usize + 100);
+        let data = format!("{big}\n{{\"ok\":1}}\n");
+        let mut reader = std::io::BufReader::new(data.as_bytes());
+        let mut line = String::new();
+
+        match read_jsonl_line(&mut reader, &mut line).unwrap() {
+            JsonlLineState::Oversized(consumed) => {
+                assert_eq!(consumed, big.len() + 1);
+                assert!(line.is_empty(), "oversized content must not be retained");
+            }
+            _ => panic!("expected Oversized for a line beyond MAX_JSONL_LINE_BYTES"),
+        }
+
+        match read_jsonl_line(&mut reader, &mut line).unwrap() {
+            JsonlLineState::Complete(_) => assert_eq!(line.trim_end(), "{\"ok\":1}"),
+            _ => panic!("expected the next line to parse normally"),
+        }
+    }
+
+    #[test]
+    fn test_read_jsonl_line_oversized_without_newline_at_eof() {
+        let big = "x".repeat(MAX_JSONL_LINE_BYTES as usize + 50);
+        let mut reader = std::io::BufReader::new(big.as_bytes());
+        let mut line = String::new();
+
+        match read_jsonl_line(&mut reader, &mut line).unwrap() {
+            JsonlLineState::Oversized(consumed) => assert_eq!(consumed, big.len()),
+            _ => panic!("expected Oversized even when the giant line lacks a newline"),
+        }
+    }
+
+    #[test]
+    fn test_read_jsonl_line_oversized_multibyte_at_cap_boundary() {
+        // 8 MiB is not divisible by 3, so a line of 3-byte characters
+        // guarantees the byte cap slices mid-character. The reader must
+        // classify Oversized — a read_line-based implementation returns
+        // InvalidData here and wedges the stream at a fixed watermark.
+        let euro = "€"; // 3 bytes in UTF-8
+        let big = euro.repeat((MAX_JSONL_LINE_BYTES as usize / 3) + 50);
+        let data = format!("{big}\n{{\"ok\":1}}\n");
+        let mut reader = std::io::BufReader::new(data.as_bytes());
+        let mut line = String::new();
+
+        match read_jsonl_line(&mut reader, &mut line).unwrap() {
+            JsonlLineState::Oversized(consumed) => assert_eq!(consumed, big.len() + 1),
+            _ => panic!("expected Oversized for a multi-byte giant line"),
+        }
+
+        match read_jsonl_line(&mut reader, &mut line).unwrap() {
+            JsonlLineState::Complete(_) => assert_eq!(line.trim_end(), "{\"ok\":1}"),
+            _ => panic!("expected the next line to parse normally"),
+        }
+    }
+
+    #[test]
+    fn test_read_jsonl_line_invalid_utf8_within_cap_still_errors() {
+        // Non-UTF-8 content on a normal-sized line keeps read_line's
+        // InvalidData contract.
+        let data: &[u8] = b"\xff\xfe bad bytes\n";
+        let mut reader = std::io::BufReader::new(data);
+        let mut line = String::new();
+        let err = read_jsonl_line(&mut reader, &mut line).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
     }
 }


### PR DESCRIPTION
Part **3/7** of the #2244 stack.

`read_json_line` buffered socket lines of unbounded length. Lines beyond 4 MiB are now discarded without buffering (byte-based, same multi-byte-safety rationale as 1/7). The control loop **answers** an oversized request with an error response - silently eating it would stall the client until its socket timeout, after which it reconnects and resends the same request forever. The trace loop skips and keeps reading.

**Depends on #2246** (stacked; review the **last commit only** for this part's diff).

## Stack

1. #2245 - streams: cap JSONL line size and transcript batch bytes
2. #2246 - daemon: serialize transcript metric events incrementally
3. #2247 - daemon: cap control/trace socket line size
4. #2248 - daemon: advance stream watermark before batch processing
5. #2249 - daemon: memory watchdog decides on current RSS, not lifetime peak
6. #2250 - daemon: never defer self-restart while processing is stalled
7. #2251 - streams: cap the initial backfill of first-seen stream files

Each PR targets `main`; the incremental diff of part N is its last commit. Root-cause analysis, production evidence, and the repro live in #2244.

## Verification

- Deterministic repro from #2244 (315 MB synthetic Cursor transcript + one commit, 384 MB
  daemon memory limit): unpatched v1.6.24 aborts in ~1 s and re-aborts after respawn
  (watermark 0); with the full stack the daemon survives, **peak RSS 76 MB vs 589 MB**,
  zero memory emergencies, traced-git probes at 0.05-0.07 s throughout.
- `cargo fmt --check` clean; `cargo test --lib`: 2,401 passed. Three failures
  (`commands::upgrade::...pending_update`, `daemon::...conflict_resolution_note_read_errors...`,
  `git::authorship_traversal::...ai_touched_files...`) reproduce identically on clean `main`
  in this environment - pre-existing, unrelated.
