### PR TITLE
perf(token-usage): hold the sweep duty cycle across small files, emission, and reconcile

### DIFF
--- a/docs/token-usage-events-spec.md
+++ b/docs/token-usage-events-spec.md
@@ -70,8 +70,10 @@ Driven by `TokenUsageWorker` (`src/daemon/token_usage_worker.rs`):
   dedup would re-count that history on every resume. When a replacement moves
   an entry between sessions, the previous owner is durably flagged
   (`needs_reconcile`, in the same transaction) and re-reconciled DB-only —
-  inline after the pass and from sweeps for crash recovery — so the
-  correction lands even if that session's transcripts were deleted. Entries
+  inline after a notification-driven pass (so the drain barrier reflects the
+  move), and for sweep passes once the backlog drains plus on every sweep
+  tick (crash recovery), throttled like all sweep work — so the correction
+  lands even if that session's transcripts were deleted. Entries
   older than the 90-day retention window are dropped at insert (backfill
   never uploads history the prune would delete), and stored entries/bucket
   state are pruned atomically on sweep.

--- a/src/daemon/telemetry_worker.rs
+++ b/src/daemon/telemetry_worker.rs
@@ -932,11 +932,14 @@ fn flush_metrics(events: &[MetricEvent], pace: bool) {
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
 
     for chunk in events.chunks(MAX_METRICS_PER_ENVELOPE) {
-        let chunk_started = std::time::Instant::now();
+        let store_started = std::time::Instant::now();
         if let Err(e) = store_metrics_in_db(chunk) {
             tracing::warn!(%e, "telemetry: failed to persist metrics before upload");
             continue;
         }
+        // Only the store is charged here: the drain below paces itself, and
+        // wrapping it would bill its own pauses as fresh work.
+        pace_background_flush(pace, store_started.elapsed());
 
         if should_upload && !upload_failed && std::time::Instant::now() < deadline {
             match flush_pending_metrics_from_db(&client, deadline, pace) {
@@ -947,7 +950,6 @@ fn flush_metrics(events: &[MetricEvent], pace: bool) {
                 }
             }
         }
-        pace_background_flush(pace, chunk_started.elapsed());
     }
 }
 
@@ -972,8 +974,10 @@ fn flush_pending_metrics(pace: bool) {
 }
 
 /// Sleep out a paced flush segment's pause: the same shared ledger and duty
-/// cycle as the token sweep, with the pause additionally capped so an
-/// awaited flush arriving behind a paced drain is not held long.
+/// cycle as the token sweep. The sleep is capped so an awaited flush
+/// arriving behind a paced drain is not held long; the capped remainder is
+/// not forgiven — the ledger reservation stands and the next background
+/// segment (either pipeline) waits it out.
 fn pace_background_flush(pace: bool, work: std::time::Duration) {
     const MAX_FLUSH_PAUSE: std::time::Duration = std::time::Duration::from_secs(1);
     if !pace {
@@ -1100,17 +1104,21 @@ where
     // A paced (periodic, background) drain processes a bounded slice of the
     // backlog per flush cycle: pending rows are durable, the next tick (3s)
     // resumes, and an awaited flush never queues behind a long paced drain.
-    // Paced batches are also smaller: each iteration's live set (dequeued
-    // rows, parsed events, serialized envelope) sets the process's RSS
-    // high-water mark, which a background drain must keep low — an awaited
-    // flush keeps the full envelope size.
+    // The cap counts iterations, not uploads — a backlog of filtered or
+    // malformed records must not loop unpaced to the deadline. Paced batches
+    // are also smaller: each iteration's live set (dequeued rows, parsed
+    // events, serialized envelope) sets the process's RSS high-water mark,
+    // which a background drain must keep low — an awaited flush keeps the
+    // full envelope size.
     const MAX_PACED_BATCHES_PER_CYCLE: usize = 16;
     const PACED_BATCH_SIZE: usize = 250;
+    let mut iterations = 0usize;
 
     while std::time::Instant::now() < budget.deadline {
-        if budget.paced && result.uploaded_batches >= MAX_PACED_BATCHES_PER_CYCLE {
+        if budget.paced && iterations >= MAX_PACED_BATCHES_PER_CYCLE {
             break;
         }
+        iterations += 1;
         let batch_started = std::time::Instant::now();
         let batch_size = if budget.paced {
             budget.max_batch_size.min(PACED_BATCH_SIZE)
@@ -1152,6 +1160,7 @@ where
         }
 
         if events.is_empty() {
+            pace_background_flush(budget.paced, batch_started.elapsed());
             continue;
         }
 
@@ -2198,6 +2207,58 @@ mod tests {
         let drained = run(false);
         assert_eq!(drained.uploaded_batches, 4, "unpaced drain runs dry");
         assert_eq!(db.borrow().count().unwrap(), 0);
+    }
+
+    #[test]
+    fn paced_flush_caps_iterations_even_when_nothing_uploads() {
+        // A backlog of malformed records uploads nothing, so a cap counted
+        // in uploaded batches would never trip and the drain would loop
+        // unpaced to its 30s deadline. The cap counts iterations.
+        let (metrics_db, _metrics_db_dir) = MetricsDatabase::new_temp_for_tests().unwrap();
+        let db = Rc::new(RefCell::new(metrics_db));
+        let rows: Vec<String> = (0..20).map(|_| "not json".to_string()).collect();
+        db.borrow_mut().insert_events(&rows).unwrap();
+
+        let result = flush_pending_metric_records_with(
+            {
+                let db = Rc::clone(&db);
+                move |limit| db.borrow_mut().dequeue_pending_batch(limit)
+            },
+            {
+                let db = Rc::clone(&db);
+                move |ids| db.borrow_mut().mark_records_delivered(ids, unix_now())
+            },
+            {
+                let db = Rc::clone(&db);
+                move |ids, err| {
+                    let now = unix_now();
+                    db.borrow_mut()
+                        .mark_records_failed(ids, &err.to_string(), now)
+                }
+            },
+            {
+                let db = Rc::clone(&db);
+                move |records| {
+                    db.borrow_mut()
+                        .mark_records_undeliverable(records, unix_now())
+                }
+            },
+            |_batch| Ok(MetricsUploadResponse { errors: vec![] }),
+            PendingFlushBudget {
+                deadline: std::time::Instant::now() + std::time::Duration::from_secs(60),
+                max_batch_size: 1,
+                paced: true,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(result.uploaded_batches, 0);
+        assert_eq!(result.invalid_records, 16, "one invalid row per iteration");
+        assert_eq!(
+            db.borrow().count().unwrap(),
+            4,
+            "the rest waits for the next cycle"
+        );
     }
 
     #[test]

--- a/src/daemon/telemetry_worker.rs
+++ b/src/daemon/telemetry_worker.rs
@@ -749,10 +749,15 @@ async fn telemetry_flush_loop(
         let flush_result = tokio::task::spawn_blocking(move || {
             #[cfg(feature = "test-support")]
             maybe_stall_telemetry_upload_for_test();
+            // Periodic flushes pace their metrics work against the shared
+            // background-work ledger (the token sweep charges the same one),
+            // so a backfill's emission volume cannot saturate cores; awaited
+            // flushes drain at full speed for the `git-ai await` barrier.
+            let pace = flush_mode == FlushMode::Periodic;
             let requeue_daemon_logs = if let Some(snapshot) = snapshot {
-                flush_telemetry_batch(snapshot, &daemon_id_for_flush)
+                flush_telemetry_batch(snapshot, &daemon_id_for_flush, pace)
             } else {
-                flush_pending_metrics();
+                flush_pending_metrics(pace);
                 Vec::new()
             };
             let await_status = collect_await_flush_status(flush_mode);
@@ -830,13 +835,17 @@ fn maybe_stall_telemetry_upload_for_test() {
     }
 }
 
-fn flush_telemetry_batch(batch: TelemetryBuffer, daemon_id: &str) -> Vec<DaemonLogEvent> {
+fn flush_telemetry_batch(
+    batch: TelemetryBuffer,
+    daemon_id: &str,
+    pace: bool,
+) -> Vec<DaemonLogEvent> {
     let config = Config::get();
     let distinct_id = get_or_create_distinct_id();
 
     // Flush metrics (always processed — uploaded or stored in SQLite)
     if !batch.metrics.is_empty() {
-        flush_metrics(&batch.metrics);
+        flush_metrics(&batch.metrics, pace);
     }
 
     // Flush Sentry events (errors, performance, messages)
@@ -861,7 +870,7 @@ fn flush_telemetry_batch(batch: TelemetryBuffer, daemon_id: &str) -> Vec<DaemonL
     // Flush pending notes (reads directly from notes-db; no-op when kind != Http).
     flush_notes();
 
-    flush_pending_metrics();
+    flush_pending_metrics(pace);
 
     if batch.daemon_logs.is_empty() {
         Vec::new()
@@ -911,7 +920,7 @@ fn count_pending_metrics_for_await() -> usize {
         .unwrap_or(0)
 }
 
-fn flush_metrics(events: &[MetricEvent]) {
+fn flush_metrics(events: &[MetricEvent], pace: bool) {
     let context = ApiContext::new(None);
     let api_base_url = context.base_url.clone();
     let client = ApiClient::new(context);
@@ -923,13 +932,14 @@ fn flush_metrics(events: &[MetricEvent]) {
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
 
     for chunk in events.chunks(MAX_METRICS_PER_ENVELOPE) {
+        let chunk_started = std::time::Instant::now();
         if let Err(e) = store_metrics_in_db(chunk) {
             tracing::warn!(%e, "telemetry: failed to persist metrics before upload");
             continue;
         }
 
         if should_upload && !upload_failed && std::time::Instant::now() < deadline {
-            match flush_pending_metrics_from_db(&client, deadline) {
+            match flush_pending_metrics_from_db(&client, deadline, pace) {
                 Ok(_) => {}
                 Err(e) => {
                     tracing::warn!(%e, "telemetry: failed to upload pending metrics");
@@ -937,10 +947,11 @@ fn flush_metrics(events: &[MetricEvent]) {
                 }
             }
         }
+        pace_background_flush(pace, chunk_started.elapsed());
     }
 }
 
-fn flush_pending_metrics() {
+fn flush_pending_metrics(pace: bool) {
     let context = ApiContext::new(None);
     let api_base_url = context.base_url.clone();
     let client = ApiClient::new(context);
@@ -955,8 +966,22 @@ fn flush_pending_metrics() {
     }
 
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
-    if let Err(e) = flush_pending_metrics_from_db(&client, deadline) {
+    if let Err(e) = flush_pending_metrics_from_db(&client, deadline, pace) {
         tracing::warn!(%e, "telemetry: failed to upload pending metrics");
+    }
+}
+
+/// Sleep out a paced flush segment's pause: the same shared ledger and duty
+/// cycle as the token sweep, with the pause additionally capped so an
+/// awaited flush arriving behind a paced drain is not held long.
+fn pace_background_flush(pace: bool, work: std::time::Duration) {
+    const MAX_FLUSH_PAUSE: std::time::Duration = std::time::Duration::from_secs(1);
+    if !pace {
+        return;
+    }
+    let pause = crate::daemon::token_usage_worker::background_work_pause(work).min(MAX_FLUSH_PAUSE);
+    if !pause.is_zero() {
+        std::thread::sleep(pause);
     }
 }
 
@@ -981,6 +1006,14 @@ fn store_metrics_in_db(events: &[MetricEvent]) -> Result<Vec<i64>, GitAiError> {
     db_lock.insert_events(&event_jsons)
 }
 
+/// How much of the pending backlog one flush invocation may drain, and
+/// whether it paces itself against the shared background-work ledger.
+struct PendingFlushBudget {
+    deadline: std::time::Instant,
+    max_batch_size: usize,
+    paced: bool,
+}
+
 #[derive(Debug, Default, PartialEq, Eq)]
 struct PendingMetricsFlushResult {
     uploaded_events: usize,
@@ -991,6 +1024,7 @@ struct PendingMetricsFlushResult {
 fn flush_pending_metrics_from_db(
     client: &ApiClient,
     deadline: std::time::Instant,
+    pace: bool,
 ) -> Result<PendingMetricsFlushResult, GitAiError> {
     flush_pending_metric_records_with(
         read_pending_metrics_batch,
@@ -998,8 +1032,11 @@ fn flush_pending_metrics_from_db(
         mark_metric_records_failed,
         mark_metric_records_undeliverable,
         |batch| client.upload_metrics(batch),
-        deadline,
-        MAX_METRICS_PER_ENVELOPE,
+        PendingFlushBudget {
+            deadline,
+            max_batch_size: MAX_METRICS_PER_ENVELOPE,
+            paced: pace,
+        },
     )
 }
 
@@ -1048,8 +1085,7 @@ fn flush_pending_metric_records_with<
     mut mark_failed: MarkFailed,
     mut mark_undeliverable: MarkUndeliverable,
     mut upload_batch: UploadBatch,
-    deadline: std::time::Instant,
-    max_batch_size: usize,
+    budget: PendingFlushBudget,
 ) -> Result<PendingMetricsFlushResult, GitAiError>
 where
     DequeueBatch: FnMut(usize) -> Result<Vec<MetricRecord>, GitAiError>,
@@ -1061,8 +1097,27 @@ where
     let mut result = PendingMetricsFlushResult::default();
     let config = Config::fresh();
 
-    while std::time::Instant::now() < deadline {
-        let batch = dequeue_batch(max_batch_size)?;
+    // A paced (periodic, background) drain processes a bounded slice of the
+    // backlog per flush cycle: pending rows are durable, the next tick (3s)
+    // resumes, and an awaited flush never queues behind a long paced drain.
+    // Paced batches are also smaller: each iteration's live set (dequeued
+    // rows, parsed events, serialized envelope) sets the process's RSS
+    // high-water mark, which a background drain must keep low — an awaited
+    // flush keeps the full envelope size.
+    const MAX_PACED_BATCHES_PER_CYCLE: usize = 16;
+    const PACED_BATCH_SIZE: usize = 250;
+
+    while std::time::Instant::now() < budget.deadline {
+        if budget.paced && result.uploaded_batches >= MAX_PACED_BATCHES_PER_CYCLE {
+            break;
+        }
+        let batch_started = std::time::Instant::now();
+        let batch_size = if budget.paced {
+            budget.max_batch_size.min(PACED_BATCH_SIZE)
+        } else {
+            budget.max_batch_size
+        };
+        let batch = dequeue_batch(batch_size)?;
         if batch.is_empty() {
             break;
         }
@@ -1161,6 +1216,7 @@ where
 
         result.uploaded_events += successful_ids.len();
         result.uploaded_batches += 1;
+        pace_background_flush(budget.paced, batch_started.elapsed());
     }
 
     Ok(result)
@@ -2065,8 +2121,11 @@ mod tests {
                     Ok(MetricsUploadResponse { errors: vec![] })
                 }
             },
-            std::time::Instant::now() + std::time::Duration::from_secs(60),
-            1,
+            PendingFlushBudget {
+                deadline: std::time::Instant::now() + std::time::Duration::from_secs(60),
+                max_batch_size: 1,
+                paced: false,
+            },
         )
         .unwrap();
 
@@ -2084,6 +2143,61 @@ mod tests {
             db.borrow().get_metric_history(0, None, &[1]).unwrap().len(),
             2
         );
+    }
+
+    #[test]
+    fn paced_flush_drains_a_bounded_slice_per_cycle() {
+        // A paced (periodic background) drain must stop after its per-cycle
+        // batch cap: pending rows are durable and resume next tick, and an
+        // awaited flush never queues behind a long paced drain. An unpaced
+        // (awaited) drain with the same backlog runs it dry.
+        let (metrics_db, _metrics_db_dir) = MetricsDatabase::new_temp_for_tests().unwrap();
+        let db = Rc::new(RefCell::new(metrics_db));
+        let events: Vec<String> = (0..20).map(|i| event_json(now_ts() - 30 + i)).collect();
+        db.borrow_mut().insert_events(&events).unwrap();
+
+        let run = |pace: bool| {
+            flush_pending_metric_records_with(
+                {
+                    let db = Rc::clone(&db);
+                    move |limit| db.borrow_mut().dequeue_pending_batch(limit)
+                },
+                {
+                    let db = Rc::clone(&db);
+                    move |ids| db.borrow_mut().mark_records_delivered(ids, unix_now())
+                },
+                {
+                    let db = Rc::clone(&db);
+                    move |ids, err| {
+                        let now = unix_now();
+                        db.borrow_mut()
+                            .mark_records_failed(ids, &err.to_string(), now)
+                    }
+                },
+                {
+                    let db = Rc::clone(&db);
+                    move |records| {
+                        db.borrow_mut()
+                            .mark_records_undeliverable(records, unix_now())
+                    }
+                },
+                |_batch| Ok(MetricsUploadResponse { errors: vec![] }),
+                PendingFlushBudget {
+                    deadline: std::time::Instant::now() + std::time::Duration::from_secs(60),
+                    max_batch_size: 1,
+                    paced: pace,
+                },
+            )
+            .unwrap()
+        };
+
+        let paced = run(true);
+        assert_eq!(paced.uploaded_batches, 16, "paced cycle stops at its cap");
+        assert_eq!(db.borrow().count().unwrap(), 4, "the rest stays pending");
+
+        let drained = run(false);
+        assert_eq!(drained.uploaded_batches, 4, "unpaced drain runs dry");
+        assert_eq!(db.borrow().count().unwrap(), 0);
     }
 
     #[test]
@@ -2129,8 +2243,11 @@ mod tests {
                     Ok(MetricsUploadResponse { errors: vec![] })
                 }
             },
-            std::time::Instant::now() + std::time::Duration::from_secs(60),
-            10,
+            PendingFlushBudget {
+                deadline: std::time::Instant::now() + std::time::Duration::from_secs(60),
+                max_batch_size: 10,
+                paced: false,
+            },
         )
         .unwrap();
 
@@ -2200,8 +2317,11 @@ mod tests {
                     })
                 }
             },
-            std::time::Instant::now() + std::time::Duration::from_secs(60),
-            10,
+            PendingFlushBudget {
+                deadline: std::time::Instant::now() + std::time::Duration::from_secs(60),
+                max_batch_size: 10,
+                paced: false,
+            },
         )
         .unwrap();
 
@@ -2276,8 +2396,11 @@ mod tests {
                     ],
                 })
             },
-            std::time::Instant::now() + std::time::Duration::from_secs(60),
-            10,
+            PendingFlushBudget {
+                deadline: std::time::Instant::now() + std::time::Duration::from_secs(60),
+                max_batch_size: 10,
+                paced: false,
+            },
         )
         .unwrap();
 
@@ -2343,8 +2466,11 @@ mod tests {
                     }],
                 })
             },
-            std::time::Instant::now() + std::time::Duration::from_secs(60),
-            10,
+            PendingFlushBudget {
+                deadline: std::time::Instant::now() + std::time::Duration::from_secs(60),
+                max_batch_size: 10,
+                paced: false,
+            },
         );
 
         assert!(result.is_err());
@@ -2388,8 +2514,11 @@ mod tests {
                 }
             },
             |_batch| Err(GitAiError::Generic("upload failed".to_string())),
-            std::time::Instant::now() + std::time::Duration::from_secs(60),
-            10,
+            PendingFlushBudget {
+                deadline: std::time::Instant::now() + std::time::Duration::from_secs(60),
+                max_batch_size: 10,
+                paced: false,
+            },
         );
 
         assert!(result.is_err());
@@ -2431,8 +2560,11 @@ mod tests {
                 }
             },
             |_batch| Err(GitAiError::Generic("upload failed".to_string())),
-            std::time::Instant::now() + std::time::Duration::from_secs(60),
-            1,
+            PendingFlushBudget {
+                deadline: std::time::Instant::now() + std::time::Duration::from_secs(60),
+                max_batch_size: 1,
+                paced: false,
+            },
         );
         assert!(failed.is_err());
         assert_eq!(db.borrow().count_retryable().unwrap(), 0);
@@ -2477,8 +2609,11 @@ mod tests {
                     Ok(MetricsUploadResponse { errors: vec![] })
                 }
             },
-            std::time::Instant::now() + std::time::Duration::from_secs(60),
-            1,
+            PendingFlushBudget {
+                deadline: std::time::Instant::now() + std::time::Duration::from_secs(60),
+                max_batch_size: 1,
+                paced: false,
+            },
         )
         .unwrap();
 

--- a/src/daemon/token_usage_worker.rs
+++ b/src/daemon/token_usage_worker.rs
@@ -108,6 +108,26 @@ const THROTTLE_MIN_WORK: Duration = Duration::from_millis(5);
 /// unpaid stays on the ledger.
 const THROTTLE_MAX_PAUSE: Duration = Duration::from_secs(5);
 
+/// One process-wide ledger for all paced background work: the sweep's
+/// parse/emit segments and the telemetry worker's background metrics flush
+/// charge the same debt, so their combined CPU holds the duty cycle instead
+/// of each pipeline claiming 30% on its own thread. Notify-origin passes and
+/// awaited flushes never charge it.
+static BACKGROUND_WORK_DEBT: std::sync::Mutex<Duration> = std::sync::Mutex::new(Duration::ZERO);
+
+/// Charge `work` to the shared background ledger and return the pause owed.
+pub(crate) fn background_work_pause(work: Duration) -> Duration {
+    let mut debt = BACKGROUND_WORK_DEBT
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    settle_throttle_debt(&mut debt, work)
+}
+
+/// Cap on one batch's wall time: a slow-disk batch pauses (and observes
+/// shutdown) at this cadence instead of only at the byte/entry bounds, so a
+/// one-second window never holds much more work than the duty cycle allows.
+const BATCH_MAX_SEGMENT: Duration = Duration::from_millis(150);
+
 /// Add `work` to the debt ledger and settle it into the pause now owed.
 /// Debt the returned pause does not cover (the floor or the cap) carries to
 /// the next settlement, so the duty cycle holds across many small segments,
@@ -222,7 +242,6 @@ pub fn spawn_token_usage_worker(
         sweep_queue: VecDeque::new(),
         queued: HashSet::new(),
         sweep_interval: Duration::from_secs(30 * 60),
-        throttle_debt: Arc::new(std::sync::Mutex::new(Duration::ZERO)),
         #[cfg(test)]
         test_sink: None,
         #[cfg(test)]
@@ -252,9 +271,6 @@ struct TokenUsageWorker {
     queued: HashSet<TokenUsageTask>,
     /// 30 minutes in production; injectable so tests can drive the ticker.
     sweep_interval: Duration,
-    /// Sweep-work debt ledger shared by every throttled segment (see
-    /// `settle_throttle_debt`); carried across batches, files, and tasks.
-    throttle_debt: Arc<std::sync::Mutex<Duration>>,
     /// Test-only event capture: the metrics DB is a process-lifetime
     /// singleton, so run()-level tests inject a sink instead of a real
     /// telemetry handle.
@@ -518,7 +534,6 @@ impl TokenUsageWorker {
     /// wall-clock waits.
     fn make_throttle(&self) -> impl Fn(Duration) + Send + Sync + use<> {
         let shutdown_flag = self.shutdown_flag.clone();
-        let debt = self.throttle_debt.clone();
         #[cfg(test)]
         let test_throttle = self.test_throttle.clone();
         move |work: Duration| {
@@ -527,11 +542,7 @@ impl TokenUsageWorker {
                 throttle(work);
                 return;
             }
-            let pause = {
-                let mut debt = debt.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
-                settle_throttle_debt(&mut debt, work)
-            };
-            throttle_sleep(pause, &shutdown_flag);
+            throttle_sleep(background_work_pause(work), &shutdown_flag);
         }
     }
 
@@ -1139,7 +1150,10 @@ fn process_file(
                         entries.extend(extractor.extract_line(trimmed));
                         serve_parent_request(&mut extractor);
                     }
-                    if entries.len() >= BATCH_MAX_ENTRIES || consumed >= BATCH_MAX_BYTES {
+                    if entries.len() >= BATCH_MAX_ENTRIES
+                        || consumed >= BATCH_MAX_BYTES
+                        || batch_started.elapsed() >= BATCH_MAX_SEGMENT
+                    {
                         break;
                     }
                 }
@@ -2407,7 +2421,6 @@ mod tests {
             sweep_queue: VecDeque::new(),
             queued: HashSet::new(),
             sweep_interval: Duration::from_secs(600),
-            throttle_debt: Arc::new(std::sync::Mutex::new(Duration::ZERO)),
             test_sink: Some(sink),
             test_throttle: Some(Arc::new(|_| {})),
         };
@@ -2530,7 +2543,6 @@ mod tests {
             sweep_queue: VecDeque::new(),
             queued: HashSet::new(),
             sweep_interval: Duration::from_secs(30 * 60),
-            throttle_debt: Arc::new(std::sync::Mutex::new(Duration::ZERO)),
             test_sink: None,
             test_throttle: None,
         }
@@ -2997,7 +3009,6 @@ mod tests {
             sweep_queue: VecDeque::new(),
             queued: HashSet::new(),
             sweep_interval,
-            throttle_debt: Arc::new(std::sync::Mutex::new(Duration::ZERO)),
             test_sink: Some(sink),
             test_throttle,
         };

--- a/src/daemon/token_usage_worker.rs
+++ b/src/daemon/token_usage_worker.rs
@@ -103,9 +103,10 @@ const THROTTLE_DUTY_PERCENT: u32 = 30;
 /// all and run at full speed — the floor only batches sleeps, it must not
 /// forgive work.
 const THROTTLE_MIN_WORK: Duration = Duration::from_millis(5);
-/// Upper bound on a single pause (guards pathologically slow segments, and
-/// bounds how long a pass can delay a drain or shutdown). Work the cap left
-/// unpaid stays on the ledger.
+/// Upper bound on a single pause AND on one caller's total wait including
+/// reservations queued by other pipelines (guards pathologically slow
+/// segments, and bounds how long a pass can delay a drain or shutdown).
+/// Work the cap left unpaid stays on the ledger.
 const THROTTLE_MAX_PAUSE: Duration = Duration::from_secs(5);
 
 /// One process-wide ledger for all paced background work: the sweep's
@@ -146,13 +147,26 @@ fn reserve_background_pause(
     let mut ledger = ledger
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
-    let pause = settle_throttle_debt(&mut ledger.debt, work);
+    let pause_owed = settle_throttle_debt(&mut ledger.debt, work);
     let now = std::time::Instant::now();
     let start = match ledger.paused_until {
         Some(reserved) if reserved > now => reserved,
         _ => now,
     };
-    let end = start + pause;
+    // No caller — queued reservations included — waits past this horizon:
+    // fresh notifications and drains sit behind at most one capped pause.
+    // The pause that does not fit is not forgiven: its work equivalent is
+    // refunded to the debt ledger and a later settlement pays it.
+    let horizon = now + THROTTLE_MAX_PAUSE;
+    let room = horizon.saturating_duration_since(start);
+    let granted = pause_owed.min(room);
+    let refused = pause_owed.saturating_sub(granted);
+    if !refused.is_zero() {
+        ledger.debt = ledger.debt.saturating_add(
+            refused.saturating_mul(THROTTLE_DUTY_PERCENT) / (100 - THROTTLE_DUTY_PERCENT),
+        );
+    }
+    let end = start + granted;
     if end > now {
         ledger.paused_until = Some(end);
     }
@@ -373,28 +387,7 @@ impl TokenUsageWorker {
                     }
                     if let Some((task, origin)) = self.pop_next() {
                         self.process_task(task, origin).await;
-                        // Sweep tasks defer cross-session reconciliation (a
-                        // notify task settles all flags inline for the drain
-                        // barrier): settle once the backlog drains, instead
-                        // of re-aggregating the flagged sessions after every
-                        // file of a large backfill. Ingest what arrived
-                        // during the pass first — traffic sitting in the
-                        // channels must not wait behind even one throttled
-                        // reconcile step. Runs after notify tasks too: their
-                        // inline reconcile normally leaves nothing (this is
-                        // then one SELECT), but flags left by a FAILED
-                        // inline pass must not wait for the next 30-minute
-                        // sweep tick.
-                        while let Ok(task) = self.notify_rx.try_recv() {
-                            self.enqueue_notify(task);
-                        }
-                        if self.notify_queue.is_empty()
-                            && self.sweep_queue.is_empty()
-                            && self.drain_rx.is_empty()
-                            && !self.shutdown_flag.load(Ordering::Relaxed)
-                        {
-                            self.reconcile_flagged().await;
-                        }
+                        self.settle_flags_if_drained().await;
                     }
                 }
                 _ = sweep_ticker.tick() => {
@@ -410,6 +403,10 @@ impl TokenUsageWorker {
                 }
                 Some(request) = self.drain_rx.recv() => {
                     self.handle_drain(request).await;
+                    // A drain that arrived as the last sweep task finished
+                    // suppressed that task's deferred reconcile; settle now
+                    // rather than waiting for the next sweep tick.
+                    self.settle_flags_if_drained().await;
                 }
             }
         }
@@ -515,6 +512,29 @@ impl TokenUsageWorker {
         }
         for task in tasks {
             self.enqueue_sweep(task);
+        }
+    }
+
+    /// Settle deferred cross-session reconcile flags once the backlog is
+    /// drained. Sweep tasks defer reconciliation (a notify task settles all
+    /// flags inline for the drain barrier): settling once the backlog
+    /// drains re-aggregates each flagged session once instead of after
+    /// every file of a large backfill. Pending channel traffic is ingested
+    /// first — it must not wait behind even one throttled reconcile step.
+    /// Also runs after notify tasks and drains: their inline reconciles
+    /// normally leave nothing (this is then one SELECT), but flags left by
+    /// a FAILED inline pass must not wait for the next 30-minute sweep
+    /// tick.
+    async fn settle_flags_if_drained(&mut self) {
+        while let Ok(task) = self.notify_rx.try_recv() {
+            self.enqueue_notify(task);
+        }
+        if self.notify_queue.is_empty()
+            && self.sweep_queue.is_empty()
+            && self.drain_rx.is_empty()
+            && !self.shutdown_flag.load(Ordering::Relaxed)
+        {
+            self.reconcile_flagged().await;
         }
     }
 
@@ -2780,6 +2800,33 @@ mod tests {
         assert!(
             remainder >= Duration::from_millis(1350),
             "reservation persists: {remainder:?}"
+        );
+    }
+
+    #[test]
+    fn no_caller_waits_past_the_pause_cap_and_refused_pause_stays_owed() {
+        // Stacked reservations must not make one sweep sleep exceed the cap
+        // (fresh notifications and drains wait behind at most one capped
+        // pause), and pause that does not fit the horizon is refunded to
+        // the debt ledger rather than forgiven.
+        let ledger = std::sync::Mutex::new(BackgroundLedger {
+            debt: Duration::ZERO,
+            paused_until: None,
+        });
+        for _ in 0..4 {
+            let wait = reserve_background_pause(&ledger, Duration::from_secs(30));
+            assert!(
+                wait <= THROTTLE_MAX_PAUSE,
+                "wait bounded by the cap: {wait:?}"
+            );
+        }
+        // 120s of work owes ~280s of pause; the horizon granted at most 5s.
+        // The refused remainder must survive as debt: even with no new
+        // work, settlements keep owing full capped pauses.
+        let debt = ledger.lock().unwrap().debt;
+        assert!(
+            debt >= Duration::from_secs(100),
+            "refused pause refunded as debt: {debt:?}"
         );
     }
 

--- a/src/daemon/token_usage_worker.rs
+++ b/src/daemon/token_usage_worker.rs
@@ -402,11 +402,10 @@ impl TokenUsageWorker {
                     self.enqueue_notify(task);
                 }
                 Some(request) = self.drain_rx.recv() => {
+                    // handle_drain settles reconcile flags before its ack,
+                    // which also covers flags whose deferred settle a
+                    // pending drain suppressed in the ready-task arm.
                     self.handle_drain(request).await;
-                    // A drain that arrived as the last sweep task finished
-                    // suppressed that task's deferred reconcile; settle now
-                    // rather than waiting for the next sweep tick.
-                    self.settle_flags_if_drained().await;
                 }
             }
         }
@@ -425,6 +424,19 @@ impl TokenUsageWorker {
                 break;
             }
         }
+        // Settle reconcile flags BEFORE acknowledging, unthrottled like all
+        // barrier work: a notify task's inline reconcile can fail
+        // transiently, and the barrier must not report success while a
+        // correction it produced is still pending. Normally one SELECT; a
+        // failure here leaves the durable flags for the next trigger.
+        let token_db = self.token_db.clone();
+        let sink = self.make_sink();
+        let _ = tokio::task::spawn_blocking(move || {
+            if let Err(e) = reconcile_flagged_sessions(&token_db, &sink) {
+                tracing::warn!(error = %e, "token-usage reconcile before drain ack failed; flags retained for retry");
+            }
+        })
+        .await;
         let _ = request.completion.send(());
     }
 
@@ -2501,6 +2513,66 @@ mod tests {
         worker.notify_rx.try_recv().unwrap();
         worker.reconcile_flagged().await;
         assert!(token_db.sessions_needing_reconcile().unwrap().is_empty());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn drain_settles_reconcile_flags_before_acknowledging() {
+        // The barrier must not report success while corrections are still
+        // pending: flags left over (e.g. by a failed inline pass, or by a
+        // deferred sweep settle a pending drain suppressed) are settled
+        // before the drain acknowledgment, so by the time `git-ai await`
+        // returns, the corrections are in the sink.
+        let dir = tempfile::tempdir().unwrap();
+        let streams_db =
+            Arc::new(StreamsDatabase::open(dir.path().join("transcripts-db")).unwrap());
+        let token_db =
+            Arc::new(TokenUsageDatabase::open(dir.path().join("token-usage-db")).unwrap());
+        let base = dir.path().join("base.jsonl");
+        fs::write(
+            &base,
+            format!("{}\n", claude_line("m1", "r1", &recent_ts(1, 0), 50)),
+        )
+        .unwrap();
+        let resume = dir.path().join("resume.jsonl");
+        fs::write(
+            &resume,
+            format!("{}\n", claude_line("m1", "r1", &recent_ts(1, 30), 90)),
+        )
+        .unwrap();
+        let identity_base = SessionIdentity {
+            session_id: "s_base".to_string(),
+            external_session_id: "s_base-ext".to_string(),
+            external_parent_session_id: None,
+            tool: "claude".to_string(),
+        };
+        let identity_resume = SessionIdentity {
+            session_id: "s_resume".to_string(),
+            external_session_id: "s_resume-ext".to_string(),
+            external_parent_session_id: None,
+            tool: "claude".to_string(),
+        };
+        run_as(&token_db, &identity_base, &base).unwrap();
+        run_as(&token_db, &identity_resume, &resume).unwrap();
+        // The replacement left s_base flagged (run_as never reconciles).
+        assert_eq!(token_db.sessions_needing_reconcile().unwrap().len(), 1);
+
+        let (collected, sink) = collecting_sink();
+        let (handle, shutdown) = spawn_run_loop(
+            streams_db.clone(),
+            token_db.clone(),
+            sink,
+            Duration::from_secs(600),
+        );
+        handle.drain().await.unwrap();
+        // The ack has been received: the flag is already settled and the
+        // correction already handed to the sink.
+        assert!(token_db.sessions_needing_reconcile().unwrap().is_empty());
+        let corrected = collected.lock().unwrap().iter().any(|e| {
+            EventAttributes::from_sparse(&e.attrs).session_id == Some(Some("s_base".to_string()))
+                && value_u64(e, token_usage_pos::TOTAL_TOKENS) == Some(0)
+        });
+        assert!(corrected, "correction emitted before the drain ack");
+        shutdown.notify_one();
     }
 
     #[test]

--- a/src/daemon/token_usage_worker.rs
+++ b/src/daemon/token_usage_worker.rs
@@ -3394,4 +3394,322 @@ mod tests {
             .collect();
         println!("duty/s: {}", timeline.join(" "));
     }
+
+    /// CPU/RSS profile over a small number of GIANT transcripts (500MB-2GB
+    /// each, ~8GB total), the complement of `bench_backfill_cpu_duty`'s
+    /// many-small-files corpus: single-file batch chains hundreds of
+    /// batches long, a fork prefix streamed from a 1GB parent, a resume
+    /// copy flagging a giant session, and pathological single lines (100MB
+    /// unmatched, 50MB matching the usage prefilter) that bound the line
+    /// buffer and parse allocations. Ignored: needs ~8GB free in the temp
+    /// dir; run manually with NO_CAPTURE and --ignored and read the
+    /// printed duty/RSS timeline.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[ignore]
+    #[cfg(target_os = "linux")] // CPU/RSS sampling reads /proc
+    async fn bench_giant_transcripts_cpu_rss() {
+        use std::io::Write;
+
+        fn cpu_ticks() -> u64 {
+            let stat = std::fs::read_to_string("/proc/self/stat").unwrap();
+            let after = &stat[stat.rfind(')').unwrap() + 2..];
+            let fields: Vec<&str> = after.split_whitespace().collect();
+            fields[11].parse::<u64>().unwrap() + fields[12].parse::<u64>().unwrap()
+        }
+        fn rss_kb() -> u64 {
+            std::fs::read_to_string("/proc/self/status")
+                .unwrap()
+                .lines()
+                .find(|l| l.starts_with("VmRSS:"))
+                .and_then(|l| l.split_whitespace().nth(1))
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(0)
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let streams_db =
+            Arc::new(StreamsDatabase::open(dir.path().join("transcripts-db")).unwrap());
+        let token_db =
+            Arc::new(TokenUsageDatabase::open(dir.path().join("token-usage-db")).unwrap());
+
+        // ~3KB noise lines that miss each tool's prefilter.
+        let claude_noise = format!(
+            "{{\"type\":\"assistant\",\"timestamp\":\"{}\",\"content\":\"{}\"}}\n",
+            recent_ts(1, 0),
+            "n".repeat(3000)
+        );
+        let codex_noise = format!(
+            "{{\"timestamp\":\"{}\",\"type\":\"event_msg\",\"payload\":{{\"type\":\"agent_message\",\"message\":\"{}\"}}}}\n",
+            recent_ts(1, 0),
+            "n".repeat(3000)
+        );
+        let claude_usage = |sess: &str, i: usize, output: u64| {
+            let ts = recent_ts((i / 12) as u32 % 1000, (i % 12) as u32 * 5);
+            format!(
+                "{{\"timestamp\":\"{ts}\",\"sessionId\":\"ext-{sess}\",\"requestId\":\"r{sess}_{i}\",\"message\":{{\"id\":\"m{sess}_{i}\",\"model\":\"claude-sonnet-4-6-20260115\",\"usage\":{{\"input_tokens\":220,\"output_tokens\":{output},\"cache_creation_input_tokens\":40,\"cache_read_input_tokens\":18000}}}}}}\n"
+            )
+        };
+        let codex_usage = |i: usize| {
+            let base = (i as u64 + 1) * 1500;
+            format!(
+                "{}\n",
+                codex_usage_line(
+                    &recent_ts((i / 12) as u32 % 1000, (i % 12) as u32 * 5),
+                    (base, base / 3, base / 10, base / 40, base + base / 10),
+                )
+            )
+        };
+
+        // Write `target` bytes: one usage line per `interval` noise lines.
+        let write_claude_giant = |path: &std::path::Path, sess: &str, target: u64, output: u64| {
+            let mut w = std::io::BufWriter::with_capacity(
+                1024 * 1024,
+                std::fs::File::create(path).unwrap(),
+            );
+            let mut written = 0u64;
+            let mut i = 0usize;
+            while written < target {
+                for _ in 0..50 {
+                    w.write_all(claude_noise.as_bytes()).unwrap();
+                    written += claude_noise.len() as u64;
+                }
+                let usage = claude_usage(sess, i, output);
+                w.write_all(usage.as_bytes()).unwrap();
+                written += usage.len() as u64;
+                i += 1;
+            }
+            w.flush().unwrap();
+        };
+        let write_codex_giant = |path: &std::path::Path, ext_id: &str, target: u64| {
+            let mut w = std::io::BufWriter::with_capacity(
+                1024 * 1024,
+                std::fs::File::create(path).unwrap(),
+            );
+            let meta = format!("{}\n", codex_meta_line(ext_id, None, &recent_ts(0, 1)));
+            w.write_all(meta.as_bytes()).unwrap();
+            let mut written = meta.len() as u64;
+            let mut i = 0usize;
+            while written < target {
+                for _ in 0..50 {
+                    w.write_all(codex_noise.as_bytes()).unwrap();
+                    written += codex_noise.len() as u64;
+                }
+                let usage = codex_usage(i);
+                w.write_all(usage.as_bytes()).unwrap();
+                written += usage.len() as u64;
+                i += 1;
+            }
+            w.flush().unwrap();
+        };
+        let insert = |session: &str, tool: &str, path: &std::path::Path, parent: Option<&str>| {
+            let mut record = stream_record(session, tool, &path.display().to_string());
+            if let Some(parent) = parent {
+                record.external_parent_session_id = Some(parent.to_string());
+            }
+            streams_db.insert_stream(&record).unwrap();
+        };
+
+        const GB: u64 = 1024 * 1024 * 1024;
+        const MB: u64 = 1024 * 1024;
+        let gen_started = std::time::Instant::now();
+
+        for (name, size) in [
+            ("g0", 2 * GB),
+            ("g1", GB),
+            ("g2", 800 * MB),
+            ("g3", 500 * MB),
+        ] {
+            let path = dir.path().join(format!("claude-{name}.jsonl"));
+            write_claude_giant(&path, name, size, 900);
+            insert(&format!("s_claude_{name}"), "claude", &path, None);
+        }
+
+        // Pathological single lines: a 100MB line missing the prefilter and
+        // a 50MB line matching it (a real usage object at the end), inside a
+        // 500MB file of normal traffic.
+        {
+            let path = dir.path().join("claude-hugeline.jsonl");
+            write_claude_giant(&path, "hl", 350 * MB, 900);
+            let mut w = std::fs::OpenOptions::new()
+                .append(true)
+                .open(&path)
+                .unwrap();
+            let unmatched = format!(
+                "{{\"type\":\"assistant\",\"content\":\"{}\"}}\n",
+                "x".repeat(100 * MB as usize)
+            );
+            w.write_all(unmatched.as_bytes()).unwrap();
+            drop(unmatched);
+            let matched = format!(
+                "{{\"timestamp\":\"{}\",\"sessionId\":\"ext-hl\",\"requestId\":\"rhl_huge\",\"filler\":\"{}\",\"message\":{{\"id\":\"mhl_huge\",\"model\":\"claude-sonnet-4-6-20260115\",\"usage\":{{\"input_tokens\":220,\"output_tokens\":900,\"cache_creation_input_tokens\":40,\"cache_read_input_tokens\":18000}}}}}}\n",
+                recent_ts(999, 0),
+                "y".repeat(50 * MB as usize)
+            );
+            w.write_all(matched.as_bytes()).unwrap();
+            w.flush().unwrap();
+            insert("s_claude_hl", "claude", &path, None);
+        }
+
+        // Resume copy of the 2GB giant's usage with larger totals: every
+        // duplicated id replaces g0's row and flags a ~14k-entry session.
+        {
+            let path = dir.path().join("claude-resume-g0.jsonl");
+            let mut w = std::io::BufWriter::with_capacity(
+                1024 * 1024,
+                std::fs::File::create(&path).unwrap(),
+            );
+            let mut written = 0u64;
+            let mut i = 0usize;
+            while written < 500 * MB {
+                for _ in 0..50 {
+                    w.write_all(claude_noise.as_bytes()).unwrap();
+                    written += claude_noise.len() as u64;
+                }
+                let usage = claude_usage("g0", i, 910);
+                w.write_all(usage.as_bytes()).unwrap();
+                written += usage.len() as u64;
+                i += 1;
+            }
+            w.flush().unwrap();
+            insert("s_claude_resume", "claude", &path, None);
+        }
+
+        for (name, size) in [("cg0", GB), ("cg1", 700 * MB), ("cg2", 500 * MB)] {
+            let path = dir.path().join(format!("codex-{name}.jsonl"));
+            write_codex_giant(&path, name, size);
+            insert(&format!("s_codex_{name}"), "codex", &path, None);
+        }
+
+        // A 300MB fork child of the 1GB parent: prefix resolution streams
+        // the parent up to the fork instant. The replayed head repeats the
+        // parent's first cumulative totals verbatim.
+        {
+            let path = dir.path().join("codex-fork.jsonl");
+            let mut w = std::io::BufWriter::with_capacity(
+                1024 * 1024,
+                std::fs::File::create(&path).unwrap(),
+            );
+            let meta = format!(
+                "{}\n",
+                codex_meta_line("fork-child", Some("cg0"), &recent_ts(1100, 0))
+            );
+            w.write_all(meta.as_bytes()).unwrap();
+            for i in 0..200usize {
+                w.write_all(codex_usage(i).as_bytes()).unwrap();
+            }
+            let mut written = 0u64;
+            let mut i = 200usize;
+            while written < 300 * MB {
+                for _ in 0..50 {
+                    w.write_all(codex_noise.as_bytes()).unwrap();
+                    written += codex_noise.len() as u64;
+                }
+                let base = (i as u64 + 1) * 1700;
+                let own = format!(
+                    "{}\n",
+                    codex_usage_line(
+                        &recent_ts(1101 + (i as u32 % 90), (i % 12) as u32 * 5),
+                        (base, base / 3, base / 10, base / 40, base + base / 10),
+                    )
+                );
+                w.write_all(own.as_bytes()).unwrap();
+                written += own.len() as u64;
+                i += 1;
+            }
+            w.flush().unwrap();
+            let mut record = stream_record("s_codex_fork", "codex", &path.display().to_string());
+            record.external_session_id = "fork-child".to_string();
+            record.external_parent_session_id = Some("cg0".to_string());
+            streams_db.insert_stream(&record).unwrap();
+        }
+
+        let total: u64 = std::fs::read_dir(dir.path())
+            .unwrap()
+            .flatten()
+            .filter(|e| e.path().extension().is_some_and(|x| x == "jsonl"))
+            .filter_map(|e| e.metadata().ok())
+            .map(|m| m.len())
+            .sum();
+        println!(
+            "corpus: {:.1} GiB in 10 giants, generated in {:.0}s",
+            total as f64 / GB as f64,
+            gen_started.elapsed().as_secs_f64()
+        );
+
+        let stop = Arc::new(AtomicBool::new(false));
+        let sampler_stop = stop.clone();
+        let sampler = std::thread::spawn(move || {
+            let mut last = cpu_ticks();
+            let mut cpu: Vec<f64> = Vec::new();
+            let mut rss: Vec<u64> = Vec::new();
+            while !sampler_stop.load(Ordering::Relaxed) {
+                std::thread::sleep(Duration::from_millis(100));
+                let now = cpu_ticks();
+                cpu.push((now - last) as f64);
+                last = now;
+                rss.push(rss_kb());
+            }
+            (cpu, rss)
+        });
+
+        let started = std::time::Instant::now();
+        let (collected, sink) = collecting_sink();
+        let (_handle, shutdown) = spawn_run_loop(
+            streams_db.clone(),
+            token_db.clone(),
+            sink,
+            Duration::from_secs(3600),
+        );
+
+        loop {
+            tokio::time::sleep(Duration::from_secs(1)).await;
+            let streams_db = streams_db.clone();
+            let token_db = token_db.clone();
+            let quiet = tokio::task::spawn_blocking(move || {
+                sweep_candidates(&streams_db, &token_db).is_empty()
+                    && token_db.sessions_needing_reconcile().unwrap().is_empty()
+            })
+            .await
+            .unwrap();
+            if quiet && started.elapsed() > Duration::from_secs(5) {
+                break;
+            }
+            assert!(started.elapsed() < Duration::from_secs(1800), "bench hung");
+        }
+        let wall = started.elapsed();
+        shutdown.notify_one();
+        stop.store(true, Ordering::Relaxed);
+        let (cpu, rss) = sampler.join().unwrap();
+
+        let events = collected.lock().unwrap().len();
+        let total_cpu: f64 = cpu.iter().sum::<f64>() / 1000.0;
+        let mut cpu_sorted = cpu.clone();
+        cpu_sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        let pct =
+            |q: f64| cpu_sorted[((cpu_sorted.len() as f64 * q) as usize).min(cpu_sorted.len() - 1)];
+        let mut rss_sorted = rss.clone();
+        rss_sorted.sort_unstable();
+        println!(
+            "wall={:.0}s cpu={:.0}s avg_duty={:.0}% p95={:.0}% max={:.0}% rss_p50={}MiB rss_p95={}MiB rss_max={}MiB events={events}",
+            wall.as_secs_f64(),
+            total_cpu,
+            total_cpu / wall.as_secs_f64() * 100.0,
+            pct(0.95),
+            cpu_sorted[cpu_sorted.len() - 1],
+            rss_sorted[rss_sorted.len() / 2] / 1024,
+            rss_sorted[((rss_sorted.len() as f64 * 0.95) as usize).min(rss_sorted.len() - 1)]
+                / 1024,
+            rss_sorted[rss_sorted.len() - 1] / 1024,
+        );
+        let duty_line: Vec<String> = cpu
+            .chunks(50)
+            .map(|c| format!("{:.0}", c.iter().sum::<f64>() / c.len() as f64))
+            .collect();
+        println!("duty/5s: {}", duty_line.join(" "));
+        let rss_line: Vec<String> = rss
+            .chunks(50)
+            .map(|c| format!("{}", c.iter().max().unwrap() / 1024))
+            .collect();
+        println!("rssMiB/5s: {}", rss_line.join(" "));
+    }
 }

--- a/src/daemon/token_usage_worker.rs
+++ b/src/daemon/token_usage_worker.rs
@@ -113,14 +113,50 @@ const THROTTLE_MAX_PAUSE: Duration = Duration::from_secs(5);
 /// charge the same debt, so their combined CPU holds the duty cycle instead
 /// of each pipeline claiming 30% on its own thread. Notify-origin passes and
 /// awaited flushes never charge it.
-static BACKGROUND_WORK_DEBT: std::sync::Mutex<Duration> = std::sync::Mutex::new(Duration::ZERO);
+///
+/// Pauses are issued as *serialized reservations* (`paused_until`): a caller
+/// settling while another caller's pause is still reserved queues its pause
+/// behind it and is told to wait out both, so concurrent sleepers cannot
+/// overlap their pauses and double the effective duty. A caller that sleeps
+/// less than it was told (the flush caps its sleeps to stay responsive)
+/// forgives nothing — the reservation stands and the next background segment
+/// absorbs the remainder.
+struct BackgroundLedger {
+    debt: Duration,
+    paused_until: Option<std::time::Instant>,
+}
 
-/// Charge `work` to the shared background ledger and return the pause owed.
+static BACKGROUND_LEDGER: std::sync::Mutex<BackgroundLedger> =
+    std::sync::Mutex::new(BackgroundLedger {
+        debt: Duration::ZERO,
+        paused_until: None,
+    });
+
+/// Charge `work` to the shared background ledger and return how long this
+/// caller must wait (its own pause queued behind any outstanding
+/// reservation).
 pub(crate) fn background_work_pause(work: Duration) -> Duration {
-    let mut debt = BACKGROUND_WORK_DEBT
+    reserve_background_pause(&BACKGROUND_LEDGER, work)
+}
+
+fn reserve_background_pause(
+    ledger: &std::sync::Mutex<BackgroundLedger>,
+    work: Duration,
+) -> Duration {
+    let mut ledger = ledger
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
-    settle_throttle_debt(&mut debt, work)
+    let pause = settle_throttle_debt(&mut ledger.debt, work);
+    let now = std::time::Instant::now();
+    let start = match ledger.paused_until {
+        Some(reserved) if reserved > now => reserved,
+        _ => now,
+    };
+    let end = start + pause;
+    if end > now {
+        ledger.paused_until = Some(end);
+    }
+    end - now
 }
 
 /// Cap on one batch's wall time: a slow-disk batch pauses (and observes
@@ -344,12 +380,15 @@ impl TokenUsageWorker {
                         // file of a large backfill. Ingest what arrived
                         // during the pass first — traffic sitting in the
                         // channels must not wait behind even one throttled
-                        // reconcile step.
+                        // reconcile step. Runs after notify tasks too: their
+                        // inline reconcile normally leaves nothing (this is
+                        // then one SELECT), but flags left by a FAILED
+                        // inline pass must not wait for the next 30-minute
+                        // sweep tick.
                         while let Ok(task) = self.notify_rx.try_recv() {
                             self.enqueue_notify(task);
                         }
-                        if matches!(origin, TaskOrigin::Sweep)
-                            && self.notify_queue.is_empty()
+                        if self.notify_queue.is_empty()
                             && self.sweep_queue.is_empty()
                             && self.drain_rx.is_empty()
                             && !self.shutdown_flag.load(Ordering::Relaxed)
@@ -2710,6 +2749,38 @@ mod tests {
         let identity = SessionIdentity::from_stream(&stream);
         assert_eq!(identity.session_id, "s_child");
         assert_eq!(identity.external_parent_session_id, None);
+    }
+
+    #[test]
+    fn background_pauses_are_serialized_reservations() {
+        // Two pipelines settling concurrently must queue their pauses, not
+        // overlap them: the second caller is told to wait out the first
+        // caller's outstanding reservation plus its own pause, so combined
+        // background CPU holds one duty cycle instead of two.
+        let ledger = std::sync::Mutex::new(BackgroundLedger {
+            debt: Duration::ZERO,
+            paused_until: None,
+        });
+        let first = reserve_background_pause(&ledger, Duration::from_millis(300));
+        assert!(
+            first >= Duration::from_millis(690) && first <= Duration::from_millis(710),
+            "own pause only: {first:?}"
+        );
+        // Settle immediately (the first sleeper has not woken): queued.
+        let second = reserve_background_pause(&ledger, Duration::from_millis(300));
+        assert!(
+            second >= Duration::from_millis(1380) && second <= Duration::from_millis(1420),
+            "queued behind the first reservation: {second:?}"
+        );
+
+        // A caller that under-sleeps its reservation (the flush caps its
+        // sleeps) forgives nothing: with zero new work, the wait returned to
+        // the next caller still covers the outstanding reservation.
+        let remainder = reserve_background_pause(&ledger, Duration::ZERO);
+        assert!(
+            remainder >= Duration::from_millis(1350),
+            "reservation persists: {remainder:?}"
+        );
     }
 
     #[test]

--- a/src/daemon/token_usage_worker.rs
+++ b/src/daemon/token_usage_worker.rs
@@ -90,26 +90,38 @@ fn read_line_bytes(
 const BATCH_MAX_ENTRIES: usize = 1_000;
 const BATCH_MAX_BYTES: usize = 4 * 1024 * 1024;
 
-/// CPU duty cycle for sweep-origin transcript passes: after each batch, the
-/// pass sleeps long enough that the work occupies at most this share of one
-/// core (work W is followed by a pause of W * (100 - duty) / duty). A multi-
-/// gigabyte backfill therefore takes ~3x longer instead of pinning a core.
+/// CPU duty cycle for sweep-origin work: every charged segment (batch,
+/// bucket emission, cross-session reconcile) is followed by a pause long
+/// enough that the work occupies at most this share of one core (work W is
+/// followed by a pause of W * (100 - duty) / duty). A multi-gigabyte
+/// backfill therefore takes ~3x longer instead of pinning a core.
 /// Notification-origin passes are never throttled (see `TaskOrigin`).
 const THROTTLE_DUTY_PERCENT: u32 = 30;
-/// Batches doing less work than this owe no pause (quiet skips, small
-/// appends swept between notifications).
+/// Work debt below this settles without a pause; it stays on the ledger and
+/// is paid by a later settlement. Without the carried debt, a backfill of
+/// many small files (each under the floor per segment) would never pause at
+/// all and run at full speed — the floor only batches sleeps, it must not
+/// forgive work.
 const THROTTLE_MIN_WORK: Duration = Duration::from_millis(5);
-/// Upper bound on a single pause (guards pathologically slow batches, and
-/// bounds how long a pass can delay a drain or shutdown).
+/// Upper bound on a single pause (guards pathologically slow segments, and
+/// bounds how long a pass can delay a drain or shutdown). Work the cap left
+/// unpaid stays on the ledger.
 const THROTTLE_MAX_PAUSE: Duration = Duration::from_secs(5);
 
-/// The pause owed after `work` of batch processing under the duty cycle.
-fn throttle_pause_for(work: Duration) -> Duration {
-    if work < THROTTLE_MIN_WORK {
+/// Add `work` to the debt ledger and settle it into the pause now owed.
+/// Debt the returned pause does not cover (the floor or the cap) carries to
+/// the next settlement, so the duty cycle holds across many small segments,
+/// not just within large ones.
+fn settle_throttle_debt(debt: &mut Duration, work: Duration) -> Duration {
+    *debt = debt.saturating_add(work);
+    if *debt < THROTTLE_MIN_WORK {
         return Duration::ZERO;
     }
-    (work.saturating_mul(100 - THROTTLE_DUTY_PERCENT) / THROTTLE_DUTY_PERCENT)
-        .min(THROTTLE_MAX_PAUSE)
+    let pause = (debt.saturating_mul(100 - THROTTLE_DUTY_PERCENT) / THROTTLE_DUTY_PERCENT)
+        .min(THROTTLE_MAX_PAUSE);
+    let paid = pause.saturating_mul(THROTTLE_DUTY_PERCENT) / (100 - THROTTLE_DUTY_PERCENT);
+    *debt = debt.saturating_sub(paid);
+    pause
 }
 
 /// Sleep out a throttle pause in small chunks so shutdown stays prompt.
@@ -210,6 +222,7 @@ pub fn spawn_token_usage_worker(
         sweep_queue: VecDeque::new(),
         queued: HashSet::new(),
         sweep_interval: Duration::from_secs(30 * 60),
+        throttle_debt: Arc::new(std::sync::Mutex::new(Duration::ZERO)),
         #[cfg(test)]
         test_sink: None,
         #[cfg(test)]
@@ -239,12 +252,16 @@ struct TokenUsageWorker {
     queued: HashSet<TokenUsageTask>,
     /// 30 minutes in production; injectable so tests can drive the ticker.
     sweep_interval: Duration,
+    /// Sweep-work debt ledger shared by every throttled segment (see
+    /// `settle_throttle_debt`); carried across batches, files, and tasks.
+    throttle_debt: Arc<std::sync::Mutex<Duration>>,
     /// Test-only event capture: the metrics DB is a process-lifetime
     /// singleton, so run()-level tests inject a sink instead of a real
     /// telemetry handle.
     #[cfg(test)]
     test_sink: Option<TestSink>,
-    /// Test-only throttle-pause recorder, replacing the real sleep.
+    /// Test-only recorder of charged work segments, replacing the debt
+    /// ledger and the real sleep.
     #[cfg(test)]
     test_throttle: Option<TestThrottle>,
 }
@@ -304,6 +321,18 @@ impl TokenUsageWorker {
                     }
                     if let Some((task, origin)) = self.pop_next() {
                         self.process_task(task, origin).await;
+                        // Sweep tasks defer cross-session reconciliation (a
+                        // notify task settles all flags inline for the drain
+                        // barrier): settle once the backlog drains, instead
+                        // of re-aggregating the flagged sessions after every
+                        // file of a large backfill.
+                        if matches!(origin, TaskOrigin::Sweep)
+                            && self.notify_queue.is_empty()
+                            && self.sweep_queue.is_empty()
+                            && !self.shutdown_flag.load(Ordering::Relaxed)
+                        {
+                            self.reconcile_flagged().await;
+                        }
                     }
                 }
                 _ = sweep_ticker.tick() => {
@@ -427,31 +456,42 @@ impl TokenUsageWorker {
         }
     }
 
-    /// Reconcile cross-session flags off the async loop (used by sweeps for
-    /// crash recovery; the per-task path reconciles inline).
+    /// Reconcile cross-session flags off the async loop, throttled like all
+    /// other sweep-origin work (notify tasks reconcile inline, unthrottled,
+    /// for the drain barrier). Called when the task backlog drains, on every
+    /// sweep tick (crash recovery for flags left by a pass that died between
+    /// its batch commit and its reconcile), and at startup.
     async fn reconcile_flagged(&self) {
         let token_db = self.token_db.clone();
         let sink = self.make_sink();
+        let throttle = self.make_throttle();
         let _ = tokio::task::spawn_blocking(move || {
-            if let Err(e) = reconcile_flagged_sessions(&token_db, &sink) {
+            if let Err(e) = reconcile_flagged_sessions(&token_db, &sink, Some(&throttle)) {
                 tracing::warn!(error = %e, "token-usage cross-session reconcile failed");
             }
         })
         .await;
     }
 
-    /// The pause a sweep-origin pass sleeps after each batch. Tests inject a
-    /// recorder to pin the per-batch call sites without wall-clock waits.
+    /// The charge function sweep-origin work calls with each segment's
+    /// measured work: it settles the shared debt ledger and sleeps out the
+    /// pause owed. Tests inject a recorder to pin the charge sites without
+    /// wall-clock waits.
     fn make_throttle(&self) -> impl Fn(Duration) + Send + Sync + use<> {
         let shutdown_flag = self.shutdown_flag.clone();
+        let debt = self.throttle_debt.clone();
         #[cfg(test)]
         let test_throttle = self.test_throttle.clone();
-        move |pause: Duration| {
+        move |work: Duration| {
             #[cfg(test)]
             if let Some(throttle) = &test_throttle {
-                throttle(pause);
+                throttle(work);
                 return;
             }
+            let pause = {
+                let mut debt = debt.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+                settle_throttle_debt(&mut debt, work)
+            };
             throttle_sleep(pause, &shutdown_flag);
         }
     }
@@ -677,12 +717,17 @@ fn process_task_blocking(
         );
     }
     // Cross-session replacements flagged other sessions during the batch
-    // commits: reconcile them now, DB-only. Failures here belong to the
-    // flagged sessions (the durable flag retries them), NOT to this task's
+    // commits: notify-origin passes (unthrottled — the drain barrier awaits
+    // them) reconcile inline, DB-only, so `git-ai await` reflects the moves.
+    // Sweep passes leave the durable flags for the run loop to settle once
+    // the backlog drains, instead of re-aggregating the flagged sessions
+    // after every file of a backfill. Failures here belong to the flagged
+    // sessions (the durable flag retries them), NOT to this task's
     // transcript — charging them here would put a healthy file into error
     // backoff and point diagnostics at the wrong session.
     if result.is_ok()
-        && let Err(e) = reconcile_flagged_sessions(token_db, sink)
+        && throttle.is_none()
+        && let Err(e) = reconcile_flagged_sessions(token_db, sink, None)
     {
         tracing::warn!(error = %e, "token-usage cross-session reconcile failed; flags retained for retry");
     }
@@ -716,8 +761,10 @@ fn persist_events(
 fn reconcile_flagged_sessions(
     token_db: &TokenUsageDatabase,
     sink: &impl Fn(&[MetricEvent]) -> Result<(), GitAiError>,
+    throttle: Option<&(dyn Fn(Duration) + Sync)>,
 ) -> Result<(), GitAiError> {
     for session in token_db.sessions_needing_reconcile()? {
+        let started = std::time::Instant::now();
         let identity = SessionIdentity {
             session_id: session.session_id.clone(),
             external_session_id: session.external_session_id,
@@ -726,6 +773,9 @@ fn reconcile_flagged_sessions(
         };
         emit_changed_buckets(token_db, &identity, || session.repo_url, sink)?;
         token_db.clear_needs_reconcile(&session.session_id)?;
+        if let Some(throttle) = throttle {
+            throttle(started.elapsed());
+        }
     }
     Ok(())
 }
@@ -948,6 +998,12 @@ fn process_file(
         return Ok(());
     }
 
+    // The pass is live from here on: everything below up to the first batch
+    // commit (config lookup, parent-prefix resolution, open, seek) is work
+    // the first batch's throttle charge covers. Quiet skips returned above
+    // and stay free.
+    let mut batch_started = std::time::Instant::now();
+
     // Only lines fed below consume the fallback speed, so quiet-skipped
     // passes never pay the config lookup.
     if identity.tool == "codex" {
@@ -979,7 +1035,6 @@ fn process_file(
     let mut reached_end = false;
     let mut interrupted = false;
     while !reached_end && !interrupted {
-        let batch_started = std::time::Instant::now();
         let mut entries = Vec::new();
         let mut consumed = 0usize;
         loop {
@@ -1043,12 +1098,14 @@ fn process_file(
             pending_flush: extractor.has_pending(),
             min_bucket_ts: cutoff,
         })?;
-        // CPU throttle (sweep-origin passes only): pay for this batch's work
-        // with a proportional pause (also after the final batch, so back-to-
-        // back file passes during a large backfill hold the duty cycle too).
+        // CPU throttle (sweep-origin passes only): charge this batch's work
+        // to the debt ledger and sleep out the pause owed (also after the
+        // final batch, so back-to-back file passes during a large backfill
+        // hold the duty cycle too).
         if let Some(throttle) = throttle {
-            throttle(throttle_pause_for(batch_started.elapsed()));
+            throttle(batch_started.elapsed());
         }
+        batch_started = std::time::Instant::now();
     }
 
     if interrupted {
@@ -1057,11 +1114,19 @@ fn process_file(
         // reconciles emission.
         return Ok(());
     }
+    let emit_started = std::time::Instant::now();
     emit_changed_buckets(token_db, identity, resolve_repo_url, sink)?;
     // The quiet-skip snapshot is written only after emission succeeded, so a
     // failed hand-off (or a crash anywhere in this pass) leaves the file
     // "changed" and the next pass re-runs reconciliation.
-    token_db.update_file_metadata(&identity.session_id, stream_path, size, modified)
+    let result = token_db.update_file_metadata(&identity.session_id, stream_path, size, modified);
+    // Bucket aggregation and event emission are real work too — charge them
+    // like a batch, or a backfill's duty cycle only covers the parsing half
+    // of each pass.
+    if let Some(throttle) = throttle {
+        throttle(emit_started.elapsed());
+    }
+    result
 }
 
 /// Reconcile the session's buckets in one pass and emit those whose
@@ -2011,10 +2076,14 @@ mod tests {
         // The DB-only reconcile pass emits A's emptied bucket as zero with
         // A's stored identity, no file read required, and clears the flag.
         let collected = Mutex::new(Vec::new());
-        reconcile_flagged_sessions(&db, &|events: &[MetricEvent]| {
-            collected.lock().unwrap().extend(events.to_vec());
-            Ok(())
-        })
+        reconcile_flagged_sessions(
+            &db,
+            &|events: &[MetricEvent]| {
+                collected.lock().unwrap().extend(events.to_vec());
+                Ok(())
+            },
+            None,
+        )
         .unwrap();
         let events = collected.into_inner().unwrap();
         assert_eq!(events.len(), 1);
@@ -2064,22 +2133,162 @@ mod tests {
 
         // The flag survives a failed reconcile sink...
         assert!(
-            reconcile_flagged_sessions(&db, &|_: &[MetricEvent]| {
-                Err(GitAiError::Generic("sink down".to_string()))
-            })
+            reconcile_flagged_sessions(
+                &db,
+                &|_: &[MetricEvent]| { Err(GitAiError::Generic("sink down".to_string())) },
+                None
+            )
             .is_err()
         );
         assert_eq!(db.sessions_needing_reconcile().unwrap().len(), 1);
 
         // ...and the retry emits the correction and clears it.
         let collected = Mutex::new(Vec::new());
-        reconcile_flagged_sessions(&db, &|events: &[MetricEvent]| {
-            collected.lock().unwrap().extend(events.to_vec());
-            Ok(())
-        })
+        reconcile_flagged_sessions(
+            &db,
+            &|events: &[MetricEvent]| {
+                collected.lock().unwrap().extend(events.to_vec());
+                Ok(())
+            },
+            None,
+        )
         .unwrap();
         assert_eq!(collected.into_inner().unwrap().len(), 1);
         assert!(db.sessions_needing_reconcile().unwrap().is_empty());
+    }
+
+    #[test]
+    fn sweep_origin_pass_defers_cross_session_reconcile() {
+        // A throttled (sweep-origin) pass must NOT reconcile flagged
+        // sessions inline: during a large backfill that would re-aggregate
+        // every flagged session after every file, unthrottled. The durable
+        // flag stays for the run loop to settle; a notify-origin pass still
+        // settles it inline for the drain barrier.
+        let dir = tempfile::tempdir().unwrap();
+        let streams_db =
+            Arc::new(StreamsDatabase::open(dir.path().join("transcripts-db")).unwrap());
+        let token_db =
+            Arc::new(TokenUsageDatabase::open(dir.path().join("token-usage-db")).unwrap());
+        let base = dir.path().join("base.jsonl");
+        fs::write(
+            &base,
+            format!("{}\n", claude_line("m1", "r1", &recent_ts(1, 0), 50)),
+        )
+        .unwrap();
+        let resume = dir.path().join("resume.jsonl");
+        fs::write(
+            &resume,
+            format!("{}\n", claude_line("m1", "r1", &recent_ts(1, 30), 90)),
+        )
+        .unwrap();
+        for (session, path) in [("s_base", &base), ("s_resume", &resume)] {
+            streams_db
+                .insert_stream(&stream_record(
+                    session,
+                    "claude",
+                    &path.display().to_string(),
+                ))
+                .unwrap();
+        }
+        let (_collected, sink) = collecting_sink();
+        let noop_throttle = |_: Duration| {};
+        for session in ["s_base", "s_resume"] {
+            process_task_blocking(
+                &streams_db,
+                &token_db,
+                &|e| sink(e),
+                Some(&noop_throttle),
+                &TokenUsageTask {
+                    session_id: session.to_string(),
+                    tool: "claude".to_string(),
+                    stream_path: if session == "s_base" { &base } else { &resume }
+                        .display()
+                        .to_string(),
+                },
+                &flag_off(),
+            )
+            .unwrap();
+        }
+        // The resume pass moved m1 to s_resume and flagged s_base — and the
+        // sweep-origin pass left the flag alone.
+        assert_eq!(token_db.sessions_needing_reconcile().unwrap().len(), 1);
+
+        // A notify-origin (unthrottled) pass settles all flags inline.
+        process_task_blocking(
+            &streams_db,
+            &token_db,
+            &|e| sink(e),
+            None,
+            &TokenUsageTask {
+                session_id: "s_resume".to_string(),
+                tool: "claude".to_string(),
+                stream_path: resume.display().to_string(),
+            },
+            &flag_off(),
+        )
+        .unwrap();
+        assert!(token_db.sessions_needing_reconcile().unwrap().is_empty());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn run_loop_settles_sweep_reconcile_flags_when_the_backlog_drains() {
+        // End to end through run(): the startup sweep backfills a base
+        // session and a resumed copy that steals its entry; the deferred
+        // reconcile pass runs once the backlog drains and emits the base
+        // session's corrected (zeroed) bucket without any notification.
+        let dir = tempfile::tempdir().unwrap();
+        let streams_db =
+            Arc::new(StreamsDatabase::open(dir.path().join("transcripts-db")).unwrap());
+        let token_db =
+            Arc::new(TokenUsageDatabase::open(dir.path().join("token-usage-db")).unwrap());
+        let base = dir.path().join("base.jsonl");
+        fs::write(
+            &base,
+            format!("{}\n", claude_line("m1", "r1", &recent_ts(1, 0), 50)),
+        )
+        .unwrap();
+        let resume = dir.path().join("resume.jsonl");
+        fs::write(
+            &resume,
+            format!("{}\n", claude_line("m1", "r1", &recent_ts(1, 30), 90)),
+        )
+        .unwrap();
+        for (session, path) in [("s_base", &base), ("s_resume", &resume)] {
+            streams_db
+                .insert_stream(&stream_record(
+                    session,
+                    "claude",
+                    &path.display().to_string(),
+                ))
+                .unwrap();
+        }
+        let (collected, sink) = collecting_sink();
+        let (_handle, shutdown) = spawn_run_loop(
+            streams_db.clone(),
+            token_db.clone(),
+            sink,
+            Duration::from_secs(600),
+        );
+
+        // The correction is a re-emission of s_base's bucket at zero.
+        for _ in 0..600 {
+            let corrected = collected.lock().unwrap().iter().any(|e| {
+                EventAttributes::from_sparse(&e.attrs).session_id
+                    == Some(Some("s_base".to_string()))
+                    && value_u64(e, token_usage_pos::TOTAL_TOKENS) == Some(0)
+            });
+            if corrected {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        let corrected = collected.lock().unwrap().iter().any(|e| {
+            EventAttributes::from_sparse(&e.attrs).session_id == Some(Some("s_base".to_string()))
+                && value_u64(e, token_usage_pos::TOTAL_TOKENS) == Some(0)
+        });
+        assert!(corrected, "deferred reconcile emits the correction");
+        assert!(token_db.sessions_needing_reconcile().unwrap().is_empty());
+        shutdown.notify_one();
     }
 
     #[test]
@@ -2181,6 +2390,7 @@ mod tests {
             sweep_queue: VecDeque::new(),
             queued: HashSet::new(),
             sweep_interval: Duration::from_secs(30 * 60),
+            throttle_debt: Arc::new(std::sync::Mutex::new(Duration::ZERO)),
             test_sink: None,
             test_throttle: None,
         }
@@ -2350,23 +2560,43 @@ mod tests {
     }
 
     #[test]
-    fn throttle_pause_holds_the_duty_cycle() {
-        // Below the floor: not throttled (quiet skips, small appends), so
-        // notification-driven work and the drain barrier stay fast.
-        assert_eq!(throttle_pause_for(Duration::from_millis(4)), Duration::ZERO);
-        // 30% duty cycle: work W is followed by a pause of 7W/3.
+    fn throttle_debt_holds_the_duty_cycle_across_small_segments() {
+        // 30% duty cycle: work W is followed by a pause of 7W/3, and the
+        // ledger returns to (near) zero.
+        let mut debt = Duration::ZERO;
         assert_eq!(
-            throttle_pause_for(Duration::from_millis(300)),
+            settle_throttle_debt(&mut debt, Duration::from_millis(300)),
             Duration::from_millis(700)
         );
+        assert!(debt < Duration::from_micros(10), "paid debt clears");
+
+        // Below the floor no pause is owed yet, but the work is NOT
+        // forgiven: it stays on the ledger and a later settlement pays it.
+        // (Without the carry, a backfill of many small files would never
+        // pause at all.)
+        let mut debt = Duration::ZERO;
         assert_eq!(
-            throttle_pause_for(Duration::from_millis(900)),
-            Duration::from_millis(2100)
+            settle_throttle_debt(&mut debt, Duration::from_millis(4)),
+            Duration::ZERO
         );
-        // Capped, so one pathologically slow batch cannot stall a drain or
-        // shutdown for minutes.
+        assert_eq!(debt, Duration::from_millis(4));
         assert_eq!(
-            throttle_pause_for(Duration::from_secs(60)),
+            settle_throttle_debt(&mut debt, Duration::from_millis(2)),
+            Duration::from_millis(14)
+        );
+        assert!(debt < Duration::from_micros(10));
+
+        // Capped, so one pathologically slow segment cannot stall a drain
+        // or shutdown for minutes; the unpaid remainder carries.
+        let mut debt = Duration::ZERO;
+        assert_eq!(
+            settle_throttle_debt(&mut debt, Duration::from_secs(60)),
+            THROTTLE_MAX_PAUSE
+        );
+        // 5s of pause pays ~2.14s of work; the rest stays owed.
+        assert!(debt > Duration::from_secs(57));
+        assert_eq!(
+            settle_throttle_debt(&mut debt, Duration::ZERO),
             THROTTLE_MAX_PAUSE
         );
     }
@@ -2380,11 +2610,11 @@ mod tests {
     }
 
     #[test]
-    fn throttled_passes_pay_a_pause_per_batch_and_quiet_skips_pay_nothing() {
-        // Pins the call site (finding: deleting the throttle call failed no
-        // test): a throttled multi-batch pass owes exactly one pause per
-        // batch commit, recorded via the injectable sleeper — no wall-clock
-        // assertions needed.
+    fn throttled_passes_charge_each_batch_and_emission_and_quiet_skips_pay_nothing() {
+        // Pins the charge sites (finding: deleting the throttle call failed
+        // no test): a throttled multi-batch pass charges once per batch
+        // commit plus once for bucket emission, recorded via the injectable
+        // recorder — no wall-clock assertions needed.
         let (_dir, db, transcript) = setup();
         let mut content = String::new();
         for i in 0..(BATCH_MAX_ENTRIES + 1) {
@@ -2398,8 +2628,8 @@ mod tests {
         }
         fs::write(&transcript, content).unwrap();
 
-        let pauses = Mutex::new(Vec::new());
-        let recorder = |pause: Duration| pauses.lock().unwrap().push(pause);
+        let charges = Mutex::new(Vec::new());
+        let recorder = |work: Duration| charges.lock().unwrap().push(work);
         let flag = AtomicBool::new(false);
         process_file(
             &db,
@@ -2411,9 +2641,13 @@ mod tests {
             Some(&recorder),
         )
         .unwrap();
-        assert_eq!(pauses.lock().unwrap().len(), 2, "one pause per batch");
+        assert_eq!(
+            charges.lock().unwrap().len(),
+            3,
+            "one charge per batch plus one for emission"
+        );
 
-        // Quiet skip: unchanged bytes owe no pause at all.
+        // Quiet skip: unchanged bytes charge nothing at all.
         process_file(
             &db,
             &identity(),
@@ -2424,7 +2658,7 @@ mod tests {
             Some(&recorder),
         )
         .unwrap();
-        assert_eq!(pauses.lock().unwrap().len(), 2, "quiet skip pays nothing");
+        assert_eq!(charges.lock().unwrap().len(), 3, "quiet skip pays nothing");
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -2620,6 +2854,7 @@ mod tests {
             sweep_queue: VecDeque::new(),
             queued: HashSet::new(),
             sweep_interval,
+            throttle_debt: Arc::new(std::sync::Mutex::new(Duration::ZERO)),
             test_sink: Some(sink),
             test_throttle,
         };
@@ -2746,5 +2981,273 @@ mod tests {
             .filter(|e| value_u64(e, token_usage_pos::BUCKET_TS) == Some(bucket_of(1, 0)))
             .count();
         assert_eq!(first_bucket_emissions, 1, "restart must not re-emit");
+    }
+
+    /// CPU/RSS profile of a cold backfill over a realistic corpus, at the
+    /// real run() loop with the real throttle. Ignored: run manually with
+    /// `task test TEST_FILTER=bench_backfill_cpu_duty NO_CAPTURE=true \
+    ///  EXTRA_TEST_BINARY_ARGS="--ignored"` and read the printed duty
+    /// timeline. Guards the ~30% sweep duty-cycle contract end to end —
+    /// including emission and cross-session reconciliation, not just the
+    /// parse batches.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[ignore]
+    async fn bench_backfill_cpu_duty() {
+        const BASE_SESSIONS: usize = 240;
+        const LINES_PER_SESSION: usize = 800;
+        const RESUME_SESSIONS: usize = 120;
+        const SIDECHAIN_SESSIONS: usize = 60;
+        const CODEX_SESSIONS: usize = 40;
+        const CODEX_TURNS: usize = 600;
+        const CODEX_FORKS: usize = 20;
+        const SMALL_SESSIONS: usize = 400;
+
+        fn cpu_ticks() -> u64 {
+            let stat = std::fs::read_to_string("/proc/self/stat").unwrap();
+            // utime + stime are fields 14 + 15; comm (field 2) may contain
+            // spaces, so parse after the closing paren.
+            let after = &stat[stat.rfind(')').unwrap() + 2..];
+            let fields: Vec<&str> = after.split_whitespace().collect();
+            fields[11].parse::<u64>().unwrap() + fields[12].parse::<u64>().unwrap()
+        }
+        fn rss_kb() -> u64 {
+            std::fs::read_to_string("/proc/self/status")
+                .unwrap()
+                .lines()
+                .find(|l| l.starts_with("VmRSS:"))
+                .and_then(|l| l.split_whitespace().nth(1))
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(0)
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let streams_db =
+            Arc::new(StreamsDatabase::open(dir.path().join("transcripts-db")).unwrap());
+        let token_db =
+            Arc::new(TokenUsageDatabase::open(dir.path().join("token-usage-db")).unwrap());
+
+        let claude_usage = |sess: usize, i: usize, output: u64| {
+            // ~55 buckets per session, all inside the retention window.
+            let ts = recent_ts((i / 8) as u32 % 1200, (i % 8) as u32 * 7);
+            format!(
+                r#"{{"timestamp":"{ts}","sessionId":"ext-{sess}","requestId":"r{sess}_{i}","message":{{"id":"m{sess}_{i}","model":"claude-sonnet-4-6-20260115","usage":{{"input_tokens":220,"output_tokens":{output},"cache_creation_input_tokens":40,"cache_read_input_tokens":18000}}}}}}"#
+            )
+        };
+
+        let insert = |session: &str, tool: &str, path: &std::path::Path| {
+            streams_db
+                .insert_stream(&stream_record(session, tool, &path.display().to_string()))
+                .unwrap();
+        };
+
+        let mut total_bytes = 0usize;
+        // Base claude sessions first (the bulk parse phase).
+        for sess in 0..BASE_SESSIONS {
+            let mut body = String::with_capacity(LINES_PER_SESSION * 320);
+            for i in 0..LINES_PER_SESSION {
+                body.push_str(&claude_usage(sess, i, 900));
+                body.push('\n');
+            }
+            total_bytes += body.len();
+            let path = dir.path().join(format!("claude-{sess}.jsonl"));
+            fs::write(&path, body).unwrap();
+            insert(&format!("s_claude_{sess}"), "claude", &path);
+        }
+        // Many small sessions (the common real shape): each is one batch of
+        // a few milliseconds — work the throttle floor must accumulate, not
+        // forgive, or this whole phase runs unthrottled.
+        for sess in 0..SMALL_SESSIONS {
+            let mut body = String::with_capacity(12 * 320);
+            for i in 0..12usize {
+                body.push_str(&claude_usage(BASE_SESSIONS + sess, i, 900));
+                body.push('\n');
+            }
+            total_bytes += body.len();
+            let path = dir.path().join(format!("claude-small-{sess}.jsonl"));
+            fs::write(&path, body).unwrap();
+            insert(&format!("s_claude_small_{sess}"), "claude", &path);
+        }
+        // Codex rollouts + forks replaying a parent prefix.
+        for sess in 0..CODEX_SESSIONS {
+            let mut body = String::with_capacity(CODEX_TURNS * 300);
+            body.push_str(&codex_meta_line(
+                &format!("codex-{sess}"),
+                None,
+                &recent_ts(0, 5),
+            ));
+            body.push('\n');
+            for i in 0..CODEX_TURNS {
+                let base = (i as u64 + 1) * 1200;
+                body.push_str(&codex_usage_line(
+                    &recent_ts((i / 6) as u32 % 1200, (i % 6) as u32 * 9),
+                    (base, base / 3, base / 10, base / 40, base + base / 10),
+                ));
+                body.push('\n');
+            }
+            total_bytes += body.len();
+            let path = dir.path().join(format!("codex-{sess}.jsonl"));
+            fs::write(&path, body).unwrap();
+            insert(&format!("s_codex_{sess}"), "codex", &path);
+        }
+        for fork in 0..CODEX_FORKS {
+            let parent = fork % CODEX_SESSIONS;
+            let mut body = String::new();
+            body.push_str(&codex_meta_line(
+                &format!("fork-{fork}"),
+                Some(&format!("codex-{parent}")),
+                &recent_ts(600, 0),
+            ));
+            body.push('\n');
+            // Replay the parent's first 50 cumulative totals verbatim.
+            for i in 0..50usize {
+                let base = (i as u64 + 1) * 1200;
+                body.push_str(&codex_usage_line(
+                    &recent_ts(600, 1),
+                    (base, base / 3, base / 10, base / 40, base + base / 10),
+                ));
+                body.push('\n');
+            }
+            // Then its own turns.
+            for i in 50..80usize {
+                let base = (i as u64 + 1) * 1300;
+                body.push_str(&codex_usage_line(
+                    &recent_ts(601 + (i as u32 - 50), 0),
+                    (base, base / 3, base / 10, base / 40, base + base / 10),
+                ));
+                body.push('\n');
+            }
+            total_bytes += body.len();
+            let path = dir.path().join(format!("codex-fork-{fork}.jsonl"));
+            fs::write(&path, body).unwrap();
+            let mut record = stream_record(
+                &format!("s_codex_fork_{fork}"),
+                "codex",
+                &path.display().to_string(),
+            );
+            record.external_session_id = format!("fork-{fork}");
+            record.external_parent_session_id = Some(format!("codex-{parent}"));
+            streams_db.insert_stream(&record).unwrap();
+        }
+        // Sidechain replays (message-id dedup against the base sessions).
+        for sc in 0..SIDECHAIN_SESSIONS {
+            let parent = sc % BASE_SESSIONS;
+            let mut body = String::new();
+            for i in 0..120usize {
+                let ts = recent_ts((i / 8) as u32 % 1200, (i % 8) as u32 * 7);
+                body.push_str(&format!(
+                    r#"{{"timestamp":"{ts}","isSidechain":true,"sessionId":"ext-sc-{sc}","requestId":"rsc{sc}_{i}","message":{{"id":"m{parent}_{i}","model":"claude-sonnet-4-6-20260115","usage":{{"input_tokens":220,"output_tokens":900,"cache_creation_input_tokens":40,"cache_read_input_tokens":45000}}}}}}"#
+                ));
+                body.push('\n');
+            }
+            total_bytes += body.len();
+            let path = dir.path().join(format!("claude-sc-{sc}.jsonl"));
+            fs::write(&path, body).unwrap();
+            let mut record = stream_record(
+                &format!("s_claude_sc_{sc}"),
+                "claude",
+                &path.display().to_string(),
+            );
+            record.external_session_id = format!("sc-{sc}-ext");
+            record.external_parent_session_id = Some(format!("ext-{parent}"));
+            streams_db.insert_stream(&record).unwrap();
+        }
+        // Resume copies LAST: every duplicated message carries larger totals,
+        // so each line replaces the base session's row and flags it for
+        // reconciliation — the storm lands at the end of the cycle, like a
+        // real backfill tail.
+        for res in 0..RESUME_SESSIONS {
+            let parent = res % BASE_SESSIONS;
+            let mut body = String::with_capacity(LINES_PER_SESSION * 320);
+            for i in 0..LINES_PER_SESSION {
+                body.push_str(&claude_usage(parent, i, 910));
+                body.push('\n');
+            }
+            total_bytes += body.len();
+            let path = dir.path().join(format!("claude-resume-{res}.jsonl"));
+            fs::write(&path, body).unwrap();
+            insert(&format!("s_claude_res_{res}"), "claude", &path);
+        }
+
+        let files = BASE_SESSIONS
+            + SMALL_SESSIONS
+            + CODEX_SESSIONS
+            + CODEX_FORKS
+            + SIDECHAIN_SESSIONS
+            + RESUME_SESSIONS;
+        println!(
+            "corpus: {files} files, {:.1} MiB",
+            total_bytes as f64 / 1048576.0
+        );
+
+        // Sample process CPU + RSS at 100ms.
+        let stop = Arc::new(AtomicBool::new(false));
+        let sampler_stop = stop.clone();
+        let sampler = std::thread::spawn(move || {
+            let tick_hz = 100.0; // Linux USER_HZ
+            let mut last = cpu_ticks();
+            let mut samples: Vec<f64> = Vec::new();
+            let mut max_rss = 0u64;
+            while !sampler_stop.load(Ordering::Relaxed) {
+                std::thread::sleep(Duration::from_millis(100));
+                let now = cpu_ticks();
+                samples.push((now - last) as f64 / tick_hz / 0.1 * 100.0);
+                last = now;
+                max_rss = max_rss.max(rss_kb());
+            }
+            (samples, max_rss)
+        });
+
+        let started = std::time::Instant::now();
+        let (collected, sink) = collecting_sink();
+        let (_handle, shutdown) = spawn_run_loop(
+            streams_db.clone(),
+            token_db.clone(),
+            sink,
+            Duration::from_secs(600),
+        );
+
+        // Done when every file is quiet (size/mtime snapshots written, no
+        // pending flushes) and nothing is left to reconcile.
+        loop {
+            tokio::time::sleep(Duration::from_millis(500)).await;
+            let streams_db = streams_db.clone();
+            let token_db = token_db.clone();
+            let quiet = tokio::task::spawn_blocking(move || {
+                sweep_candidates(&streams_db, &token_db).is_empty()
+                    && token_db.sessions_needing_reconcile().unwrap().is_empty()
+            })
+            .await
+            .unwrap();
+            if quiet && started.elapsed() > Duration::from_secs(2) {
+                break;
+            }
+            assert!(started.elapsed() < Duration::from_secs(1200), "bench hung");
+        }
+        let wall = started.elapsed();
+        shutdown.notify_one();
+        stop.store(true, Ordering::Relaxed);
+        let (samples, max_rss) = sampler.join().unwrap();
+
+        let events = collected.lock().unwrap().len();
+        let total_cpu: f64 = samples.iter().sum::<f64>() * 0.1 / 100.0;
+        let mut sorted = samples.clone();
+        sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        let pct = |q: f64| sorted[((sorted.len() as f64 * q) as usize).min(sorted.len() - 1)];
+        println!(
+            "wall={:.1}s cpu={:.1}s avg_duty={:.0}% p50={:.0}% p95={:.0}% max={:.0}% max_rss={}MiB events={events}",
+            wall.as_secs_f64(),
+            total_cpu,
+            total_cpu / wall.as_secs_f64() * 100.0,
+            pct(0.5),
+            pct(0.95),
+            sorted[sorted.len() - 1],
+            max_rss / 1024,
+        );
+        // 1-second duty timeline (10 samples each).
+        let timeline: Vec<String> = samples
+            .chunks(10)
+            .map(|c| format!("{:.0}", c.iter().sum::<f64>() / c.len() as f64))
+            .collect();
+        println!("duty/s: {}", timeline.join(" "));
     }
 }

--- a/src/daemon/token_usage_worker.rs
+++ b/src/daemon/token_usage_worker.rs
@@ -325,10 +325,17 @@ impl TokenUsageWorker {
                         // notify task settles all flags inline for the drain
                         // barrier): settle once the backlog drains, instead
                         // of re-aggregating the flagged sessions after every
-                        // file of a large backfill.
+                        // file of a large backfill. Ingest what arrived
+                        // during the pass first — traffic sitting in the
+                        // channels must not wait behind even one throttled
+                        // reconcile step.
+                        while let Ok(task) = self.notify_rx.try_recv() {
+                            self.enqueue_notify(task);
+                        }
                         if matches!(origin, TaskOrigin::Sweep)
                             && self.notify_queue.is_empty()
                             && self.sweep_queue.is_empty()
+                            && self.drain_rx.is_empty()
                             && !self.shutdown_flag.load(Ordering::Relaxed)
                         {
                             self.reconcile_flagged().await;

--- a/src/daemon/token_usage_worker.rs
+++ b/src/daemon/token_usage_worker.rs
@@ -809,10 +809,10 @@ fn reconcile_next_flagged_session(
     sink: &impl Fn(&[MetricEvent]) -> Result<(), GitAiError>,
     throttle: &(dyn Fn(Duration) + Sync),
 ) -> Result<bool, GitAiError> {
+    let started = std::time::Instant::now();
     let Some(session) = token_db.next_session_needing_reconcile()? else {
         return Ok(false);
     };
-    let started = std::time::Instant::now();
     reconcile_session(token_db, session, sink)?;
     throttle(started.elapsed());
     Ok(true)

--- a/src/daemon/token_usage_worker.rs
+++ b/src/daemon/token_usage_worker.rs
@@ -460,17 +460,49 @@ impl TokenUsageWorker {
     /// other sweep-origin work (notify tasks reconcile inline, unthrottled,
     /// for the drain barrier). Called when the task backlog drains, on every
     /// sweep tick (crash recovery for flags left by a pass that died between
-    /// its batch commit and its reconcile), and at startup.
-    async fn reconcile_flagged(&self) {
-        let token_db = self.token_db.clone();
-        let sink = self.make_sink();
-        let throttle = self.make_throttle();
-        let _ = tokio::task::spawn_blocking(move || {
-            if let Err(e) = reconcile_flagged_sessions(&token_db, &sink, Some(&throttle)) {
-                tracing::warn!(error = %e, "token-usage cross-session reconcile failed");
+    /// its batch commit and its reconcile), and at startup. One session per
+    /// blocking job — its throttle pause included — so shutdown, drains, and
+    /// fresh notifications are serviced between sessions instead of stalling
+    /// behind the whole flag set.
+    async fn reconcile_flagged(&mut self) {
+        loop {
+            if self.shutdown_flag.load(Ordering::Relaxed) {
+                return;
             }
-        })
-        .await;
+            let token_db = self.token_db.clone();
+            let sink = self.make_sink();
+            let throttle = self.make_throttle();
+            let mut handle = tokio::task::spawn_blocking(move || {
+                reconcile_next_flagged_session(&token_db, &sink, &throttle)
+            });
+            let result = tokio::select! {
+                result = &mut handle => result,
+                _ = self.shutdown_notify.notified() => {
+                    self.shutdown_flag.store(true, Ordering::Relaxed);
+                    (&mut handle).await
+                }
+            };
+            match result {
+                Ok(Ok(true)) => {}
+                Ok(Ok(false)) => return,
+                Ok(Err(e)) => {
+                    tracing::warn!(error = %e, "token-usage cross-session reconcile failed");
+                    return;
+                }
+                Err(e) => {
+                    tracing::error!(error = %e, "token-usage cross-session reconcile panicked");
+                    return;
+                }
+            }
+            // Fresh traffic takes priority over the remaining flags: a
+            // notify task's inline reconcile settles them anyway, and a
+            // drain must not wait out throttle pauses. Flags are durable —
+            // whatever is left resumes at the next backlog drain or sweep
+            // tick.
+            if !self.notify_rx.is_empty() || !self.drain_rx.is_empty() {
+                return;
+            }
+        }
     }
 
     /// The charge function sweep-origin work calls with each segment's
@@ -727,7 +759,7 @@ fn process_task_blocking(
     // backoff and point diagnostics at the wrong session.
     if result.is_ok()
         && throttle.is_none()
-        && let Err(e) = reconcile_flagged_sessions(token_db, sink, None)
+        && let Err(e) = reconcile_flagged_sessions(token_db, sink)
     {
         tracing::warn!(error = %e, "token-usage cross-session reconcile failed; flags retained for retry");
     }
@@ -761,23 +793,44 @@ fn persist_events(
 fn reconcile_flagged_sessions(
     token_db: &TokenUsageDatabase,
     sink: &impl Fn(&[MetricEvent]) -> Result<(), GitAiError>,
-    throttle: Option<&(dyn Fn(Duration) + Sync)>,
 ) -> Result<(), GitAiError> {
     for session in token_db.sessions_needing_reconcile()? {
-        let started = std::time::Instant::now();
-        let identity = SessionIdentity {
-            session_id: session.session_id.clone(),
-            external_session_id: session.external_session_id,
-            external_parent_session_id: session.external_parent_session_id,
-            tool: session.tool,
-        };
-        emit_changed_buckets(token_db, &identity, || session.repo_url, sink)?;
-        token_db.clear_needs_reconcile(&session.session_id)?;
-        if let Some(throttle) = throttle {
-            throttle(started.elapsed());
-        }
+        reconcile_session(token_db, session, sink)?;
     }
     Ok(())
+}
+
+/// Reconcile one flagged session (the deferred, throttled path): emit its
+/// changed buckets, clear its flag, and charge the throttle for the work.
+/// Returns whether a session was reconciled, so the caller can hand control
+/// back to its event loop between sessions and come back for the rest.
+fn reconcile_next_flagged_session(
+    token_db: &TokenUsageDatabase,
+    sink: &impl Fn(&[MetricEvent]) -> Result<(), GitAiError>,
+    throttle: &(dyn Fn(Duration) + Sync),
+) -> Result<bool, GitAiError> {
+    let Some(session) = token_db.next_session_needing_reconcile()? else {
+        return Ok(false);
+    };
+    let started = std::time::Instant::now();
+    reconcile_session(token_db, session, sink)?;
+    throttle(started.elapsed());
+    Ok(true)
+}
+
+fn reconcile_session(
+    token_db: &TokenUsageDatabase,
+    session: crate::token_usage::db::ReconcileSession,
+    sink: &impl Fn(&[MetricEvent]) -> Result<(), GitAiError>,
+) -> Result<(), GitAiError> {
+    let identity = SessionIdentity {
+        session_id: session.session_id.clone(),
+        external_session_id: session.external_session_id,
+        external_parent_session_id: session.external_parent_session_id,
+        tool: session.tool,
+    };
+    emit_changed_buckets(token_db, &identity, || session.repo_url, sink)?;
+    token_db.clear_needs_reconcile(&session.session_id)
 }
 
 /// Speed fallback from the rollout's codex-home `config.toml` (recorded
@@ -2076,14 +2129,10 @@ mod tests {
         // The DB-only reconcile pass emits A's emptied bucket as zero with
         // A's stored identity, no file read required, and clears the flag.
         let collected = Mutex::new(Vec::new());
-        reconcile_flagged_sessions(
-            &db,
-            &|events: &[MetricEvent]| {
-                collected.lock().unwrap().extend(events.to_vec());
-                Ok(())
-            },
-            None,
-        )
+        reconcile_flagged_sessions(&db, &|events: &[MetricEvent]| {
+            collected.lock().unwrap().extend(events.to_vec());
+            Ok(())
+        })
         .unwrap();
         let events = collected.into_inner().unwrap();
         assert_eq!(events.len(), 1);
@@ -2133,25 +2182,19 @@ mod tests {
 
         // The flag survives a failed reconcile sink...
         assert!(
-            reconcile_flagged_sessions(
-                &db,
-                &|_: &[MetricEvent]| { Err(GitAiError::Generic("sink down".to_string())) },
-                None
-            )
+            reconcile_flagged_sessions(&db, &|_: &[MetricEvent]| {
+                Err(GitAiError::Generic("sink down".to_string()))
+            },)
             .is_err()
         );
         assert_eq!(db.sessions_needing_reconcile().unwrap().len(), 1);
 
         // ...and the retry emits the correction and clears it.
         let collected = Mutex::new(Vec::new());
-        reconcile_flagged_sessions(
-            &db,
-            &|events: &[MetricEvent]| {
-                collected.lock().unwrap().extend(events.to_vec());
-                Ok(())
-            },
-            None,
-        )
+        reconcile_flagged_sessions(&db, &|events: &[MetricEvent]| {
+            collected.lock().unwrap().extend(events.to_vec());
+            Ok(())
+        })
         .unwrap();
         assert_eq!(collected.into_inner().unwrap().len(), 1);
         assert!(db.sessions_needing_reconcile().unwrap().is_empty());
@@ -2289,6 +2332,92 @@ mod tests {
         assert!(corrected, "deferred reconcile emits the correction");
         assert!(token_db.sessions_needing_reconcile().unwrap().is_empty());
         shutdown.notify_one();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn deferred_reconcile_yields_to_fresh_notifications_between_sessions() {
+        // The deferred pass reconciles one session per blocking job and
+        // hands control back when notify traffic arrives: the remaining
+        // durable flags must not make a fresh notification (or drain) wait
+        // out throttle pauses for the whole flag set.
+        let dir = tempfile::tempdir().unwrap();
+        let streams_db =
+            Arc::new(StreamsDatabase::open(dir.path().join("transcripts-db")).unwrap());
+        let token_db =
+            Arc::new(TokenUsageDatabase::open(dir.path().join("token-usage-db")).unwrap());
+        for (session, message) in [("s_base1", "m1"), ("s_base2", "m2")] {
+            let path = dir.path().join(format!("{session}.jsonl"));
+            fs::write(
+                &path,
+                format!("{}\n", claude_line(message, message, &recent_ts(1, 0), 50)),
+            )
+            .unwrap();
+            let identity = SessionIdentity {
+                session_id: session.to_string(),
+                external_session_id: format!("{session}-ext"),
+                external_parent_session_id: None,
+                tool: "claude".to_string(),
+            };
+            run_as(&token_db, &identity, &path).unwrap();
+        }
+        // One resumed session steals an entry from each base session,
+        // flagging both.
+        let resume = dir.path().join("resume.jsonl");
+        fs::write(
+            &resume,
+            format!(
+                "{}\n{}\n",
+                claude_line("m1", "m1", &recent_ts(1, 30), 90),
+                claude_line("m2", "m2", &recent_ts(1, 30), 90)
+            ),
+        )
+        .unwrap();
+        let identity = SessionIdentity {
+            session_id: "s_resume".to_string(),
+            external_session_id: "s_resume-ext".to_string(),
+            external_parent_session_id: None,
+            tool: "claude".to_string(),
+        };
+        run_as(&token_db, &identity, &resume).unwrap();
+        assert_eq!(token_db.sessions_needing_reconcile().unwrap().len(), 2);
+
+        let (notify_tx, notify_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (_drain_tx, drain_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (_collected, sink) = collecting_sink();
+        let mut worker = TokenUsageWorker {
+            streams_db,
+            token_db: token_db.clone(),
+            telemetry: DaemonTelemetryWorkerHandle::new_noop(),
+            shutdown_notify: Arc::new(Notify::new()),
+            shutdown_flag: Arc::new(AtomicBool::new(false)),
+            notify_rx,
+            drain_rx,
+            notify_queue: VecDeque::new(),
+            sweep_queue: VecDeque::new(),
+            queued: HashSet::new(),
+            sweep_interval: Duration::from_secs(600),
+            throttle_debt: Arc::new(std::sync::Mutex::new(Duration::ZERO)),
+            test_sink: Some(sink),
+            test_throttle: Some(Arc::new(|_| {})),
+        };
+        notify_tx
+            .send(TokenUsageTask {
+                session_id: "s_resume".to_string(),
+                tool: "claude".to_string(),
+                stream_path: resume.display().to_string(),
+            })
+            .unwrap();
+        worker.reconcile_flagged().await;
+        assert_eq!(
+            token_db.sessions_needing_reconcile().unwrap().len(),
+            1,
+            "one session settled, then control returned to the queued notification"
+        );
+
+        // With no pending traffic, the pass runs the flag set dry.
+        worker.notify_rx.try_recv().unwrap();
+        worker.reconcile_flagged().await;
+        assert!(token_db.sessions_needing_reconcile().unwrap().is_empty());
     }
 
     #[test]

--- a/src/daemon/token_usage_worker.rs
+++ b/src/daemon/token_usage_worker.rs
@@ -547,6 +547,7 @@ impl TokenUsageWorker {
                 &token_db,
                 &sink,
                 throttle,
+                origin,
                 &task_clone,
                 &shutdown_flag,
             )
@@ -710,6 +711,7 @@ fn process_task_blocking(
     token_db: &TokenUsageDatabase,
     sink: &impl Fn(&[MetricEvent]) -> Result<(), GitAiError>,
     throttle: Option<&(dyn Fn(Duration) + Sync)>,
+    origin: TaskOrigin,
     task: &TokenUsageTask,
     shutdown_flag: &AtomicBool,
 ) -> Result<(), GitAiError> {
@@ -758,7 +760,7 @@ fn process_task_blocking(
     // transcript — charging them here would put a healthy file into error
     // backoff and point diagnostics at the wrong session.
     if result.is_ok()
-        && throttle.is_none()
+        && origin == TaskOrigin::Notify
         && let Err(e) = reconcile_flagged_sessions(token_db, sink)
     {
         tracing::warn!(error = %e, "token-usage cross-session reconcile failed; flags retained for retry");
@@ -2241,6 +2243,7 @@ mod tests {
                 &token_db,
                 &|e| sink(e),
                 Some(&noop_throttle),
+                TaskOrigin::Sweep,
                 &TokenUsageTask {
                     session_id: session.to_string(),
                     tool: "claude".to_string(),
@@ -2262,6 +2265,7 @@ mod tests {
             &token_db,
             &|e| sink(e),
             None,
+            TaskOrigin::Notify,
             &TokenUsageTask {
                 session_id: "s_resume".to_string(),
                 tool: "claude".to_string(),
@@ -2647,6 +2651,7 @@ mod tests {
             &token_db,
             &|_: &[MetricEvent]| Ok(()),
             None,
+            TaskOrigin::Notify,
             &task,
             &AtomicBool::new(false),
         );
@@ -2908,6 +2913,7 @@ mod tests {
             &token_db,
             &|e| sink(e),
             None,
+            TaskOrigin::Notify,
             &task,
             &flag_off(),
         )
@@ -2931,6 +2937,7 @@ mod tests {
             &token_db,
             &|e| sink(e),
             None,
+            TaskOrigin::Notify,
             &task,
             &flag_off(),
         )
@@ -3121,6 +3128,7 @@ mod tests {
     /// parse batches.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     #[ignore]
+    #[cfg(target_os = "linux")] // CPU/RSS sampling reads /proc
     async fn bench_backfill_cpu_duty() {
         const BASE_SESSIONS: usize = 240;
         const LINES_PER_SESSION: usize = 800;

--- a/src/token_usage/db.rs
+++ b/src/token_usage/db.rs
@@ -685,9 +685,27 @@ impl TokenUsageDatabase {
     }
 
     /// One flagged session, for callers that reconcile incrementally and
-    /// hand control back between sessions.
+    /// hand control back between sessions (same grouped projection as
+    /// [`Self::sessions_needing_reconcile`], stopping at the first group).
     pub fn next_session_needing_reconcile(&self) -> Result<Option<ReconcileSession>, GitAiError> {
-        Ok(self.sessions_needing_reconcile()?.into_iter().next())
+        let conn = self.lock();
+        let mut stmt = conn.prepare(
+            "SELECT session_id, MAX(external_session_id), MAX(external_parent_session_id),
+                    MAX(tool), MAX(repo_url)
+             FROM tracked_files WHERE needs_reconcile = 1 GROUP BY session_id LIMIT 1",
+        )?;
+        Ok(stmt
+            .query_map([], |row| {
+                Ok(ReconcileSession {
+                    session_id: row.get(0)?,
+                    external_session_id: row.get(1)?,
+                    external_parent_session_id: row.get(2)?,
+                    tool: row.get(3)?,
+                    repo_url: row.get(4)?,
+                })
+            })?
+            .next()
+            .transpose()?)
     }
 
     /// Persist the repo_url the session's events are emitted with, so later

--- a/src/token_usage/db.rs
+++ b/src/token_usage/db.rs
@@ -454,6 +454,23 @@ pub struct ReconcileSession {
     pub repo_url: Option<String>,
 }
 
+/// Grouped projection of the flagged sessions, shared by the full listing
+/// and the incremental single-session fetch so the two can never diverge.
+const RECONCILE_SESSIONS_SQL: &str =
+    "SELECT session_id, MAX(external_session_id), MAX(external_parent_session_id),
+            MAX(tool), MAX(repo_url)
+     FROM tracked_files WHERE needs_reconcile = 1 GROUP BY session_id";
+
+fn read_reconcile_session(row: &rusqlite::Row<'_>) -> rusqlite::Result<ReconcileSession> {
+    Ok(ReconcileSession {
+        session_id: row.get(0)?,
+        external_session_id: row.get(1)?,
+        external_parent_session_id: row.get(2)?,
+        tool: row.get(3)?,
+        repo_url: row.get(4)?,
+    })
+}
+
 /// One extracted batch to persist atomically.
 pub struct BatchCommit<'a> {
     pub session_id: &'a str,
@@ -667,20 +684,8 @@ impl TokenUsageDatabase {
     /// file: identity plus the repo_url their events were last emitted with.
     pub fn sessions_needing_reconcile(&self) -> Result<Vec<ReconcileSession>, GitAiError> {
         let conn = self.lock();
-        let mut stmt = conn.prepare(
-            "SELECT session_id, MAX(external_session_id), MAX(external_parent_session_id),
-                    MAX(tool), MAX(repo_url)
-             FROM tracked_files WHERE needs_reconcile = 1 GROUP BY session_id",
-        )?;
-        let rows = stmt.query_map([], |row| {
-            Ok(ReconcileSession {
-                session_id: row.get(0)?,
-                external_session_id: row.get(1)?,
-                external_parent_session_id: row.get(2)?,
-                tool: row.get(3)?,
-                repo_url: row.get(4)?,
-            })
-        })?;
+        let mut stmt = conn.prepare(RECONCILE_SESSIONS_SQL)?;
+        let rows = stmt.query_map([], read_reconcile_session)?;
         Ok(rows.collect::<Result<Vec<_>, _>>()?)
     }
 
@@ -689,21 +694,9 @@ impl TokenUsageDatabase {
     /// [`Self::sessions_needing_reconcile`], stopping at the first group).
     pub fn next_session_needing_reconcile(&self) -> Result<Option<ReconcileSession>, GitAiError> {
         let conn = self.lock();
-        let mut stmt = conn.prepare(
-            "SELECT session_id, MAX(external_session_id), MAX(external_parent_session_id),
-                    MAX(tool), MAX(repo_url)
-             FROM tracked_files WHERE needs_reconcile = 1 GROUP BY session_id LIMIT 1",
-        )?;
+        let mut stmt = conn.prepare(&format!("{RECONCILE_SESSIONS_SQL} LIMIT 1"))?;
         Ok(stmt
-            .query_map([], |row| {
-                Ok(ReconcileSession {
-                    session_id: row.get(0)?,
-                    external_session_id: row.get(1)?,
-                    external_parent_session_id: row.get(2)?,
-                    tool: row.get(3)?,
-                    repo_url: row.get(4)?,
-                })
-            })?
+            .query_map([], read_reconcile_session)?
             .next()
             .transpose()?)
     }

--- a/src/token_usage/db.rs
+++ b/src/token_usage/db.rs
@@ -684,6 +684,12 @@ impl TokenUsageDatabase {
         Ok(rows.collect::<Result<Vec<_>, _>>()?)
     }
 
+    /// One flagged session, for callers that reconcile incrementally and
+    /// hand control back between sessions.
+    pub fn next_session_needing_reconcile(&self) -> Result<Option<ReconcileSession>, GitAiError> {
+        Ok(self.sessions_needing_reconcile()?.into_iter().next())
+    }
+
     /// Persist the repo_url the session's events are emitted with, so later
     /// DB-only corrections carry the same repo gate attribute. Never erases
     /// a stored value (a transient resolution failure must not drop it).


### PR DESCRIPTION
## Problem

A cold token-usage backfill (observed with ~1,100-session corpora on two machines) ran far above the worker's 30% CPU duty target: sustained 40-50% with one-second samples up to 100%, worst late in the cycle. Three kinds of sweep work escaped the throttle, and a fourth pipeline had no governor at all:

1. **Small files paid nothing.** Batches under the 5ms `THROTTLE_MIN_WORK` floor were forgiven entirely, per batch. Most real transcripts are a single batch of a few milliseconds, so a backlog of them ran completely unthrottled.
2. **Emission was never charged.** `emit_changed_buckets` and pass setup (config lookup, fork parent-prefix resolution) ran outside the batch timer.
3. **Cross-session reconciliation ran inline after every task, unthrottled**, re-aggregating all flagged sessions after each file of a backfill.
4. **The periodic metrics flush drained pending uploads at full speed on its own thread** — a backfill's emission volume was serialized/uploaded as fast as the network allowed, entirely outside the duty cycle (against a local server it saturates a core; over a real network it shows as 40-50% one-second spikes).

## Fix

- **Debt-carrying throttle** (`settle_throttle_debt`): the floor and the 5s cap defer payment, never forgive it. `process_file` charges the whole pass — setup folds into the first batch, emission is its own segment; batches are additionally time-bounded (150ms) for slow disks. Quiet skips stay free.
- **Deferred, incremental reconciliation**: sweep passes leave the durable flags for the run loop, which settles them once the backlog drains (plus sweep ticks and startup) — one session per blocking job under the select-on-shutdown pattern, yielding to fresh notify/drain traffic. Notify passes still reconcile inline for the drain barrier, and `handle_drain` settles any remaining flags *before* acknowledging, so `git-ai await` never reports success while a correction it produced is pending.
- **One shared duty cycle for all background work**: periodic metrics flushes charge each store/upload segment to the same process-wide ledger the sweep charges. Pauses are serialized reservations (`paused_until`) so concurrent pipelines can't overlap their sleeps and double the effective duty; reservations are granted only up to a `now + 5s` horizon (no caller ever waits past one capped pause) with the refused remainder refunded to the debt ledger. Paced drains are bounded to 16×250-row batches per 3s cycle (iteration-counted, so filtered/malformed backlogs can't loop unpaced) — pending rows are durable and resume next tick. Awaited flushes keep full-speed, full-envelope draining.

## Proof

Two ignored Linux benches drive the real `run()` loop sampling process CPU/RSS at 100ms:

- `bench_backfill_cpu_duty` (880 files / 80MiB: bulk, small-file, codex-fork, sidechain, resume phases): before **avg 34%, p95 50%, max 100%**; after **avg 31%, p95 40%, max 50%**, flat timeline, identical total CPU.
- `bench_giant_transcripts_cpu_rss` (ten 300MB-2GB transcripts, ~7.7GiB, incl. a fork child streaming a 1GB parent and 100MB/50MB pathological single lines): steady RSS 27MiB with a single 126MiB sample at the 100MB line — memory is bounded by the largest line, not file size.
- Live daemon, isolated-HOME rig, worst-case 159k-event pending upload backlog: unpaced saturates a core for the whole drain; paced holds a **35% one-second maximum (2 of 562 seconds above 30%)** with RSS high-water down from 74MiB to 52MiB.
- Live cold backfill over a 720MB real corpus (1,030 sessions): active-second average 22.7%, RSS ≤47MiB; daemon-restart rescan re-sweeps in 15ms at ~0.1% CPU.

Behavior is pinned by unit tests for the debt ledger, serialized/horizon-capped reservations, per-segment charge sites, deferred/incremental/pre-ack reconciliation, and paced-drain bounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
