### PR TITLE
feat(daemon): log checkpoint admission delayed behind trace ingestion

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -112,6 +112,11 @@ const CHECKPOINT_FAMILY_DRAIN_CONCURRENCY: usize = 2;
 /// semaphore: they run on the blocking pool and must not be starved by
 /// long command passes.
 const COMMAND_SIDE_EFFECT_CONCURRENCY: usize = 2;
+/// How long an accepted checkpoint may wait on the trace-ingest watermark
+/// before the delay is logged, and the cadence of repeat logs while it keeps
+/// waiting. Healthy admission takes milliseconds; a wait this long means
+/// trace ingestion is stalled and must be visible in the logs (#2252).
+const CHECKPOINT_ADMISSION_DELAY_LOG_INTERVAL: Duration = Duration::from_secs(5);
 // Trace2 frames are written synchronously by Git to the daemon's Unix socket.
 // With small kernel socket buffers (macOS defaults to ~8 KiB), a bursty trace2
 // stream can fill the buffer and block the raw `git` process in `write()` until
@@ -165,6 +170,9 @@ struct CheckpointIngressReservation {
 struct AcceptedCheckpoint {
     receipt_seq: u64,
     received_at_ns: u128,
+    /// Monotonic receipt timestamp for admission-delay measurement;
+    /// `received_at_ns` is wall-clock and can move backwards.
+    received_at: std::time::Instant,
     trace_ingest_target: u64,
     body: Vec<u8>,
     reservation: CheckpointIngressReservation,
@@ -4498,8 +4506,12 @@ impl ActorDaemonCoordinator {
         });
 
         self.notify_checkpoint_stream(&request);
-        self.wait_for_trace_ingest_seq(accepted.trace_ingest_target)
-            .await;
+        self.wait_for_trace_ingest_seq_logging_delay(
+            accepted.trace_ingest_target,
+            accepted.receipt_seq,
+            accepted.received_at,
+        )
+        .await;
 
         tracing::info!(
             component = "daemon",
@@ -4695,6 +4707,58 @@ impl ActorDaemonCoordinator {
             tokio::select! {
                 _ = &mut progress => {}
                 _ = self.wait_for_shutdown() => return,
+            }
+        }
+    }
+
+    fn checkpoint_admission_delay_log_interval() -> Duration {
+        #[cfg(feature = "test-support")]
+        if let Ok(raw) = std::env::var("GIT_AI_TEST_CHECKPOINT_ADMISSION_DELAY_LOG_INTERVAL_MS")
+            && let Ok(interval_ms) = raw.parse::<u64>()
+            && interval_ms > 0
+        {
+            return Duration::from_millis(interval_ms);
+        }
+
+        CHECKPOINT_ADMISSION_DELAY_LOG_INTERVAL
+    }
+
+    /// As [`Self::wait_for_trace_ingest_seq`], but logs whenever the total
+    /// time since the checkpoint's receipt exceeds
+    /// [`CHECKPOINT_ADMISSION_DELAY_LOG_INTERVAL`], so a stalled trace-ingest
+    /// watermark shows up as delayed checkpoint admission instead of having
+    /// to be inferred from absent admission log lines. Admission is serial,
+    /// so a checkpoint can spend most of its delay queued behind the
+    /// head-of-line one; measuring from receipt makes the first warning for
+    /// such a checkpoint fire immediately once its turn comes, and
+    /// `unadmitted_checkpoints` shows how many more are queued behind.
+    async fn wait_for_trace_ingest_seq_logging_delay(
+        &self,
+        target: u64,
+        receipt_seq: u64,
+        received_at: std::time::Instant,
+    ) {
+        let log_interval = Self::checkpoint_admission_delay_log_interval();
+        let mut next_log_in = log_interval.saturating_sub(received_at.elapsed());
+        loop {
+            match tokio::time::timeout(next_log_in, self.wait_for_trace_ingest_seq(target)).await {
+                Ok(()) => return,
+                Err(_) => {
+                    tracing::warn!(
+                        component = "daemon",
+                        phase = "checkpoint_admission",
+                        reason = "admission_delayed_by_trace_ingest",
+                        receipt_seq,
+                        trace_ingest_target = target,
+                        processed_trace_ingest_seq =
+                            self.processed_trace_ingest_seq.load(Ordering::Acquire) as u64,
+                        unadmitted_checkpoints =
+                            self.unadmitted_checkpoints.load(Ordering::Acquire) as u64,
+                        waited_ms = received_at.elapsed().as_millis() as u64,
+                        "checkpoint admission delayed waiting for trace ingestion"
+                    );
+                    next_log_in = log_interval;
+                }
             }
         }
     }
@@ -8304,6 +8368,7 @@ fn handle_control_connection_actor_reader<R: ControlConnection>(
                             as u64
                             + 1;
                         let received_at_ns = now_unix_nanos();
+                        let received_at = std::time::Instant::now();
                         let trace_ingest_target =
                             coordinator.next_trace_ingest_seq.load(Ordering::Acquire) as u64;
                         coordinator
@@ -8312,6 +8377,7 @@ fn handle_control_connection_actor_reader<R: ControlConnection>(
                         permit.send(AcceptedCheckpoint {
                             receipt_seq,
                             received_at_ns,
+                            received_at,
                             trace_ingest_target,
                             body,
                             reservation,

--- a/tests/daemon_mode.rs
+++ b/tests/daemon_mode.rs
@@ -2451,6 +2451,101 @@ fn sync_family_covers_cross_repo_side_effects_of_other_families() {
     );
 }
 
+/// #2252 observability: when checkpoint admission is delayed behind the
+/// trace-ingest watermark, the daemon must log the delay explicitly instead
+/// of it having to be inferred from absent admission log lines.
+#[test]
+#[cfg(not(windows))]
+fn delayed_checkpoint_admission_is_logged() {
+    let repo = TestRepo::new_with_daemon_scope(DaemonTestScope::NoDaemon);
+    // Delay the trace ingest worker's start so the synthetic frames below are
+    // enqueued but the watermark checkpoint admission waits on cannot advance.
+    // The delay-log interval is lowered so the warning fires well within the
+    // stall window even when daemon startup eats seconds on a loaded runner.
+    let mut daemon = DaemonGuard::start_with_env(
+        &repo,
+        &[
+            ("GIT_AI_TEST_TRACE_INGEST_WORKER_START_DELAY_MS", "10000"),
+            (
+                "GIT_AI_TEST_CHECKPOINT_ADMISSION_DELAY_LOG_INTERVAL_MS",
+                "500",
+            ),
+        ],
+    );
+    let worktree = repo_workdir_string(&repo);
+    let git_dir = repo.path().join(".git").to_string_lossy().to_string();
+
+    send_trace_frames(
+        &daemon_trace_socket_path(&repo),
+        &[
+            json!({
+                "event": "start",
+                "sid": "stalled-ingest-root",
+                "argv": ["git", "commit", "-m", "synthetic"],
+                "time_ns": 10_000u64,
+            }),
+            json!({
+                "event": "def_repo",
+                "sid": "stalled-ingest-root",
+                "worktree": worktree,
+                "repo": git_dir,
+                "time_ns": 10_001u64,
+            }),
+            json!({
+                "event": "exit",
+                "sid": "stalled-ingest-root",
+                "code": 0,
+                "time_ns": 10_100u64,
+            }),
+            trace_atexit_frame("stalled-ingest-root", 0, 10_101u64),
+        ],
+    );
+    // Let the trace reader enqueue the frames (allocating ingest sequence
+    // numbers) before the checkpoint samples its admission target.
+    thread::sleep(Duration::from_millis(200));
+
+    fs::write(repo.path().join("delayed.txt"), "delayed\n").unwrap();
+    let checkpoint = CheckpointRequest {
+        trace_id: "delayed-admission-checkpoint".to_string(),
+        checkpoint_kind: CheckpointKind::AiAgent,
+        agent_id: Some(AgentId {
+            tool: "mock_ai".to_string(),
+            id: "delayed-admission-checkpoint".to_string(),
+            model: "test".to_string(),
+        }),
+        files: vec![CheckpointFile {
+            path: PathBuf::from("delayed.txt"),
+            content: Some("delayed\n".to_string()),
+            repo_work_dir: repo.path().to_path_buf(),
+            base_commit: BaseCommit::Initial,
+        }],
+        path_role: PreparedPathRole::Edited,
+        stream_source: None,
+        metadata: Default::default(),
+    };
+    let response = send_checkpoint_request_with_timeout(
+        &daemon_control_socket_path(&repo),
+        &checkpoint,
+        Duration::from_secs(2),
+    )
+    .expect("checkpoint should be acknowledged while trace ingest is stalled");
+    assert!(response.ok, "checkpoint failed: {response:?}");
+
+    let started = std::time::Instant::now();
+    loop {
+        let logs = daemon.stderr_contents();
+        if logs.contains("checkpoint admission delayed waiting for trace ingestion") {
+            break;
+        }
+        assert!(
+            started.elapsed() < Duration::from_secs(9),
+            "stalled checkpoint admission was not logged (#2252); daemon logs:\n{logs}"
+        );
+        thread::sleep(Duration::from_millis(50));
+    }
+    daemon.shutdown();
+}
+
 #[test]
 #[cfg(not(windows))]
 fn daemon_checkpoint_processing_failure_is_logged_after_receipt_ack() {


### PR DESCRIPTION
## Summary

Observability follow-up for #2252 (stacked on the fix PR), implementing the issue's third suggested direction:

> Emit an explicit log line when ingress admission is delayed beyond a threshold (seq 77-84 above had to be inferred from the absence of admission lines).

Checkpoint admission waits on the trace-ingest watermark. In the incident, checkpoints sat "received into bounded ingress" with no admission line, and the stall had to be inferred from absent logs. Admission now logs a warning once the wait exceeds 5 seconds (`CHECKPOINT_ADMISSION_DELAY_LOG_INTERVAL`), repeating at that cadence while it persists:

```
WARN checkpoint admission delayed waiting for trace ingestion component="daemon" phase="checkpoint_admission" reason="admission_delayed_by_trace_ingest" receipt_seq=77 trace_ingest_target=1042 processed_trace_ingest_seq=1017 waited_ms=5000
```

The healthy path is unaffected: `wait_for_trace_ingest_seq` checks the watermark atomically before enrolling in the notify, so when admission completes in milliseconds the 5s timer is never observably involved, and the wrapped wait is safe to cancel/retry (the inner loop re-enrolls before every re-check, so no wakeups are lost; shutdown still exits the loop).

The interval is overridable in test builds via `GIT_AI_TEST_CHECKPOINT_ADMISSION_DELAY_LOG_INTERVAL_MS` so the test below keeps a wide margin on slow CI runners instead of racing daemon startup against the 5s threshold.

## Tests (TDD)

- `delayed_checkpoint_admission_is_logged` — stalls the ingest worker with the existing `GIT_AI_TEST_TRACE_INGEST_WORKER_START_DELAY_MS` hook, enqueues synthetic mutating trace frames, submits a checkpoint, and asserts the warning appears. Fails without this change.
