### PR TITLE
streams: one shared bounded JSONL reader for all line-oriented agents

### DIFF
--- a/src/daemon/token_usage_worker.rs
+++ b/src/daemon/token_usage_worker.rs
@@ -70,6 +70,10 @@ enum LineRead {
     /// reader advanced past its newline, so one giant transcript line cannot
     /// balloon daemon RSS (#2244).
     Oversized(usize),
+    /// Line exceeded `max_line_bytes` but reached EOF before a newline: the
+    /// writer may still be appending. The cursor must stay before the line —
+    /// resuming mid-line would extract its tail as bogus usage data.
+    OversizedPartial,
 }
 
 /// Lossy byte-level sibling of `streams::types::read_jsonl_line`: it must
@@ -95,7 +99,10 @@ fn read_line_bytes(
             // Cap hit mid-line: discard the buffered prefix and skip the rest
             // of the physical line without storing it.
             buf.clear();
-            let skipped = reader.skip_until(b'\n')?;
+            let (skipped, terminated) = crate::streams::types::skip_line_remainder(reader)?;
+            if !terminated {
+                return Ok(LineRead::OversizedPartial);
+            }
             return Ok(LineRead::Oversized(bytes + skipped));
         }
         return Ok(LineRead::Partial(bytes));
@@ -864,6 +871,12 @@ fn process_file(
                         break;
                     }
                 }
+                // An oversized line still being written: stop with the cursor
+                // before it; a later pass consumes it whole once terminated.
+                LineRead::OversizedPartial => {
+                    reached_end = true;
+                    break;
+                }
                 // Advance past the skipped line; counting it toward the batch
                 // budget keeps commit cadence, so the persisted cursor moves
                 // beyond the giant line promptly.
@@ -1027,6 +1040,21 @@ mod tests {
                 assert_eq!(String::from_utf8_lossy(&buf).trim_end(), "{\"ok\":1}")
             }
             _ => panic!("expected the next line to read normally"),
+        }
+    }
+
+    #[test]
+    fn read_line_bytes_unterminated_oversized_line_is_partial() {
+        // The cursor must stay before a giant line still being written:
+        // resuming mid-line would extract its tail as bogus usage data.
+        let cap: u64 = 64;
+        let big = "x".repeat(cap as usize + 100);
+        let mut reader = std::io::BufReader::new(big.as_bytes());
+        let mut buf = Vec::new();
+
+        match read_line_bytes(&mut reader, &mut buf, cap).unwrap() {
+            LineRead::OversizedPartial => {}
+            _ => panic!("expected OversizedPartial for an unterminated giant line"),
         }
     }
 

--- a/src/daemon/token_usage_worker.rs
+++ b/src/daemon/token_usage_worker.rs
@@ -66,18 +66,38 @@ enum LineRead {
     /// No trailing newline: the writer may still be appending.
     Partial(usize),
     Complete(usize),
+    /// Line exceeded `max_line_bytes`; the content was discarded and the
+    /// reader advanced past its newline, so one giant transcript line cannot
+    /// balloon daemon RSS (#2244).
+    Oversized(usize),
 }
 
+/// Lossy byte-level sibling of `streams::types::read_jsonl_line`: it must
+/// stay byte-based (not UTF-8-strict) for ccusage parity, so the two readers
+/// share the config cap but not an implementation.
 fn read_line_bytes(
     reader: &mut impl std::io::BufRead,
     buf: &mut Vec<u8>,
+    max_line_bytes: u64,
 ) -> std::io::Result<LineRead> {
+    use std::io::{BufRead, Read};
+
     buf.clear();
-    let bytes = reader.read_until(b'\n', buf)?;
+    let bytes = reader
+        .by_ref()
+        .take(max_line_bytes)
+        .read_until(b'\n', buf)?;
     if bytes == 0 {
         return Ok(LineRead::Eof);
     }
     if buf.last() != Some(&b'\n') {
+        if bytes as u64 == max_line_bytes {
+            // Cap hit mid-line: discard the buffered prefix and skip the rest
+            // of the physical line without storing it.
+            buf.clear();
+            let skipped = reader.skip_until(b'\n')?;
+            return Ok(LineRead::Oversized(bytes + skipped));
+        }
         return Ok(LineRead::Partial(bytes));
     }
     Ok(LineRead::Complete(bytes))
@@ -794,6 +814,7 @@ fn process_file(
     reader.seek(SeekFrom::Start(offset))?;
 
     let cutoff = retention_cutoff_bucket(now);
+    let max_line_bytes = crate::config::Config::get().max_transcript_line_bytes();
     let mut line: Vec<u8> = Vec::new();
     let mut reached_end = false;
     let mut interrupted = false;
@@ -806,7 +827,7 @@ fn process_file(
                 interrupted = true;
                 break;
             }
-            match read_line_bytes(&mut reader, &mut line)? {
+            match read_line_bytes(&mut reader, &mut line, max_line_bytes)? {
                 LineRead::Eof => {
                     reached_end = true;
                     break;
@@ -839,6 +860,21 @@ fn process_file(
                     if extractor.wants_line(trimmed) {
                         entries.extend(extractor.extract_line(trimmed));
                     }
+                    if entries.len() >= BATCH_MAX_ENTRIES || consumed >= BATCH_MAX_BYTES {
+                        break;
+                    }
+                }
+                // Advance past the skipped line; counting it toward the batch
+                // budget keeps commit cadence, so the persisted cursor moves
+                // beyond the giant line promptly.
+                LineRead::Oversized(bytes) => {
+                    tracing::warn!(
+                        session_id = %identity.session_id,
+                        max_bytes = max_line_bytes,
+                        "token usage: skipping oversized transcript line"
+                    );
+                    offset += bytes as u64;
+                    consumed += bytes;
                     if entries.len() >= BATCH_MAX_ENTRIES || consumed >= BATCH_MAX_BYTES {
                         break;
                     }
@@ -969,6 +1005,40 @@ mod tests {
     use crate::metrics::events::token_usage_pos;
     use std::fs;
     use std::sync::Mutex;
+
+    #[test]
+    fn read_line_bytes_skips_oversized_lines_and_recovers() {
+        let cap: u64 = 64;
+        let big = "x".repeat(cap as usize + 100);
+        let data = format!("{big}\n{{\"ok\":1}}\n");
+        let mut reader = std::io::BufReader::new(data.as_bytes());
+        let mut buf = Vec::new();
+
+        match read_line_bytes(&mut reader, &mut buf, cap).unwrap() {
+            LineRead::Oversized(consumed) => {
+                assert_eq!(consumed, big.len() + 1);
+                assert!(buf.is_empty(), "oversized content must not be retained");
+            }
+            _ => panic!("expected Oversized for a line beyond the cap"),
+        }
+
+        match read_line_bytes(&mut reader, &mut buf, cap).unwrap() {
+            LineRead::Complete(_) => {
+                assert_eq!(String::from_utf8_lossy(&buf).trim_end(), "{\"ok\":1}")
+            }
+            _ => panic!("expected the next line to read normally"),
+        }
+    }
+
+    #[test]
+    fn read_line_bytes_keeps_partial_semantics_below_cap() {
+        let mut reader = std::io::BufReader::new(&b"{\"unfinished\":1"[..]);
+        let mut buf = Vec::new();
+        match read_line_bytes(&mut reader, &mut buf, 64).unwrap() {
+            LineRead::Partial(bytes) => assert_eq!(bytes, 15),
+            _ => panic!("expected Partial for an unterminated in-cap line"),
+        }
+    }
 
     fn identity() -> SessionIdentity {
         SessionIdentity {

--- a/src/streams/agents/claude.rs
+++ b/src/streams/agents/claude.rs
@@ -4,7 +4,7 @@ use crate::authorship::authorship_log_serialization::generate_session_id;
 use crate::streams::agent::{Agent, PathResolverKind, StreamDescriptor};
 use crate::streams::sweep::{DiscoveredSession, StreamFormat, SweepStrategy};
 use crate::streams::types::{StreamBatch, StreamError};
-use crate::streams::watermark::{ByteOffsetWatermark, WatermarkStrategy};
+use crate::streams::watermark::WatermarkStrategy;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -143,97 +143,17 @@ impl Agent for ClaudeAgent {
         watermark: Box<dyn WatermarkStrategy>,
         session_id: &str,
     ) -> Result<StreamBatch, StreamError> {
-        use std::fs::File;
-        use std::io::{BufReader, Seek, SeekFrom};
-
-        let byte_watermark = watermark
-            .as_any()
-            .downcast_ref::<ByteOffsetWatermark>()
-            .ok_or_else(|| StreamError::Fatal {
-                message: format!(
-                    "Claude reader requires ByteOffsetWatermark, got incompatible type for session {}",
-                    session_id
-                ),
-            })?;
-
-        let start_offset = byte_watermark.0;
-
-        let file = File::open(path).map_err(|e| {
-            if e.kind() == std::io::ErrorKind::NotFound {
-                StreamError::Fatal {
-                    message: format!("Transcript file not found: {}", path.display()),
-                }
-            } else if e.kind() == std::io::ErrorKind::PermissionDenied {
-                StreamError::Fatal {
-                    message: format!("Permission denied reading transcript: {}", path.display()),
-                }
-            } else {
-                StreamError::Transient {
-                    message: format!("Failed to open transcript file: {}", e),
-                    retry_after: std::time::Duration::from_secs(5),
-                }
-            }
-        })?;
-
-        let mut reader = BufReader::new(file);
-
-        reader
-            .seek(SeekFrom::Start(start_offset))
-            .map_err(|e| StreamError::Transient {
-                message: format!("Failed to seek to offset {}: {}", start_offset, e),
-                retry_after: std::time::Duration::from_secs(5),
-            })?;
-
-        let batch_limit = self.batch_size_hint();
-        let mut events = Vec::with_capacity(batch_limit);
-        let mut current_offset = start_offset;
-        let mut line_number = 0;
-
-        let mut line = String::new();
-        loop {
-            match crate::streams::types::read_jsonl_line(&mut reader, &mut line).map_err(|e| {
-                StreamError::Transient {
-                    message: format!("I/O error reading line: {}", e),
-                    retry_after: std::time::Duration::from_secs(5),
-                }
-            })? {
-                crate::streams::types::JsonlLineState::Eof => break,
-                crate::streams::types::JsonlLineState::Partial => break,
-                crate::streams::types::JsonlLineState::Complete(bytes_read) => {
-                    line_number += 1;
-                    current_offset += bytes_read as u64;
-                }
-            }
-
-            if line.trim().is_empty() {
-                continue;
-            }
-
-            let entry: serde_json::Value = match serde_json::from_str(&line) {
-                Ok(v) => v,
-                Err(e) => {
-                    tracing::warn!(
-                        line = line_number,
-                        path = %path.display(),
-                        error = %e,
-                        "skipping malformed JSON line"
-                    );
-                    continue;
-                }
-            };
-
-            events.push(entry);
-            if events.len() >= batch_limit {
-                break;
-            }
-        }
-
-        let new_watermark = Box::new(ByteOffsetWatermark::new(current_offset));
-
-        Ok(StreamBatch {
-            events,
-            new_watermark,
-        })
+        crate::streams::reader::read_jsonl_event_stream(
+            path,
+            watermark,
+            session_id,
+            &crate::streams::reader::JsonlReadOptions {
+                agent_label: "Claude",
+                batch_limit: self.batch_size_hint(),
+                mode: crate::streams::reader::JsonlWatermarkMode::ByteOffset,
+                event_filter: None,
+            },
+        )
     }
 
     fn extract_event_ids(
@@ -278,15 +198,10 @@ impl Agent for ClaudeAgent {
     }
 
     fn infer_cwd(&self, stream_path: &Path) -> Option<PathBuf> {
-        use std::fs::File;
-        use std::io::{BufRead, BufReader};
-
-        let file = File::open(stream_path).ok()?;
-        let reader = BufReader::new(file);
-
-        // Check up to 50 lines for a top-level "cwd" field
-        for line in reader.lines().take(50) {
-            let Ok(line) = line else { continue };
+        // Check up to 50 lines for a top-level "cwd" field (bounded reads:
+        // this runs before the capped batch loop, so a giant line must not
+        // balloon memory here).
+        for line in crate::streams::types::read_leading_jsonl_lines(stream_path, 50) {
             if line.is_empty() {
                 continue;
             }
@@ -317,6 +232,7 @@ impl Agent for ClaudeAgent {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::streams::watermark::ByteOffsetWatermark;
 
     #[test]
     fn test_detect_subagent_parent() {

--- a/src/streams/agents/codex.rs
+++ b/src/streams/agents/codex.rs
@@ -5,9 +5,8 @@ use crate::mdm::utils::codex_home_dir;
 use crate::streams::agent::{Agent, PathResolverKind, StreamDescriptor};
 use crate::streams::sweep::{DiscoveredSession, StreamFormat, SweepStrategy};
 use crate::streams::types::{StreamBatch, StreamError};
-use crate::streams::watermark::{ByteOffsetWatermark, WatermarkStrategy};
-use std::fs::{self, File};
-use std::io::{BufRead, BufReader, Seek, SeekFrom};
+use crate::streams::watermark::WatermarkStrategy;
+use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -135,9 +134,11 @@ impl CodexAgent {
     /// `payload.thread_source == "subagent"` and `payload.forked_from_id` containing
     /// the parent session UUID.
     pub fn detect_subagent_parent(path: &Path) -> Option<String> {
-        let file = File::open(path).ok()?;
-        let reader = BufReader::new(file);
-        let first_line = reader.lines().next()?.ok()?;
+        // Bounded read: an unbounded first-line read of a runaway transcript
+        // would balloon memory before any watermark exists.
+        let first_line = crate::streams::types::read_leading_jsonl_lines(path, 1)
+            .into_iter()
+            .next()?;
         if first_line.trim().is_empty() {
             return None;
         }
@@ -207,97 +208,17 @@ impl Agent for CodexAgent {
         watermark: Box<dyn WatermarkStrategy>,
         session_id: &str,
     ) -> Result<StreamBatch, StreamError> {
-        // Downcast watermark to ByteOffsetWatermark
-        let byte_watermark = watermark
-            .as_any()
-            .downcast_ref::<ByteOffsetWatermark>()
-            .ok_or_else(|| StreamError::Fatal {
-                message: format!(
-                    "Codex reader requires ByteOffsetWatermark, got incompatible type for session {}",
-                    session_id
-                ),
-            })?;
-
-        let start_offset = byte_watermark.0;
-
-        // Open file
-        let file = File::open(path).map_err(|e| {
-            if e.kind() == std::io::ErrorKind::NotFound {
-                StreamError::Fatal {
-                    message: format!("Transcript file not found: {}", path.display()),
-                }
-            } else if e.kind() == std::io::ErrorKind::PermissionDenied {
-                StreamError::Fatal {
-                    message: format!("Permission denied reading transcript: {}", path.display()),
-                }
-            } else {
-                StreamError::Transient {
-                    message: format!("Failed to open transcript file: {}", e),
-                    retry_after: Duration::from_secs(5),
-                }
-            }
-        })?;
-
-        let mut reader = BufReader::new(file);
-
-        // Seek to watermark position
-        reader
-            .seek(SeekFrom::Start(start_offset))
-            .map_err(|e| StreamError::Transient {
-                message: format!("Failed to seek to offset {}: {}", start_offset, e),
-                retry_after: Duration::from_secs(5),
-            })?;
-
-        let batch_limit = self.batch_size_hint();
-        let mut events = Vec::with_capacity(batch_limit);
-        let mut current_offset = start_offset;
-        let mut line_number = 0;
-        let mut line = String::new();
-
-        loop {
-            match crate::streams::types::read_jsonl_line(&mut reader, &mut line).map_err(|e| {
-                StreamError::Transient {
-                    message: format!("I/O error reading line: {}", e),
-                    retry_after: Duration::from_secs(5),
-                }
-            })? {
-                crate::streams::types::JsonlLineState::Eof => break,
-                crate::streams::types::JsonlLineState::Partial => break,
-                crate::streams::types::JsonlLineState::Complete(bytes_read) => {
-                    line_number += 1;
-                    current_offset += bytes_read as u64;
-                }
-            }
-
-            if line.trim().is_empty() {
-                continue;
-            }
-
-            let entry: serde_json::Value = match serde_json::from_str(&line) {
-                Ok(v) => v,
-                Err(e) => {
-                    tracing::warn!(
-                        line = line_number,
-                        path = %path.display(),
-                        error = %e,
-                        "skipping malformed JSON line"
-                    );
-                    continue;
-                }
-            };
-
-            events.push(entry);
-            if events.len() >= batch_limit {
-                break;
-            }
-        }
-
-        let new_watermark = Box::new(ByteOffsetWatermark::new(current_offset));
-
-        Ok(StreamBatch {
-            events,
-            new_watermark,
-        })
+        crate::streams::reader::read_jsonl_event_stream(
+            path,
+            watermark,
+            session_id,
+            &crate::streams::reader::JsonlReadOptions {
+                agent_label: "Codex",
+                batch_limit: self.batch_size_hint(),
+                mode: crate::streams::reader::JsonlWatermarkMode::ByteOffset,
+                event_filter: None,
+            },
+        )
     }
 
     fn extract_event_timestamp(
@@ -311,15 +232,10 @@ impl Agent for CodexAgent {
     }
 
     fn infer_cwd(&self, stream_path: &Path) -> Option<PathBuf> {
-        use std::fs::File;
-        use std::io::{BufRead, BufReader};
-
-        let file = File::open(stream_path).ok()?;
-        let reader = BufReader::new(file);
-
         // Codex has cwd in session_meta or turn_context payload events
-        for line in reader.lines().take(20) {
-            let Ok(line) = line else { continue };
+        // (bounded reads: this runs before the capped batch loop, so a giant
+        // line must not balloon memory here).
+        for line in crate::streams::types::read_leading_jsonl_lines(stream_path, 20) {
             if line.is_empty() {
                 continue;
             }
@@ -355,6 +271,7 @@ impl Agent for CodexAgent {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::streams::watermark::ByteOffsetWatermark;
 
     #[test]
     fn test_sweep_strategy() {

--- a/src/streams/agents/copilot.rs
+++ b/src/streams/agents/copilot.rs
@@ -4,11 +4,8 @@ use crate::authorship::authorship_log_serialization::generate_session_id;
 use crate::streams::agent::{Agent, PathResolverKind, StreamDescriptor};
 use crate::streams::sweep::{DiscoveredSession, StreamFormat, SweepStrategy};
 use crate::streams::types::{StreamBatch, StreamError};
-use crate::streams::watermark::{
-    ByteOffsetWatermark, RecordIndexWatermark, WatermarkStrategy, WatermarkType,
-};
+use crate::streams::watermark::{RecordIndexWatermark, WatermarkStrategy, WatermarkType};
 use std::fs;
-use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -365,9 +362,9 @@ impl Agent for CopilotAgent {
         }
 
         // Fallback: scan first few lines for file paths in tool calls
-        let file = fs::File::open(stream_path).ok()?;
-        let reader = BufReader::new(file);
-        for line in reader.lines().take(20).map_while(Result::ok) {
+        // (bounded reads: this runs before the capped batch loop, so a giant
+        // line must not balloon memory here).
+        for line in crate::streams::types::read_leading_jsonl_lines(stream_path, 20) {
             let Some(json) = serde_json::from_str::<serde_json::Value>(&line).ok() else {
                 continue;
             };
@@ -482,106 +479,23 @@ pub(super) fn read_event_stream(
     session_id: &str,
     batch_limit: usize,
 ) -> Result<StreamBatch, StreamError> {
-    use std::fs::File;
-    use std::io::{BufReader, Seek, SeekFrom};
-
-    // Downcast watermark to ByteOffsetWatermark
-    let byte_watermark = watermark
-        .as_any()
-        .downcast_ref::<ByteOffsetWatermark>()
-        .ok_or_else(|| StreamError::Fatal {
-            message: format!(
-                "Copilot event stream reader requires ByteOffsetWatermark, got incompatible type for session {}",
-                session_id
-            ),
-        })?;
-
-    let start_offset = byte_watermark.0;
-
-    // Open file
-    let file = File::open(path).map_err(|e| {
-        if e.kind() == std::io::ErrorKind::NotFound {
-            StreamError::Fatal {
-                message: format!("Transcript file not found: {}", path.display()),
-            }
-        } else if e.kind() == std::io::ErrorKind::PermissionDenied {
-            StreamError::Fatal {
-                message: format!("Permission denied reading transcript: {}", path.display()),
-            }
-        } else {
-            StreamError::Transient {
-                message: format!("Failed to open transcript file: {}", e),
-                retry_after: std::time::Duration::from_secs(5),
-            }
-        }
-    })?;
-
-    let mut reader = BufReader::new(file);
-
-    // Seek to watermark position
-    reader
-        .seek(SeekFrom::Start(start_offset))
-        .map_err(|e| StreamError::Transient {
-            message: format!("Failed to seek to offset {}: {}", start_offset, e),
-            retry_after: std::time::Duration::from_secs(5),
-        })?;
-
-    let mut events = Vec::with_capacity(batch_limit);
-    let mut current_offset = start_offset;
-    let mut line_number = 0;
-
-    // Read lines from watermark position
-    let mut line = String::new();
-    loop {
-        match crate::streams::types::read_jsonl_line(&mut reader, &mut line).map_err(|e| {
-            StreamError::Transient {
-                message: format!("I/O error reading line: {}", e),
-                retry_after: std::time::Duration::from_secs(5),
-            }
-        })? {
-            crate::streams::types::JsonlLineState::Eof => break,
-            crate::streams::types::JsonlLineState::Partial => break,
-            crate::streams::types::JsonlLineState::Complete(bytes_read) => {
-                line_number += 1;
-                current_offset += bytes_read as u64;
-            }
-        }
-
-        if line.trim().is_empty() {
-            continue;
-        }
-
-        let entry: serde_json::Value = match serde_json::from_str(&line) {
-            Ok(v) => v,
-            Err(e) => {
-                tracing::warn!(
-                    line = line_number,
-                    path = %path.display(),
-                    error = %e,
-                    "skipping malformed JSON line"
-                );
-                continue;
-            }
-        };
-
-        events.push(entry);
-        if events.len() >= batch_limit {
-            break;
-        }
-    }
-
-    // Create new watermark with updated offset
-    let new_watermark = Box::new(ByteOffsetWatermark::new(current_offset));
-
-    Ok(StreamBatch {
-        events,
-        new_watermark,
-    })
+    crate::streams::reader::read_jsonl_event_stream(
+        path,
+        watermark,
+        session_id,
+        &crate::streams::reader::JsonlReadOptions {
+            agent_label: "Copilot event stream",
+            batch_limit,
+            mode: crate::streams::reader::JsonlWatermarkMode::ByteOffset,
+            event_filter: None,
+        },
+    )
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::streams::watermark::ByteOffsetWatermark;
 
     #[test]
     fn test_sweep_strategy() {

--- a/src/streams/agents/copilot_cli.rs
+++ b/src/streams/agents/copilot_cli.rs
@@ -124,12 +124,9 @@ impl Agent for CopilotCliAgent {
     }
 
     fn infer_cwd(&self, stream_path: &Path) -> Option<PathBuf> {
-        use std::io::{BufRead, BufReader};
-
-        let file = fs::File::open(stream_path).ok()?;
-        let reader = BufReader::new(file);
-
-        for line in reader.lines().map_while(Result::ok).take(5) {
+        // Bounded reads: this runs before the capped batch loop, so a giant
+        // line must not balloon memory here.
+        for line in crate::streams::types::read_leading_jsonl_lines(stream_path, 5) {
             let trimmed = line.trim();
             if trimmed.is_empty() {
                 continue;

--- a/src/streams/agents/cursor.rs
+++ b/src/streams/agents/cursor.rs
@@ -4,7 +4,7 @@ use crate::authorship::authorship_log_serialization::generate_session_id;
 use crate::streams::agent::{Agent, PathResolverKind, StreamDescriptor};
 use crate::streams::sweep::{DiscoveredSession, StreamFormat, SweepStrategy};
 use crate::streams::types::{StreamBatch, StreamError};
-use crate::streams::watermark::{ByteOffsetWatermark, WatermarkStrategy};
+use crate::streams::watermark::WatermarkStrategy;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -115,97 +115,17 @@ impl Agent for CursorAgent {
         watermark: Box<dyn WatermarkStrategy>,
         session_id: &str,
     ) -> Result<StreamBatch, StreamError> {
-        use std::fs::File;
-        use std::io::{BufReader, Seek, SeekFrom};
-
-        let byte_watermark = watermark
-            .as_any()
-            .downcast_ref::<ByteOffsetWatermark>()
-            .ok_or_else(|| StreamError::Fatal {
-                message: format!(
-                    "Cursor reader requires ByteOffsetWatermark, got incompatible type for session {}",
-                    session_id
-                ),
-            })?;
-
-        let start_offset = byte_watermark.0;
-
-        let file = File::open(path).map_err(|e| {
-            if e.kind() == std::io::ErrorKind::NotFound {
-                StreamError::Fatal {
-                    message: format!("Transcript file not found: {}", path.display()),
-                }
-            } else if e.kind() == std::io::ErrorKind::PermissionDenied {
-                StreamError::Fatal {
-                    message: format!("Permission denied reading transcript: {}", path.display()),
-                }
-            } else {
-                StreamError::Transient {
-                    message: format!("Failed to open transcript file: {}", e),
-                    retry_after: std::time::Duration::from_secs(5),
-                }
-            }
-        })?;
-
-        let mut reader = BufReader::new(file);
-
-        reader
-            .seek(SeekFrom::Start(start_offset))
-            .map_err(|e| StreamError::Transient {
-                message: format!("Failed to seek to offset {}: {}", start_offset, e),
-                retry_after: std::time::Duration::from_secs(5),
-            })?;
-
-        let batch_limit = self.batch_size_hint();
-        let mut events = Vec::with_capacity(batch_limit);
-        let mut current_offset = start_offset;
-        let mut line_number = 0;
-
-        let mut line = String::new();
-        loop {
-            match crate::streams::types::read_jsonl_line(&mut reader, &mut line).map_err(|e| {
-                StreamError::Transient {
-                    message: format!("I/O error reading line: {}", e),
-                    retry_after: std::time::Duration::from_secs(5),
-                }
-            })? {
-                crate::streams::types::JsonlLineState::Eof => break,
-                crate::streams::types::JsonlLineState::Partial => break,
-                crate::streams::types::JsonlLineState::Complete(bytes_read) => {
-                    line_number += 1;
-                    current_offset += bytes_read as u64;
-                }
-            }
-
-            if line.trim().is_empty() {
-                continue;
-            }
-
-            let entry: serde_json::Value = match serde_json::from_str(&line) {
-                Ok(v) => v,
-                Err(e) => {
-                    tracing::warn!(
-                        line = line_number,
-                        path = %path.display(),
-                        error = %e,
-                        "skipping malformed JSON line"
-                    );
-                    continue;
-                }
-            };
-
-            events.push(entry);
-            if events.len() >= batch_limit {
-                break;
-            }
-        }
-
-        let new_watermark = Box::new(ByteOffsetWatermark::new(current_offset));
-
-        Ok(StreamBatch {
-            events,
-            new_watermark,
-        })
+        crate::streams::reader::read_jsonl_event_stream(
+            path,
+            watermark,
+            session_id,
+            &crate::streams::reader::JsonlReadOptions {
+                agent_label: "Cursor",
+                batch_limit: self.batch_size_hint(),
+                mode: crate::streams::reader::JsonlWatermarkMode::ByteOffset,
+                event_filter: None,
+            },
+        )
     }
 
     fn extract_event_timestamp(
@@ -234,6 +154,7 @@ impl Agent for CursorAgent {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::streams::watermark::ByteOffsetWatermark;
 
     #[test]
     fn test_sweep_strategy() {

--- a/src/streams/agents/droid.rs
+++ b/src/streams/agents/droid.rs
@@ -4,7 +4,7 @@ use crate::authorship::authorship_log_serialization::generate_session_id;
 use crate::streams::agent::{Agent, PathResolverKind, StreamDescriptor};
 use crate::streams::sweep::{DiscoveredSession, StreamFormat, SweepStrategy};
 use crate::streams::types::{StreamBatch, StreamError};
-use crate::streams::watermark::{HybridWatermark, WatermarkStrategy};
+use crate::streams::watermark::WatermarkStrategy;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -118,130 +118,20 @@ impl Agent for DroidAgent {
         watermark: Box<dyn WatermarkStrategy>,
         session_id: &str,
     ) -> Result<StreamBatch, StreamError> {
-        use std::fs::File;
-        use std::io::{BufReader, Seek, SeekFrom};
-
-        // Downcast watermark to HybridWatermark
-        let hybrid_watermark = watermark
-            .as_any()
-            .downcast_ref::<HybridWatermark>()
-            .ok_or_else(|| StreamError::Fatal {
-                message: format!(
-                    "Droid reader requires HybridWatermark, got incompatible type for session {}",
-                    session_id
-                ),
-            })?;
-
-        let start_offset = hybrid_watermark.offset;
-        let mut record_count = hybrid_watermark.record;
-
-        // Open file
-        let file = File::open(path).map_err(|e| {
-            if e.kind() == std::io::ErrorKind::NotFound {
-                StreamError::Fatal {
-                    message: format!("Transcript file not found: {}", path.display()),
-                }
-            } else if e.kind() == std::io::ErrorKind::PermissionDenied {
-                StreamError::Fatal {
-                    message: format!("Permission denied reading transcript: {}", path.display()),
-                }
-            } else {
-                StreamError::Transient {
-                    message: format!("Failed to open transcript file: {}", e),
-                    retry_after: std::time::Duration::from_secs(5),
-                }
-            }
-        })?;
-
-        let mut reader = BufReader::new(file);
-
-        // Seek to watermark position
-        reader
-            .seek(SeekFrom::Start(start_offset))
-            .map_err(|e| StreamError::Transient {
-                message: format!("Failed to seek to offset {}: {}", start_offset, e),
-                retry_after: std::time::Duration::from_secs(5),
-            })?;
-
-        let batch_limit = self.batch_size_hint();
-        let mut events = Vec::with_capacity(batch_limit);
-        let mut current_offset = start_offset;
-        let mut line_number = 0;
-        let mut latest_timestamp: Option<chrono::DateTime<chrono::Utc>> =
-            hybrid_watermark.timestamp;
-
-        // Read lines from watermark position
-        let mut line = String::new();
-        loop {
-            match crate::streams::types::read_jsonl_line(&mut reader, &mut line).map_err(|e| {
-                StreamError::Transient {
-                    message: format!("I/O error reading line: {}", e),
-                    retry_after: std::time::Duration::from_secs(5),
-                }
-            })? {
-                crate::streams::types::JsonlLineState::Eof => break,
-                crate::streams::types::JsonlLineState::Partial => break,
-                crate::streams::types::JsonlLineState::Complete(bytes_read) => {
-                    line_number += 1;
-                    current_offset += bytes_read as u64;
-                }
-            }
-
-            // Skip empty lines
-            if line.trim().is_empty() {
-                continue;
-            }
-
-            // Parse JSONL entry
-            let entry: serde_json::Value = match serde_json::from_str(&line) {
-                Ok(v) => v,
-                Err(e) => {
-                    tracing::warn!(
-                        line = line_number,
-                        path = %path.display(),
-                        error = %e,
-                        "skipping malformed JSON line"
-                    );
-                    continue;
-                }
-            };
-
-            // Only process "message" entries; skip session_start, todo_state, etc.
-            if entry["type"].as_str() != Some("message") {
-                continue;
-            }
-
-            // Track record count for hybrid watermark
-            record_count += 1;
-
-            // Update latest_timestamp for hybrid watermark
-            if let Some(ts_str) = entry["timestamp"].as_str()
-                && let Ok(dt) = chrono::DateTime::parse_from_rfc3339(ts_str)
-            {
-                let utc_dt = dt.with_timezone(&chrono::Utc);
-                if latest_timestamp.is_none() || Some(utc_dt) > latest_timestamp {
-                    latest_timestamp = Some(utc_dt);
-                }
-            }
-
-            // Push raw JSON entry
-            events.push(entry);
-            if events.len() >= batch_limit {
-                break;
-            }
-        }
-
-        // Create new hybrid watermark with updated offset, record count, and timestamp
-        let new_watermark = Box::new(HybridWatermark::new(
-            current_offset,
-            record_count,
-            latest_timestamp,
-        ));
-
-        Ok(StreamBatch {
-            events,
-            new_watermark,
-        })
+        // Only "message" entries are emitted; session_start, todo_state, etc.
+        // advance the offset and hybrid record state without being returned.
+        let message_filter = |entry: &serde_json::Value| entry["type"].as_str() == Some("message");
+        crate::streams::reader::read_jsonl_event_stream(
+            path,
+            watermark,
+            session_id,
+            &crate::streams::reader::JsonlReadOptions {
+                agent_label: "Droid",
+                batch_limit: self.batch_size_hint(),
+                mode: crate::streams::reader::JsonlWatermarkMode::Hybrid,
+                event_filter: Some(&message_filter),
+            },
+        )
     }
 
     fn extract_event_timestamp(
@@ -271,6 +161,7 @@ impl Agent for DroidAgent {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::streams::watermark::HybridWatermark;
 
     fn make_droid_line(i: usize) -> String {
         format!(

--- a/src/streams/agents/gemini.rs
+++ b/src/streams/agents/gemini.rs
@@ -5,7 +5,7 @@ use crate::mdm::utils::gemini_config_dir;
 use crate::streams::agent::{Agent, PathResolverKind, StreamDescriptor};
 use crate::streams::sweep::{DiscoveredSession, StreamFormat, SweepStrategy};
 use crate::streams::types::{StreamBatch, StreamError};
-use crate::streams::watermark::{ByteOffsetWatermark, WatermarkStrategy};
+use crate::streams::watermark::WatermarkStrategy;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -117,97 +117,17 @@ impl Agent for GeminiAgent {
         watermark: Box<dyn WatermarkStrategy>,
         session_id: &str,
     ) -> Result<StreamBatch, StreamError> {
-        use std::fs::File;
-        use std::io::{BufReader, Seek, SeekFrom};
-
-        let byte_watermark = watermark
-            .as_any()
-            .downcast_ref::<ByteOffsetWatermark>()
-            .ok_or_else(|| StreamError::Fatal {
-                message: format!(
-                    "Gemini reader requires ByteOffsetWatermark, got incompatible type for session {}",
-                    session_id
-                ),
-            })?;
-
-        let start_offset = byte_watermark.0;
-
-        let file = File::open(path).map_err(|e| {
-            if e.kind() == std::io::ErrorKind::NotFound {
-                StreamError::Fatal {
-                    message: format!("Transcript file not found: {}", path.display()),
-                }
-            } else if e.kind() == std::io::ErrorKind::PermissionDenied {
-                StreamError::Fatal {
-                    message: format!("Permission denied reading transcript: {}", path.display()),
-                }
-            } else {
-                StreamError::Transient {
-                    message: format!("Failed to read transcript file: {}", e),
-                    retry_after: Duration::from_secs(5),
-                }
-            }
-        })?;
-
-        let mut reader = BufReader::new(file);
-
-        reader
-            .seek(SeekFrom::Start(start_offset))
-            .map_err(|e| StreamError::Transient {
-                message: format!("Failed to seek to offset {}: {}", start_offset, e),
-                retry_after: Duration::from_secs(5),
-            })?;
-
-        let batch_limit = self.batch_size_hint();
-        let mut events = Vec::with_capacity(batch_limit);
-        let mut current_offset = start_offset;
-        let mut line_number = 0;
-
-        let mut line = String::new();
-        loop {
-            match crate::streams::types::read_jsonl_line(&mut reader, &mut line).map_err(|e| {
-                StreamError::Transient {
-                    message: format!("I/O error reading line: {}", e),
-                    retry_after: Duration::from_secs(5),
-                }
-            })? {
-                crate::streams::types::JsonlLineState::Eof => break,
-                crate::streams::types::JsonlLineState::Partial => break,
-                crate::streams::types::JsonlLineState::Complete(bytes_read) => {
-                    line_number += 1;
-                    current_offset += bytes_read as u64;
-                }
-            }
-
-            if line.trim().is_empty() {
-                continue;
-            }
-
-            let entry: serde_json::Value = match serde_json::from_str(&line) {
-                Ok(v) => v,
-                Err(e) => {
-                    tracing::warn!(
-                        line = line_number,
-                        path = %path.display(),
-                        error = %e,
-                        "skipping malformed JSON line"
-                    );
-                    continue;
-                }
-            };
-
-            events.push(entry);
-            if events.len() >= batch_limit {
-                break;
-            }
-        }
-
-        let new_watermark = Box::new(ByteOffsetWatermark::new(current_offset));
-
-        Ok(StreamBatch {
-            events,
-            new_watermark,
-        })
+        crate::streams::reader::read_jsonl_event_stream(
+            path,
+            watermark,
+            session_id,
+            &crate::streams::reader::JsonlReadOptions {
+                agent_label: "Gemini",
+                batch_limit: self.batch_size_hint(),
+                mode: crate::streams::reader::JsonlWatermarkMode::ByteOffset,
+                event_filter: None,
+            },
+        )
     }
 
     fn extract_event_timestamp(
@@ -237,6 +157,7 @@ impl Agent for GeminiAgent {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::streams::watermark::ByteOffsetWatermark;
     use serial_test::serial;
 
     #[test]

--- a/src/streams/agents/pi.rs
+++ b/src/streams/agents/pi.rs
@@ -3,9 +3,7 @@
 use crate::streams::agent::{Agent, PathResolverKind, StreamDescriptor};
 use crate::streams::sweep::{DiscoveredSession, StreamFormat, SweepStrategy};
 use crate::streams::types::{StreamBatch, StreamError};
-use crate::streams::watermark::{ByteOffsetWatermark, WatermarkStrategy};
-use std::fs::File;
-use std::io::{BufReader, Seek, SeekFrom};
+use crate::streams::watermark::WatermarkStrategy;
 use std::path::Path;
 use std::time::Duration;
 
@@ -51,94 +49,17 @@ impl Agent for PiAgent {
         watermark: Box<dyn WatermarkStrategy>,
         session_id: &str,
     ) -> Result<StreamBatch, StreamError> {
-        let byte_watermark = watermark
-            .as_any()
-            .downcast_ref::<ByteOffsetWatermark>()
-            .ok_or_else(|| StreamError::Fatal {
-                message: format!(
-                    "Pi reader requires ByteOffsetWatermark, got incompatible type for session {}",
-                    session_id
-                ),
-            })?;
-
-        let start_offset = byte_watermark.0;
-
-        let file = File::open(path).map_err(|e| {
-            if e.kind() == std::io::ErrorKind::NotFound {
-                StreamError::Fatal {
-                    message: format!("Transcript file not found: {}", path.display()),
-                }
-            } else if e.kind() == std::io::ErrorKind::PermissionDenied {
-                StreamError::Fatal {
-                    message: format!("Permission denied reading transcript: {}", path.display()),
-                }
-            } else {
-                StreamError::Transient {
-                    message: format!("Failed to open transcript file: {}", e),
-                    retry_after: Duration::from_secs(5),
-                }
-            }
-        })?;
-
-        let mut reader = BufReader::new(file);
-
-        reader
-            .seek(SeekFrom::Start(start_offset))
-            .map_err(|e| StreamError::Transient {
-                message: format!("Failed to seek to offset {}: {}", start_offset, e),
-                retry_after: Duration::from_secs(5),
-            })?;
-
-        let batch_limit = self.batch_size_hint();
-        let mut events = Vec::with_capacity(batch_limit);
-        let mut current_offset = start_offset;
-        let mut line_number = 0;
-
-        let mut line = String::new();
-        loop {
-            match crate::streams::types::read_jsonl_line(&mut reader, &mut line).map_err(|e| {
-                StreamError::Transient {
-                    message: format!("I/O error reading line: {}", e),
-                    retry_after: Duration::from_secs(5),
-                }
-            })? {
-                crate::streams::types::JsonlLineState::Eof => break,
-                crate::streams::types::JsonlLineState::Partial => break,
-                crate::streams::types::JsonlLineState::Complete(bytes_read) => {
-                    line_number += 1;
-                    current_offset += bytes_read as u64;
-                }
-            }
-
-            if line.trim().is_empty() {
-                continue;
-            }
-
-            let entry: serde_json::Value = match serde_json::from_str(&line) {
-                Ok(v) => v,
-                Err(e) => {
-                    tracing::warn!(
-                        line = line_number,
-                        path = %path.display(),
-                        error = %e,
-                        "skipping malformed JSON line"
-                    );
-                    continue;
-                }
-            };
-
-            events.push(entry);
-            if events.len() >= batch_limit {
-                break;
-            }
-        }
-
-        let new_watermark = Box::new(ByteOffsetWatermark::new(current_offset));
-
-        Ok(StreamBatch {
-            events,
-            new_watermark,
-        })
+        crate::streams::reader::read_jsonl_event_stream(
+            path,
+            watermark,
+            session_id,
+            &crate::streams::reader::JsonlReadOptions {
+                agent_label: "Pi",
+                batch_limit: self.batch_size_hint(),
+                mode: crate::streams::reader::JsonlWatermarkMode::ByteOffset,
+                event_filter: None,
+            },
+        )
     }
 
     fn extract_event_timestamp(
@@ -168,6 +89,7 @@ impl Agent for PiAgent {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::streams::watermark::ByteOffsetWatermark;
 
     #[test]
     fn test_sweep_strategy() {

--- a/src/streams/agents/windsurf.rs
+++ b/src/streams/agents/windsurf.rs
@@ -3,9 +3,7 @@
 use crate::streams::agent::{Agent, PathResolverKind, StreamDescriptor};
 use crate::streams::sweep::{DiscoveredSession, StreamFormat, SweepStrategy};
 use crate::streams::types::{StreamBatch, StreamError};
-use crate::streams::watermark::{ByteOffsetWatermark, WatermarkStrategy};
-use std::fs::File;
-use std::io::{BufReader, Seek, SeekFrom};
+use crate::streams::watermark::WatermarkStrategy;
 use std::path::Path;
 use std::time::Duration;
 
@@ -51,94 +49,17 @@ impl Agent for WindsurfAgent {
         watermark: Box<dyn WatermarkStrategy>,
         session_id: &str,
     ) -> Result<StreamBatch, StreamError> {
-        let byte_watermark = watermark
-            .as_any()
-            .downcast_ref::<ByteOffsetWatermark>()
-            .ok_or_else(|| StreamError::Fatal {
-                message: format!(
-                    "Windsurf reader requires ByteOffsetWatermark, got incompatible type for session {}",
-                    session_id
-                ),
-            })?;
-
-        let start_offset = byte_watermark.0;
-
-        let file = File::open(path).map_err(|e| {
-            if e.kind() == std::io::ErrorKind::NotFound {
-                StreamError::Fatal {
-                    message: format!("Transcript file not found: {}", path.display()),
-                }
-            } else if e.kind() == std::io::ErrorKind::PermissionDenied {
-                StreamError::Fatal {
-                    message: format!("Permission denied reading transcript: {}", path.display()),
-                }
-            } else {
-                StreamError::Transient {
-                    message: format!("Failed to open transcript file: {}", e),
-                    retry_after: Duration::from_secs(5),
-                }
-            }
-        })?;
-
-        let mut reader = BufReader::new(file);
-
-        reader
-            .seek(SeekFrom::Start(start_offset))
-            .map_err(|e| StreamError::Transient {
-                message: format!("Failed to seek to offset {}: {}", start_offset, e),
-                retry_after: Duration::from_secs(5),
-            })?;
-
-        let batch_limit = self.batch_size_hint();
-        let mut events = Vec::with_capacity(batch_limit);
-        let mut current_offset = start_offset;
-        let mut line_number = 0;
-
-        let mut line = String::new();
-        loop {
-            match crate::streams::types::read_jsonl_line(&mut reader, &mut line).map_err(|e| {
-                StreamError::Transient {
-                    message: format!("I/O error reading line: {}", e),
-                    retry_after: Duration::from_secs(5),
-                }
-            })? {
-                crate::streams::types::JsonlLineState::Eof => break,
-                crate::streams::types::JsonlLineState::Partial => break,
-                crate::streams::types::JsonlLineState::Complete(bytes_read) => {
-                    line_number += 1;
-                    current_offset += bytes_read as u64;
-                }
-            }
-
-            if line.trim().is_empty() {
-                continue;
-            }
-
-            let entry: serde_json::Value = match serde_json::from_str(&line) {
-                Ok(v) => v,
-                Err(e) => {
-                    tracing::warn!(
-                        line = line_number,
-                        path = %path.display(),
-                        error = %e,
-                        "skipping malformed JSON line"
-                    );
-                    continue;
-                }
-            };
-
-            events.push(entry);
-            if events.len() >= batch_limit {
-                break;
-            }
-        }
-
-        let new_watermark = Box::new(ByteOffsetWatermark::new(current_offset));
-
-        Ok(StreamBatch {
-            events,
-            new_watermark,
-        })
+        crate::streams::reader::read_jsonl_event_stream(
+            path,
+            watermark,
+            session_id,
+            &crate::streams::reader::JsonlReadOptions {
+                agent_label: "Windsurf",
+                batch_limit: self.batch_size_hint(),
+                mode: crate::streams::reader::JsonlWatermarkMode::ByteOffset,
+                event_filter: None,
+            },
+        )
     }
 
     fn extract_event_timestamp(
@@ -167,6 +88,7 @@ impl Agent for WindsurfAgent {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::streams::watermark::ByteOffsetWatermark;
 
     #[test]
     fn test_sweep_strategy() {

--- a/src/streams/mod.rs
+++ b/src/streams/mod.rs
@@ -44,6 +44,7 @@ pub mod agent;
 pub mod agents;
 pub mod db;
 pub mod model_extraction;
+pub(crate) mod reader;
 pub mod sweep;
 pub mod types;
 pub mod watermark;

--- a/src/streams/reader.rs
+++ b/src/streams/reader.rs
@@ -135,7 +135,10 @@ fn read_jsonl_event_stream_with(
             }
         })? {
             JsonlLineState::Eof => break,
-            JsonlLineState::Partial => break,
+            // Partial states leave the watermark before the line: advancing
+            // past a half-written line would resume mid-record and emit its
+            // tail as a bogus event once the writer finishes.
+            JsonlLineState::Partial | JsonlLineState::OversizedPartial => break,
             JsonlLineState::Complete(bytes_read) => {
                 line_number += 1;
                 current_offset += bytes_read as u64;
@@ -151,6 +154,17 @@ fn read_jsonl_event_stream_with(
                     agent = opts.agent_label,
                     max_bytes = max_line_bytes,
                     "skipping oversized transcript line"
+                );
+                continue;
+            }
+            JsonlLineState::Invalid(bytes_read) => {
+                line_number += 1;
+                current_offset += bytes_read as u64;
+                tracing::warn!(
+                    line = line_number,
+                    path = %path.display(),
+                    agent = opts.agent_label,
+                    "skipping non-UTF-8 transcript line"
                 );
                 continue;
             }
@@ -326,6 +340,73 @@ mod tests {
         // The next poll picks up the remaining two events.
         let batch = read(&file, batch.new_watermark, &opts, TEST_LINE_CAP, 30);
         assert_eq!(batch.events.len(), 2);
+    }
+
+    #[test]
+    fn test_unterminated_oversized_line_never_emits_its_tail() {
+        // A writer paused mid-giant-line: the poll must stop with the
+        // watermark at the line's start. Once the writer finishes the line
+        // (with a tail that parses as valid JSON on its own) and appends a
+        // normal event, the next poll must skip the whole giant line and
+        // emit only the normal event — never the tail.
+        use std::fs::OpenOptions;
+
+        let prefix = "x".repeat(TEST_LINE_CAP as usize + 40);
+        let file = write_temp(&format!("{{\"a\":1}}\n{prefix}"));
+        let opts = byte_offset_opts(10);
+
+        let batch = read(
+            &file,
+            Box::new(ByteOffsetWatermark::new(0)),
+            &opts,
+            TEST_LINE_CAP,
+            TEST_BATCH_CAP,
+        );
+        assert_eq!(batch.events.len(), 1);
+        assert_eq!(
+            batch.new_watermark.serialize(),
+            "8",
+            "watermark must stop before the unterminated giant line"
+        );
+
+        let mut appender = OpenOptions::new().append(true).open(file.path()).unwrap();
+        write!(appender, "{{\"tail\":true}}\n{{\"b\":2}}\n").unwrap();
+        appender.flush().unwrap();
+
+        let batch = read(
+            &file,
+            batch.new_watermark,
+            &opts,
+            TEST_LINE_CAP,
+            TEST_BATCH_CAP,
+        );
+        assert_eq!(
+            batch.events.len(),
+            1,
+            "the giant line's tail must not be emitted"
+        );
+        assert_eq!(batch.events[0]["b"], 2);
+    }
+
+    #[test]
+    fn test_invalid_utf8_line_skipped_with_watermark_advanced() {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        file.write_all(b"{\"a\":1}\n\xff\xfe garbage\n{\"b\":2}\n")
+            .unwrap();
+        file.flush().unwrap();
+        let opts = byte_offset_opts(10);
+
+        let batch = read(
+            &file,
+            Box::new(ByteOffsetWatermark::new(0)),
+            &opts,
+            TEST_LINE_CAP,
+            TEST_BATCH_CAP,
+        );
+        assert_eq!(batch.events.len(), 2);
+        assert_eq!(batch.events[1]["b"], 2);
+        // The invalid line is consumed, never re-read.
+        assert_eq!(batch.new_watermark.serialize(), "27");
     }
 
     #[test]

--- a/src/streams/reader.rs
+++ b/src/streams/reader.rs
@@ -1,0 +1,460 @@
+//! Shared bounded JSONL reader for line-oriented transcript agents.
+//!
+//! Every JSONL agent (claude, codex, cursor, gemini, pi, windsurf, droid,
+//! copilot, copilot_cli) reads through [`read_jsonl_event_stream`], so the
+//! per-line and per-batch byte budgets from config apply to all of them —
+//! no reader can opt out of bounded ingestion (#2244).
+
+use std::path::Path;
+
+use crate::streams::types::{JsonlLineState, StreamBatch, StreamError, read_jsonl_line};
+use crate::streams::watermark::{ByteOffsetWatermark, HybridWatermark, WatermarkStrategy};
+
+/// Watermark flavor produced by [`read_jsonl_event_stream`].
+pub(crate) enum JsonlWatermarkMode {
+    /// Plain byte offset.
+    ByteOffset,
+    /// Byte offset + emitted-record count + max RFC3339 `timestamp` field (droid).
+    Hybrid,
+}
+
+pub(crate) struct JsonlReadOptions<'a> {
+    /// Agent name used in error and log messages.
+    pub agent_label: &'a str,
+    /// Event-count cap per batch (`Agent::batch_size_hint`).
+    pub batch_limit: usize,
+    pub mode: JsonlWatermarkMode,
+    /// Post-parse filter: events returning `false` consume offset bytes but
+    /// are neither emitted nor counted as records (droid keeps only
+    /// `type == "message"` entries).
+    pub event_filter: Option<&'a dyn Fn(&serde_json::Value) -> bool>,
+}
+
+/// Read a JSONL event stream incrementally from the watermark position.
+///
+/// Lines beyond `max_transcript_line_bytes` are skipped (never buffered) with
+/// the watermark advanced past them; the batch stops once it holds
+/// `batch_limit` events or `max_transcript_batch_bytes` of raw line bytes,
+/// whichever comes first. Remaining events arrive in later batches.
+pub(crate) fn read_jsonl_event_stream(
+    path: &Path,
+    watermark: Box<dyn WatermarkStrategy>,
+    session_id: &str,
+    opts: &JsonlReadOptions<'_>,
+) -> Result<StreamBatch, StreamError> {
+    let config = crate::config::Config::get();
+    read_jsonl_event_stream_with(
+        path,
+        watermark,
+        session_id,
+        opts,
+        config.max_transcript_line_bytes(),
+        config.max_transcript_batch_bytes(),
+    )
+}
+
+fn read_jsonl_event_stream_with(
+    path: &Path,
+    watermark: Box<dyn WatermarkStrategy>,
+    session_id: &str,
+    opts: &JsonlReadOptions<'_>,
+    max_line_bytes: u64,
+    max_batch_bytes: usize,
+) -> Result<StreamBatch, StreamError> {
+    use std::fs::File;
+    use std::io::{BufReader, Seek, SeekFrom};
+
+    // Resolve the starting position (and hybrid state) from the watermark.
+    let (start_offset, mut record_count, mut latest_timestamp) = match opts.mode {
+        JsonlWatermarkMode::ByteOffset => {
+            let byte_watermark = watermark
+                .as_any()
+                .downcast_ref::<ByteOffsetWatermark>()
+                .ok_or_else(|| StreamError::Fatal {
+                    message: format!(
+                        "{} reader requires ByteOffsetWatermark, got incompatible type for session {}",
+                        opts.agent_label, session_id
+                    ),
+                })?;
+            (byte_watermark.0, 0, None)
+        }
+        JsonlWatermarkMode::Hybrid => {
+            let hybrid_watermark = watermark
+                .as_any()
+                .downcast_ref::<HybridWatermark>()
+                .ok_or_else(|| StreamError::Fatal {
+                    message: format!(
+                        "{} reader requires HybridWatermark, got incompatible type for session {}",
+                        opts.agent_label, session_id
+                    ),
+                })?;
+            (
+                hybrid_watermark.offset,
+                hybrid_watermark.record,
+                hybrid_watermark.timestamp,
+            )
+        }
+    };
+
+    let file = File::open(path).map_err(|e| {
+        if e.kind() == std::io::ErrorKind::NotFound {
+            StreamError::Fatal {
+                message: format!("Transcript file not found: {}", path.display()),
+            }
+        } else if e.kind() == std::io::ErrorKind::PermissionDenied {
+            StreamError::Fatal {
+                message: format!("Permission denied reading transcript: {}", path.display()),
+            }
+        } else {
+            StreamError::Transient {
+                message: format!("Failed to open transcript file: {}", e),
+                retry_after: std::time::Duration::from_secs(5),
+            }
+        }
+    })?;
+
+    let mut reader = BufReader::new(file);
+    reader
+        .seek(SeekFrom::Start(start_offset))
+        .map_err(|e| StreamError::Transient {
+            message: format!("Failed to seek to offset {}: {}", start_offset, e),
+            retry_after: std::time::Duration::from_secs(5),
+        })?;
+
+    let mut events = Vec::with_capacity(opts.batch_limit);
+    let mut current_offset = start_offset;
+    let mut batch_bytes: usize = 0;
+    let mut line_number = 0;
+
+    let mut line = String::new();
+    loop {
+        match read_jsonl_line(&mut reader, &mut line, max_line_bytes).map_err(|e| {
+            StreamError::Transient {
+                message: format!("I/O error reading line: {}", e),
+                retry_after: std::time::Duration::from_secs(5),
+            }
+        })? {
+            JsonlLineState::Eof => break,
+            JsonlLineState::Partial => break,
+            JsonlLineState::Complete(bytes_read) => {
+                line_number += 1;
+                current_offset += bytes_read as u64;
+            }
+            JsonlLineState::Oversized(bytes_read) => {
+                // The line was skipped without being buffered; advance the
+                // watermark past it so it is never re-read.
+                line_number += 1;
+                current_offset += bytes_read as u64;
+                tracing::warn!(
+                    line = line_number,
+                    path = %path.display(),
+                    agent = opts.agent_label,
+                    max_bytes = max_line_bytes,
+                    "skipping oversized transcript line"
+                );
+                continue;
+            }
+        }
+
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        let entry: serde_json::Value = match serde_json::from_str(&line) {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!(
+                    line = line_number,
+                    path = %path.display(),
+                    error = %e,
+                    "skipping malformed JSON line"
+                );
+                continue;
+            }
+        };
+
+        if let Some(filter) = opts.event_filter
+            && !filter(&entry)
+        {
+            continue;
+        }
+
+        if matches!(opts.mode, JsonlWatermarkMode::Hybrid) {
+            record_count += 1;
+            if let Some(ts_str) = entry["timestamp"].as_str()
+                && let Ok(dt) = chrono::DateTime::parse_from_rfc3339(ts_str)
+            {
+                let utc_dt = dt.with_timezone(&chrono::Utc);
+                if latest_timestamp.is_none() || Some(utc_dt) > latest_timestamp {
+                    latest_timestamp = Some(utc_dt);
+                }
+            }
+        }
+
+        batch_bytes += line.len();
+        events.push(entry);
+        if events.len() >= opts.batch_limit || batch_bytes >= max_batch_bytes {
+            break;
+        }
+    }
+
+    let new_watermark: Box<dyn WatermarkStrategy> = match opts.mode {
+        JsonlWatermarkMode::ByteOffset => Box::new(ByteOffsetWatermark::new(current_offset)),
+        JsonlWatermarkMode::Hybrid => Box::new(HybridWatermark::new(
+            current_offset,
+            record_count,
+            latest_timestamp,
+        )),
+    };
+
+    Ok(StreamBatch {
+        events,
+        new_watermark,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    const TEST_LINE_CAP: u64 = 256;
+    const TEST_BATCH_CAP: usize = 1024 * 1024;
+
+    fn byte_offset_opts(batch_limit: usize) -> JsonlReadOptions<'static> {
+        JsonlReadOptions {
+            agent_label: "Test",
+            batch_limit,
+            mode: JsonlWatermarkMode::ByteOffset,
+            event_filter: None,
+        }
+    }
+
+    fn write_temp(content: &str) -> tempfile::NamedTempFile {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        write!(file, "{content}").unwrap();
+        file.flush().unwrap();
+        file
+    }
+
+    fn read(
+        file: &tempfile::NamedTempFile,
+        watermark: Box<dyn WatermarkStrategy>,
+        opts: &JsonlReadOptions<'_>,
+        max_line_bytes: u64,
+        max_batch_bytes: usize,
+    ) -> StreamBatch {
+        read_jsonl_event_stream_with(
+            file.path(),
+            watermark,
+            "test-session",
+            opts,
+            max_line_bytes,
+            max_batch_bytes,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn test_byte_offset_read_and_resume() {
+        let file = write_temp("{\"a\":1}\n{\"b\":2}\n{\"c\":3}\n");
+        let opts = byte_offset_opts(2);
+
+        let batch = read(
+            &file,
+            Box::new(ByteOffsetWatermark::new(0)),
+            &opts,
+            TEST_LINE_CAP,
+            TEST_BATCH_CAP,
+        );
+        assert_eq!(batch.events.len(), 2);
+        assert_eq!(batch.events[0]["a"], 1);
+
+        // Resume from the returned watermark: only the third event remains.
+        let batch = read(
+            &file,
+            batch.new_watermark,
+            &opts,
+            TEST_LINE_CAP,
+            TEST_BATCH_CAP,
+        );
+        assert_eq!(batch.events.len(), 1);
+        assert_eq!(batch.events[0]["c"], 3);
+        assert_eq!(batch.new_watermark.serialize(), "24");
+    }
+
+    #[test]
+    fn test_oversized_line_skipped_watermark_lands_after_it() {
+        let big = format!("{{\"pad\":\"{}\"}}", "x".repeat(TEST_LINE_CAP as usize));
+        let content = format!("{{\"a\":1}}\n{big}\n{{\"b\":2}}\n");
+        let file = write_temp(&content);
+        let opts = byte_offset_opts(10);
+
+        let batch = read(
+            &file,
+            Box::new(ByteOffsetWatermark::new(0)),
+            &opts,
+            TEST_LINE_CAP,
+            TEST_BATCH_CAP,
+        );
+        // The giant line is skipped, its neighbors survive, and the watermark
+        // covers the entire file so nothing is re-read.
+        assert_eq!(batch.events.len(), 2);
+        assert_eq!(batch.events[0]["a"], 1);
+        assert_eq!(batch.events[1]["b"], 2);
+        assert_eq!(batch.new_watermark.serialize(), content.len().to_string());
+    }
+
+    #[test]
+    fn test_batch_stops_at_byte_budget_with_correct_watermark() {
+        // Each line is 12 bytes; a 30-byte batch budget fits 3 lines
+        // (the budget check runs after the third push).
+        let content = "{\"n\":10000}\n".repeat(5);
+        let file = write_temp(&content);
+        let opts = byte_offset_opts(100);
+
+        let batch = read(
+            &file,
+            Box::new(ByteOffsetWatermark::new(0)),
+            &opts,
+            TEST_LINE_CAP,
+            30,
+        );
+        assert_eq!(batch.events.len(), 3);
+        assert_eq!(batch.new_watermark.serialize(), "36");
+
+        // The next poll picks up the remaining two events.
+        let batch = read(&file, batch.new_watermark, &opts, TEST_LINE_CAP, 30);
+        assert_eq!(batch.events.len(), 2);
+    }
+
+    #[test]
+    fn test_malformed_and_empty_lines_skipped() {
+        let file = write_temp("{\"a\":1}\n\nnot json\n{\"b\":2}\n");
+        let opts = byte_offset_opts(10);
+
+        let batch = read(
+            &file,
+            Box::new(ByteOffsetWatermark::new(0)),
+            &opts,
+            TEST_LINE_CAP,
+            TEST_BATCH_CAP,
+        );
+        assert_eq!(batch.events.len(), 2);
+    }
+
+    #[test]
+    fn test_partial_trailing_line_not_consumed() {
+        let file = write_temp("{\"a\":1}\n{\"b\":");
+        let opts = byte_offset_opts(10);
+
+        let batch = read(
+            &file,
+            Box::new(ByteOffsetWatermark::new(0)),
+            &opts,
+            TEST_LINE_CAP,
+            TEST_BATCH_CAP,
+        );
+        assert_eq!(batch.events.len(), 1);
+        // Watermark stops before the partial line so it is re-read once complete.
+        assert_eq!(batch.new_watermark.serialize(), "8");
+    }
+
+    #[test]
+    fn test_filter_advances_offset_without_emitting() {
+        let content = "{\"type\":\"todo\"}\n{\"type\":\"message\",\"v\":1}\n";
+        let file = write_temp(content);
+        let filter = |entry: &serde_json::Value| entry["type"].as_str() == Some("message");
+        let opts = JsonlReadOptions {
+            agent_label: "Test",
+            batch_limit: 10,
+            mode: JsonlWatermarkMode::Hybrid,
+            event_filter: Some(&filter),
+        };
+
+        let batch = read(
+            &file,
+            Box::new(HybridWatermark::new(0, 0, None)),
+            &opts,
+            TEST_LINE_CAP,
+            TEST_BATCH_CAP,
+        );
+        assert_eq!(batch.events.len(), 1);
+        assert_eq!(batch.events[0]["v"], 1);
+
+        let hybrid = batch
+            .new_watermark
+            .as_any()
+            .downcast_ref::<HybridWatermark>()
+            .unwrap();
+        // Filtered lines advance the offset but do not count as records.
+        assert_eq!(hybrid.offset, content.len() as u64);
+        assert_eq!(hybrid.record, 1);
+    }
+
+    #[test]
+    fn test_hybrid_tracks_latest_rfc3339_timestamp() {
+        let content = "{\"type\":\"message\",\"timestamp\":\"2026-01-02T00:00:00Z\"}\n\
+                       {\"type\":\"message\",\"timestamp\":\"2026-01-01T00:00:00Z\"}\n";
+        let file = write_temp(content);
+        let opts = JsonlReadOptions {
+            agent_label: "Test",
+            batch_limit: 10,
+            mode: JsonlWatermarkMode::Hybrid,
+            event_filter: None,
+        };
+
+        let batch = read(
+            &file,
+            Box::new(HybridWatermark::new(0, 0, None)),
+            &opts,
+            TEST_LINE_CAP,
+            TEST_BATCH_CAP,
+        );
+        let hybrid = batch
+            .new_watermark
+            .as_any()
+            .downcast_ref::<HybridWatermark>()
+            .unwrap();
+        assert_eq!(hybrid.record, 2);
+        // The max timestamp wins even when a later line is older.
+        assert_eq!(
+            hybrid.timestamp.unwrap().to_rfc3339(),
+            "2026-01-02T00:00:00+00:00"
+        );
+    }
+
+    #[test]
+    fn test_wrong_watermark_type_is_fatal() {
+        let file = write_temp("{\"a\":1}\n");
+        let opts = byte_offset_opts(10);
+
+        let Err(err) = read_jsonl_event_stream_with(
+            file.path(),
+            Box::new(HybridWatermark::new(0, 0, None)),
+            "test-session",
+            &opts,
+            TEST_LINE_CAP,
+            TEST_BATCH_CAP,
+        ) else {
+            panic!("expected a watermark-type error");
+        };
+        assert!(matches!(err, StreamError::Fatal { .. }));
+    }
+
+    #[test]
+    fn test_missing_file_is_fatal() {
+        let opts = byte_offset_opts(10);
+        let Err(err) = read_jsonl_event_stream_with(
+            Path::new("/nonexistent/transcript.jsonl"),
+            Box::new(ByteOffsetWatermark::new(0)),
+            "test-session",
+            &opts,
+            TEST_LINE_CAP,
+            TEST_BATCH_CAP,
+        ) else {
+            panic!("expected a missing-file error");
+        };
+        assert!(matches!(err, StreamError::Fatal { .. }));
+    }
+}

--- a/src/streams/types.rs
+++ b/src/streams/types.rs
@@ -9,13 +9,24 @@ pub enum JsonlLineState {
     /// End of file reached.
     Eof,
     /// Incomplete line (no trailing newline) — writer still appending.
+    /// Callers must stop and must not advance their watermark past it.
     Partial,
     /// Complete line ready for processing. Contains bytes read.
     Complete(usize),
-    /// Line exceeded the byte cap and was skipped without being buffered.
-    /// Contains total bytes consumed (cap + remainder up to and including the
-    /// newline) so callers can advance their watermark past it.
+    /// Line exceeded the byte cap and was skipped without being buffered;
+    /// its terminating newline was consumed. Contains total bytes consumed
+    /// (cap + remainder up to and including the newline) so callers can
+    /// advance their watermark past it.
     Oversized(usize),
+    /// Line exceeded the byte cap but reached EOF before a newline — the
+    /// writer may still be appending it. Like `Partial`, callers must stop
+    /// and must NOT advance the watermark: resuming mid-line once the
+    /// writer finishes would emit the line's tail as a bogus record.
+    OversizedPartial,
+    /// Complete line whose content is not valid UTF-8, consumed through its
+    /// newline. Contains bytes consumed so callers can skip past it — a
+    /// hard error here would wedge the stream at a fixed watermark.
+    Invalid(usize),
 }
 
 /// Read a line from a BufReader, detecting partial writes from concurrent writers.
@@ -24,10 +35,6 @@ pub enum JsonlLineState {
 /// (`Config::max_transcript_line_bytes()` in production): `read_line` is
 /// otherwise unbounded, and a single multi-hundred-MB transcript line can
 /// balloon daemon RSS past the memory watchdog's hard limit (#2244).
-///
-/// Returns `Eof` if no more data, `Partial` if the line lacks a trailing newline,
-/// `Complete(bytes)` on success, or `Oversized(bytes)` when the line exceeded
-/// `max_line_bytes` (content is discarded, reader advanced past the newline).
 pub fn read_jsonl_line(
     reader: &mut impl BufRead,
     line: &mut String,
@@ -49,23 +56,53 @@ pub fn read_jsonl_line(
         // The cap was hit mid-line: discard what we buffered (no UTF-8
         // conversion is attempted on discarded content, and dropping the
         // buffer releases the cap-sized allocation) and skip the rest of the
-        // physical line without storing it. If EOF arrives before the
-        // newline (giant line still being written), we still report
-        // Oversized — re-reading it later would OOM anyway.
+        // physical line without storing it.
         drop(buf);
-        let skipped = reader.skip_until(b'\n')?;
+        let (skipped, terminated) = skip_line_remainder(reader)?;
+        if !terminated {
+            return Ok(JsonlLineState::OversizedPartial);
+        }
         return Ok(JsonlLineState::Oversized(bytes_read + skipped));
     }
-    // Same contract as read_line: non-UTF-8 content is an InvalidData error.
-    *line = String::from_utf8(buf)
-        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
     if bytes_read == 0 {
+        *line = String::from_utf8(buf).unwrap_or_default();
         return Ok(JsonlLineState::Eof);
     }
-    if !line.ends_with('\n') {
-        return Ok(JsonlLineState::Partial);
+    let terminated = buf.last() == Some(&b'\n');
+    match String::from_utf8(buf) {
+        Ok(content) => {
+            *line = content;
+            if !terminated {
+                return Ok(JsonlLineState::Partial);
+            }
+            Ok(JsonlLineState::Complete(bytes_read))
+        }
+        // An unterminated line can legitimately end mid-UTF-8-character (the
+        // writer is mid-write): report Partial, not an error. A terminated
+        // non-UTF-8 line is reported as Invalid so callers can skip it.
+        Err(_) if !terminated => Ok(JsonlLineState::Partial),
+        Err(_) => Ok(JsonlLineState::Invalid(bytes_read)),
     }
-    Ok(JsonlLineState::Complete(bytes_read))
+}
+
+/// Consume the remainder of the current physical line without buffering it.
+/// Returns `(bytes_skipped, newline_found)` — unlike `skip_until`, callers
+/// can tell a terminated line apart from one that ran into EOF.
+pub(crate) fn skip_line_remainder(reader: &mut impl BufRead) -> std::io::Result<(usize, bool)> {
+    let mut skipped = 0usize;
+    loop {
+        let available = reader.fill_buf()?;
+        if available.is_empty() {
+            return Ok((skipped, false));
+        }
+        if let Some(pos) = available.iter().position(|&b| b == b'\n') {
+            reader.consume(pos + 1);
+            return Ok((skipped + pos + 1, true));
+        }
+        let len = available.len();
+        reader.consume(len);
+        skipped += len;
+    }
 }
 
 /// Read up to `max_lines` leading lines of a JSONL file, each bounded by
@@ -95,7 +132,7 @@ fn read_leading_jsonl_lines_with(
     let mut line = String::new();
     for _ in 0..max_lines {
         match read_jsonl_line(&mut reader, &mut line, max_line_bytes) {
-            Ok(JsonlLineState::Eof) => break,
+            Ok(JsonlLineState::Eof) | Ok(JsonlLineState::OversizedPartial) => break,
             Ok(JsonlLineState::Partial) => {
                 lines.push(std::mem::take(&mut line));
                 break;
@@ -103,10 +140,9 @@ fn read_leading_jsonl_lines_with(
             Ok(JsonlLineState::Complete(_)) => {
                 lines.push(line.trim_end_matches(['\n', '\r']).to_string());
             }
-            Ok(JsonlLineState::Oversized(_)) => {}
             // The reader consumed the offending line through its newline, so
             // the scan can continue on the next one.
-            Err(e) if e.kind() == std::io::ErrorKind::InvalidData => {}
+            Ok(JsonlLineState::Oversized(_)) | Ok(JsonlLineState::Invalid(_)) => {}
             Err(_) => break,
         }
     }
@@ -302,14 +338,51 @@ mod tests {
     }
 
     #[test]
-    fn test_read_jsonl_line_oversized_without_newline_at_eof() {
+    fn test_read_jsonl_line_oversized_without_newline_is_partial() {
+        // A giant line still being written (no newline at EOF) must not be
+        // classified as consumed: advancing the watermark past EOF would make
+        // a later poll resume mid-line and emit the line's tail as a bogus
+        // record once the writer finishes.
         let big = "x".repeat(TEST_CAP as usize + 50);
         let mut reader = std::io::BufReader::new(big.as_bytes());
         let mut line = String::new();
 
         match read_jsonl_line(&mut reader, &mut line, TEST_CAP).unwrap() {
-            JsonlLineState::Oversized(consumed) => assert_eq!(consumed, big.len()),
-            other => panic!("expected Oversized even without a trailing newline, got {other:?}"),
+            JsonlLineState::OversizedPartial => {}
+            other => panic!("expected OversizedPartial without a trailing newline, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_read_jsonl_line_invalid_utf8_terminated_line_is_skippable() {
+        // A terminated non-UTF-8 line reports Invalid with its byte count so
+        // callers advance past it instead of wedging on a hard error.
+        let data: &[u8] = b"\xff\xfe bad bytes\n{\"ok\":1}\n";
+        let mut reader = std::io::BufReader::new(data);
+        let mut line = String::new();
+
+        match read_jsonl_line(&mut reader, &mut line, TEST_CAP).unwrap() {
+            JsonlLineState::Invalid(bytes) => assert_eq!(bytes, 13),
+            other => panic!("expected Invalid for terminated non-UTF-8 line, got {other:?}"),
+        }
+        match read_jsonl_line(&mut reader, &mut line, TEST_CAP).unwrap() {
+            JsonlLineState::Complete(_) => assert_eq!(line.trim_end(), "{\"ok\":1}"),
+            other => panic!("expected the next line to parse normally, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_read_jsonl_line_unterminated_mid_utf8_char_is_partial() {
+        // A writer mid-write can pause between the bytes of a multi-byte
+        // character; that is a Partial line, not an error.
+        let euro = "€".as_bytes();
+        let data = [b"{\"t\":\"", &euro[..2]].concat();
+        let mut reader = std::io::BufReader::new(&data[..]);
+        let mut line = String::new();
+
+        match read_jsonl_line(&mut reader, &mut line, TEST_CAP).unwrap() {
+            JsonlLineState::Partial => {}
+            other => panic!("expected Partial for an unterminated mid-char line, got {other:?}"),
         }
     }
 
@@ -334,17 +407,6 @@ mod tests {
             JsonlLineState::Complete(_) => assert_eq!(line.trim_end(), "{\"ok\":1}"),
             other => panic!("expected the next line to parse normally, got {other:?}"),
         }
-    }
-
-    #[test]
-    fn test_read_jsonl_line_invalid_utf8_within_cap_still_errors() {
-        // Non-UTF-8 content on a normal-sized line keeps read_line's
-        // InvalidData contract.
-        let data: &[u8] = b"\xff\xfe bad bytes\n";
-        let mut reader = std::io::BufReader::new(data);
-        let mut line = String::new();
-        let err = read_jsonl_line(&mut reader, &mut line, TEST_CAP).unwrap_err();
-        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
     }
 
     #[test]

--- a/src/streams/types.rs
+++ b/src/streams/types.rs
@@ -1,9 +1,10 @@
 //! Core types for transcript processing.
 
-use std::io::BufRead;
+use std::io::{BufRead, Read};
 use std::time::Duration;
 
 /// Result of reading a single line from a JSONL reader.
+#[derive(Debug)]
 pub enum JsonlLineState {
     /// End of file reached.
     Eof,
@@ -11,18 +12,53 @@ pub enum JsonlLineState {
     Partial,
     /// Complete line ready for processing. Contains bytes read.
     Complete(usize),
+    /// Line exceeded the byte cap and was skipped without being buffered.
+    /// Contains total bytes consumed (cap + remainder up to and including the
+    /// newline) so callers can advance their watermark past it.
+    Oversized(usize),
 }
 
 /// Read a line from a BufReader, detecting partial writes from concurrent writers.
 ///
+/// `max_line_bytes` bounds how much of a line is ever buffered
+/// (`Config::max_transcript_line_bytes()` in production): `read_line` is
+/// otherwise unbounded, and a single multi-hundred-MB transcript line can
+/// balloon daemon RSS past the memory watchdog's hard limit (#2244).
+///
 /// Returns `Eof` if no more data, `Partial` if the line lacks a trailing newline,
-/// or `Complete(bytes)` on success.
+/// `Complete(bytes)` on success, or `Oversized(bytes)` when the line exceeded
+/// `max_line_bytes` (content is discarded, reader advanced past the newline).
 pub fn read_jsonl_line(
     reader: &mut impl BufRead,
     line: &mut String,
+    max_line_bytes: u64,
 ) -> std::io::Result<JsonlLineState> {
+    // Read raw bytes, not via read_line: the byte cap can slice a multi-byte
+    // character, and read_line's UTF-8 validation would then return
+    // InvalidData instead of letting us classify the line as Oversized —
+    // wedging the stream at a fixed watermark. The caller's buffer is reused
+    // across calls (agents hold one String for a whole batch scan), so
+    // steady-state reads stay allocation-free.
     line.clear();
-    let bytes_read = reader.read_line(line)?;
+    let mut buf = std::mem::take(line).into_bytes();
+    let bytes_read = reader
+        .by_ref()
+        .take(max_line_bytes)
+        .read_until(b'\n', &mut buf)?;
+    if buf.last() != Some(&b'\n') && bytes_read as u64 == max_line_bytes {
+        // The cap was hit mid-line: discard what we buffered (no UTF-8
+        // conversion is attempted on discarded content, and dropping the
+        // buffer releases the cap-sized allocation) and skip the rest of the
+        // physical line without storing it. If EOF arrives before the
+        // newline (giant line still being written), we still report
+        // Oversized — re-reading it later would OOM anyway.
+        drop(buf);
+        let skipped = reader.skip_until(b'\n')?;
+        return Ok(JsonlLineState::Oversized(bytes_read + skipped));
+    }
+    // Same contract as read_line: non-UTF-8 content is an InvalidData error.
+    *line = String::from_utf8(buf)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
     if bytes_read == 0 {
         return Ok(JsonlLineState::Eof);
     }
@@ -30,6 +66,51 @@ pub fn read_jsonl_line(
         return Ok(JsonlLineState::Partial);
     }
     Ok(JsonlLineState::Complete(bytes_read))
+}
+
+/// Read up to `max_lines` leading lines of a JSONL file, each bounded by
+/// `Config::max_transcript_line_bytes()`, with line endings stripped.
+///
+/// This is the bounded replacement for `BufRead::lines().take(n)` in
+/// metadata sniffers (`infer_cwd` and friends): those run before the capped
+/// batch loop and before any watermark advance, so an unbounded read of one
+/// giant line could balloon daemon RSS with no persisted progress (#2244).
+/// Oversized and invalid-UTF-8 lines are skipped but count toward the scan
+/// budget; a final unterminated line is returned as-is.
+pub fn read_leading_jsonl_lines(path: &std::path::Path, max_lines: usize) -> Vec<String> {
+    let max_line_bytes = crate::config::Config::get().max_transcript_line_bytes();
+    read_leading_jsonl_lines_with(path, max_lines, max_line_bytes)
+}
+
+fn read_leading_jsonl_lines_with(
+    path: &std::path::Path,
+    max_lines: usize,
+    max_line_bytes: u64,
+) -> Vec<String> {
+    let Ok(file) = std::fs::File::open(path) else {
+        return Vec::new();
+    };
+    let mut reader = std::io::BufReader::new(file);
+    let mut lines = Vec::with_capacity(max_lines.min(64));
+    let mut line = String::new();
+    for _ in 0..max_lines {
+        match read_jsonl_line(&mut reader, &mut line, max_line_bytes) {
+            Ok(JsonlLineState::Eof) => break,
+            Ok(JsonlLineState::Partial) => {
+                lines.push(std::mem::take(&mut line));
+                break;
+            }
+            Ok(JsonlLineState::Complete(_)) => {
+                lines.push(line.trim_end_matches(['\n', '\r']).to_string());
+            }
+            Ok(JsonlLineState::Oversized(_)) => {}
+            // The reader consumed the offending line through its newline, so
+            // the scan can continue on the next one.
+            Err(e) if e.kind() == std::io::ErrorKind::InvalidData => {}
+            Err(_) => break,
+        }
+    }
+    lines
 }
 
 /// Errors that can occur during transcript processing.
@@ -139,12 +220,15 @@ mod tests {
         }
     }
 
+    /// Cap large enough that ordinary test lines never hit it.
+    const TEST_CAP: u64 = 1024;
+
     #[test]
     fn test_read_jsonl_line_eof() {
         let data = b"";
         let mut reader = std::io::BufReader::new(&data[..]);
         let mut line = String::new();
-        let result = read_jsonl_line(&mut reader, &mut line).unwrap();
+        let result = read_jsonl_line(&mut reader, &mut line, TEST_CAP).unwrap();
         assert!(matches!(result, JsonlLineState::Eof));
     }
 
@@ -153,7 +237,7 @@ mod tests {
         let data = b"{\"id\":1}\n";
         let mut reader = std::io::BufReader::new(&data[..]);
         let mut line = String::new();
-        let result = read_jsonl_line(&mut reader, &mut line).unwrap();
+        let result = read_jsonl_line(&mut reader, &mut line, TEST_CAP).unwrap();
         assert!(matches!(result, JsonlLineState::Complete(9)));
         assert_eq!(line, "{\"id\":1}\n");
     }
@@ -163,7 +247,7 @@ mod tests {
         let data = b"{\"id\":1}";
         let mut reader = std::io::BufReader::new(&data[..]);
         let mut line = String::new();
-        let result = read_jsonl_line(&mut reader, &mut line).unwrap();
+        let result = read_jsonl_line(&mut reader, &mut line, TEST_CAP).unwrap();
         assert!(matches!(result, JsonlLineState::Partial));
     }
 
@@ -173,13 +257,13 @@ mod tests {
         let mut reader = std::io::BufReader::new(&data[..]);
         let mut line = String::new();
 
-        let r1 = read_jsonl_line(&mut reader, &mut line).unwrap();
+        let r1 = read_jsonl_line(&mut reader, &mut line, TEST_CAP).unwrap();
         assert!(matches!(r1, JsonlLineState::Complete(8)));
 
-        let r2 = read_jsonl_line(&mut reader, &mut line).unwrap();
+        let r2 = read_jsonl_line(&mut reader, &mut line, TEST_CAP).unwrap();
         assert!(matches!(r2, JsonlLineState::Complete(8)));
 
-        let r3 = read_jsonl_line(&mut reader, &mut line).unwrap();
+        let r3 = read_jsonl_line(&mut reader, &mut line, TEST_CAP).unwrap();
         assert!(matches!(r3, JsonlLineState::Eof));
     }
 
@@ -189,10 +273,99 @@ mod tests {
         let mut reader = std::io::BufReader::new(&data[..]);
         let mut line = String::new();
 
-        let r1 = read_jsonl_line(&mut reader, &mut line).unwrap();
+        let r1 = read_jsonl_line(&mut reader, &mut line, TEST_CAP).unwrap();
         assert!(matches!(r1, JsonlLineState::Complete(8)));
 
-        let r2 = read_jsonl_line(&mut reader, &mut line).unwrap();
+        let r2 = read_jsonl_line(&mut reader, &mut line, TEST_CAP).unwrap();
         assert!(matches!(r2, JsonlLineState::Partial));
+    }
+
+    #[test]
+    fn test_read_jsonl_line_oversized_is_skipped_and_reader_recovers() {
+        let big = "x".repeat(TEST_CAP as usize + 100);
+        let data = format!("{big}\n{{\"ok\":1}}\n");
+        let mut reader = std::io::BufReader::new(data.as_bytes());
+        let mut line = String::new();
+
+        match read_jsonl_line(&mut reader, &mut line, TEST_CAP).unwrap() {
+            JsonlLineState::Oversized(consumed) => {
+                assert_eq!(consumed, big.len() + 1);
+                assert!(line.is_empty(), "oversized content must not be retained");
+            }
+            other => panic!("expected Oversized for a line beyond the cap, got {other:?}"),
+        }
+
+        match read_jsonl_line(&mut reader, &mut line, TEST_CAP).unwrap() {
+            JsonlLineState::Complete(_) => assert_eq!(line.trim_end(), "{\"ok\":1}"),
+            other => panic!("expected the next line to parse normally, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_read_jsonl_line_oversized_without_newline_at_eof() {
+        let big = "x".repeat(TEST_CAP as usize + 50);
+        let mut reader = std::io::BufReader::new(big.as_bytes());
+        let mut line = String::new();
+
+        match read_jsonl_line(&mut reader, &mut line, TEST_CAP).unwrap() {
+            JsonlLineState::Oversized(consumed) => assert_eq!(consumed, big.len()),
+            other => panic!("expected Oversized even without a trailing newline, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_read_jsonl_line_oversized_multibyte_at_cap_boundary() {
+        // 1024 is not divisible by 3, so a line of 3-byte characters
+        // guarantees the byte cap slices mid-character. The reader must
+        // classify Oversized — a read_line-based implementation returns
+        // InvalidData here and wedges the stream at a fixed watermark.
+        let euro = "€"; // 3 bytes in UTF-8
+        let big = euro.repeat((TEST_CAP as usize / 3) + 50);
+        let data = format!("{big}\n{{\"ok\":1}}\n");
+        let mut reader = std::io::BufReader::new(data.as_bytes());
+        let mut line = String::new();
+
+        match read_jsonl_line(&mut reader, &mut line, TEST_CAP).unwrap() {
+            JsonlLineState::Oversized(consumed) => assert_eq!(consumed, big.len() + 1),
+            other => panic!("expected Oversized for a multi-byte giant line, got {other:?}"),
+        }
+
+        match read_jsonl_line(&mut reader, &mut line, TEST_CAP).unwrap() {
+            JsonlLineState::Complete(_) => assert_eq!(line.trim_end(), "{\"ok\":1}"),
+            other => panic!("expected the next line to parse normally, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_read_jsonl_line_invalid_utf8_within_cap_still_errors() {
+        // Non-UTF-8 content on a normal-sized line keeps read_line's
+        // InvalidData contract.
+        let data: &[u8] = b"\xff\xfe bad bytes\n";
+        let mut reader = std::io::BufReader::new(data);
+        let mut line = String::new();
+        let err = read_jsonl_line(&mut reader, &mut line, TEST_CAP).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn test_read_leading_jsonl_lines_is_bounded_and_skips_oversized() {
+        use std::io::Write;
+
+        // First line oversized, then a complete line, then an unterminated
+        // final line: the sniff scan must survive the giant line without
+        // buffering it and still return the readable lines.
+        let big = "x".repeat(TEST_CAP as usize + 10);
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        write!(file, "{big}\n{{\"cwd\":\"/repo\"}}\n{{\"n\":2}}").unwrap();
+        file.flush().unwrap();
+
+        let lines = read_leading_jsonl_lines_with(file.path(), 3, TEST_CAP);
+        assert_eq!(
+            lines,
+            vec!["{\"cwd\":\"/repo\"}".to_string(), "{\"n\":2}".to_string()]
+        );
+
+        // The oversized first line counts toward the scan budget.
+        assert!(read_leading_jsonl_lines_with(file.path(), 1, TEST_CAP).is_empty());
     }
 }


### PR DESCRIPTION
Eight agents (claude, codex, cursor, gemini, pi, windsurf, droid, and the
copilot/copilot_cli event-stream path) carried byte-for-byte copies of the
same read loop, and every copy was unbounded: read_line buffered arbitrarily
large lines and batches were capped by event count only, so one transcript
whose events embed file contents could balloon daemon RSS past the memory
watchdog and abort the daemon (#2244).

Route them all through a single streams::reader::read_jsonl_event_stream
built on a capped read_jsonl_line:

- Lines beyond max_transcript_line_bytes are classified Oversized and
  skipped without being buffered (byte-based reads so a cap slice mid-UTF-8
  character cannot surface as InvalidData and wedge the stream), with the
  watermark advanced past them.
- Batches stop at max_transcript_batch_bytes of raw line bytes in addition
  to the event-count limit; remaining events arrive in later batches.
- Droid's hybrid record/timestamp tracking and message filter become reader
  options instead of a ninth loop copy.

The metadata sniffers (infer_cwd, detect_subagent_parent) switch from
unbounded BufRead::lines() to a bounded read_leading_jsonl_lines — they run
before any watermark advance, where an unbounded read gave the #2244 abort
loop nothing to make progress on. The token-usage worker's lossy byte-level
reader (kept separate for ccusage parity) gains the same cap and skip
semantics, sharing the config budget.

Ported from #2245 with the caps converted from hardcoded consts to the
config budgets introduced in the previous part.

Co-Authored-By: Sandesh Devaraju <sandesh.devaraju@robinhood.com>
Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

## Stack

Part 2/4 of the fresh #2244 stack (stack #2264), which replaces #2245–#2251 at the layer level: config-driven byte budgets that every ingestion path inherits, instead of per-reader hardcoded caps. Ports the sound pieces of the original stack with credit.

1. #2260 — config: transcript ingestion byte budgets (env > file > default)
2. #2261 — streams: one shared bounded JSONL reader for all line-oriented agents
3. #2262 — daemon: break the transcript watermark abort loop
4. #2263 — streams/daemon: bound the whole-file, SQLite, and metrics-flush readers

## Verification

- Full suite at the stack head: 2,433 lib + 3,327 integration + 107 daemon_mode tests green. Two pre-existing failures (`conflict_resolution_note_read_errors…`, `test_load_ai_touched_files_for_specific_commits`) reproduce identically on clean `main` in this environment.
- Daemon-level capstone test (part 3) drives a real daemon with env-scaled budgets over a transcript containing a giant single-line event: the line is skipped, neighbors ingest, the watermark lands at EOF, and a restarted daemon never re-reads it.
- `task fmt` / `task lint` clean per part.

Fixes #2244 together with a small follow-up stack (socket line caps + ingest-loss accounting, watchdog current-RSS decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
