### PR TITLE
daemon: break the transcript watermark abort loop

### DIFF
--- a/src/daemon/stream_worker.rs
+++ b/src/daemon/stream_worker.rs
@@ -14,7 +14,7 @@ use crate::metrics::{
 use crate::streams::agent::{SHARED_STREAM_SESSION_ID, StreamDescriptor};
 use crate::streams::db::{StreamRecord, StreamsDatabase};
 use crate::streams::types::StreamError;
-use crate::streams::watermark::{WatermarkStrategy, WatermarkType};
+use crate::streams::watermark::WatermarkType;
 use chrono::{TimeZone, Utc};
 use std::collections::{BinaryHeap, HashSet};
 use std::path::{Path, PathBuf};
@@ -864,9 +864,8 @@ impl StreamWorker {
             return Ok(());
         }
 
-        use crate::streams::watermark::ByteOffsetWatermark;
-
-        let initial_watermark = ByteOffsetWatermark::new(0);
+        let initial_watermark = crate::streams::watermark::WatermarkType::ByteOffset
+            .create_initial_watermark_for_file(path);
         let record = StreamRecord {
             session_id: session_id.to_string(),
             stream_kind: "transcript".to_string(),
@@ -910,7 +909,7 @@ impl StreamWorker {
         }
 
         let effective_wm_type = stream.effective_watermark_type(stream_path);
-        let initial_watermark = effective_wm_type.create_initial_watermark();
+        let initial_watermark = effective_wm_type.create_initial_watermark_for_file(stream_path);
 
         // For shared streams, external_session_id/parent/repo_work_dir are meaningless
         // since the resource serves all sessions — use empty/None to avoid stale first-caller data
@@ -1095,13 +1094,16 @@ impl StreamWorker {
         }
 
         let file_meta = std::fs::metadata(&path).ok();
-        let watermark_type_str = &stream.watermark_type;
-        let is_initial_watermark = stream.watermark_value.is_empty()
-            || watermark_type_str
-                .parse::<crate::streams::watermark::WatermarkType>()
-                .ok()
-                .map(|wt| wt.create_initial_watermark().serialize() == stream.watermark_value)
-                .unwrap_or(false);
+        // "Never processed" rather than "watermark equals the zero value":
+        // capped first-seen streams start at a non-zero byte offset (see
+        // create_initial_watermark_for_file), so comparing against the
+        // serialized zero watermark would misclassify exactly those streams.
+        // update_watermark stamps last_processed_at whenever the watermark
+        // advances; polls that consume nothing leave the row untouched, so
+        // an empty first poll (stream registered before the agent flushed
+        // its first line) does not clear initial status.
+        let is_initial_watermark =
+            stream.watermark_value.is_empty() || stream.last_processed_at == 0;
 
         loop {
             if shutdown_flag.load(Ordering::Relaxed) {
@@ -1113,22 +1115,49 @@ impl StreamWorker {
             } else {
                 stream.external_session_id.as_str()
             };
+            let current_watermark_value = current_watermark.serialize();
             let batch = agent.read_incremental(&path, current_watermark, source_session_id)?;
 
             if batch.events.is_empty() {
-                db.update_watermark(
-                    &stream.session_id,
-                    &task.stream_kind,
-                    &stream.stream_path,
-                    batch.new_watermark.as_ref(),
-                )?;
+                // Persist only when the poll actually advanced (skipped
+                // malformed/oversized lines). A no-op poll must leave the row
+                // untouched: update_watermark stamps last_processed_at, and
+                // stamping an empty first poll would misclassify the
+                // stream's first real event as non-initial. Skipping it also
+                // saves one redundant sqlite write per stream per sweep.
+                if batch.new_watermark.serialize() != current_watermark_value {
+                    db.update_watermark(
+                        &stream.session_id,
+                        &task.stream_kind,
+                        &stream.stream_path,
+                        batch.new_watermark.as_ref(),
+                    )?;
+                }
                 break;
             }
 
             let batch_count = batch.events.len();
 
+            // Advance the watermark BEFORE converting/persisting the batch.
+            // Transcript metrics are best-effort telemetry; when processing a
+            // batch OOM-aborts the daemon (memory watchdog), a watermark that
+            // only advances after processing makes the respawned daemon
+            // re-read the same bytes and die again — an abort loop (#2244).
+            // Skipping one batch of diagnostics on crash is the safer
+            // failure mode.
+            db.update_watermark(
+                &stream.session_id,
+                &task.stream_kind,
+                &stream.stream_path,
+                batch.new_watermark.as_ref(),
+            )?;
+
             let is_otel_stream = task.stream_kind == "otel_traces";
-            let metric_events: Vec<MetricEvent> = batch
+            // Serialize each event as it is built and let the MetricEvent
+            // (which still holds the redacted JSON tree) drop before the next
+            // one is constructed. Collecting Vec<MetricEvent> and serializing
+            // afterwards kept two full copies of the batch alive at once (#2244).
+            let metric_event_jsons: Vec<String> = batch
                 .events
                 .into_iter()
                 .enumerate()
@@ -1164,7 +1193,7 @@ impl StreamWorker {
 
                     let attrs_sparse = event_attrs.to_sparse();
                     let raw_event = redact_json_secrets(raw_event);
-                    Some(if is_otel_stream {
+                    let metric_event = if is_otel_stream {
                         MetricEvent::from_values_with_timestamp(
                             OtelTraceValues::with_ids(raw_event, eid, pid, tid),
                             attrs_sparse,
@@ -1176,11 +1205,18 @@ impl StreamWorker {
                             attrs_sparse,
                             Some(event_ts),
                         )
-                    })
+                    };
+                    match serde_json::to_string(&metric_event) {
+                        Ok(json) => Some(json),
+                        Err(e) => {
+                            tracing::warn!(%e, "telemetry: failed to serialize transcript metric event; dropping");
+                            None
+                        }
+                    }
                 })
                 .collect();
 
-            if let Err(e) = telemetry.persist_metrics_blocking(&metric_events) {
+            if let Err(e) = telemetry.persist_metric_jsons_blocking(&metric_event_jsons) {
                 tracing::warn!(%e, "telemetry: failed to persist transcript metrics locally");
             }
 
@@ -1202,12 +1238,6 @@ impl StreamWorker {
             }
 
             total_events += batch_count;
-            db.update_watermark(
-                &stream.session_id,
-                &task.stream_kind,
-                &stream.stream_path,
-                batch.new_watermark.as_ref(),
-            )?;
             current_watermark = batch.new_watermark;
         }
 

--- a/src/daemon/telemetry_worker.rs
+++ b/src/daemon/telemetry_worker.rs
@@ -435,6 +435,19 @@ impl DaemonTelemetryWorkerHandle {
         store_metrics_in_db(events)
     }
 
+    /// Persist pre-serialized metric-event JSON rows.
+    ///
+    /// Streaming variant of [`Self::persist_metrics_blocking`] for large
+    /// transcript batches: the caller serializes each event as it is built
+    /// and drops the event immediately, so a batch's `MetricEvent` trees and
+    /// their JSON copies are never all resident at the same time (#2244).
+    pub fn persist_metric_jsons_blocking(
+        &self,
+        event_jsons: &[String],
+    ) -> Result<Vec<i64>, GitAiError> {
+        store_metric_jsons_in_db(event_jsons)
+    }
+
     /// Submit telemetry envelopes synchronously (best-effort, non-blocking).
     ///
     /// Used by the daemon process's own `observability::log_*()` calls which
@@ -970,6 +983,10 @@ fn store_metrics_in_db(events: &[MetricEvent]) -> Result<Vec<i64>, GitAiError> {
         .map(serde_json::to_string)
         .collect::<Result<_, _>>()?;
 
+    store_metric_jsons_in_db(&event_jsons)
+}
+
+fn store_metric_jsons_in_db(event_jsons: &[String]) -> Result<Vec<i64>, GitAiError> {
     if event_jsons.is_empty() {
         return Ok(Vec::new());
     }
@@ -978,7 +995,7 @@ fn store_metrics_in_db(events: &[MetricEvent]) -> Result<Vec<i64>, GitAiError> {
     let mut db_lock = db
         .lock()
         .map_err(|_| GitAiError::Generic("metrics DB lock poisoned".to_string()))?;
-    db_lock.insert_events(&event_jsons)
+    db_lock.insert_events(event_jsons)
 }
 
 #[derive(Debug, Default, PartialEq, Eq)]

--- a/src/streams/watermark.rs
+++ b/src/streams/watermark.rs
@@ -132,7 +132,11 @@ impl WatermarkType {
             return None;
         }
         let capped = meta.len() - max_backfill_bytes;
-        let start = align_offset_to_next_line(path, capped).unwrap_or(capped);
+        let start = backfill_start_from_alignment(
+            align_offset_to_next_line(path, capped),
+            meta.len(),
+            path,
+        );
         tracing::warn!(
             path = %path.display(),
             file_bytes = meta.len(),
@@ -140,6 +144,30 @@ impl WatermarkType {
             "large first-seen stream: skipping historical backfill beyond cap"
         );
         Some(start)
+    }
+}
+
+/// Fallback when line alignment of the capped backfill offset fails: never
+/// persist the raw capped offset — it can split a multi-byte UTF-8 character
+/// or begin mid-record, leaving a permanently misaligned cursor. Skipping the
+/// existing content entirely (EOF) is the safe degradation for a transient
+/// I/O failure: these streams feed best-effort diagnostics, and new appends
+/// still flow from a line boundary once the current line completes.
+fn backfill_start_from_alignment(
+    aligned: std::io::Result<u64>,
+    file_len: u64,
+    path: &std::path::Path,
+) -> u64 {
+    match aligned {
+        Ok(start) => start,
+        Err(e) => {
+            tracing::warn!(
+                path = %path.display(),
+                error = %e,
+                "backfill offset alignment failed; skipping existing content"
+            );
+            file_len
+        }
     }
 }
 
@@ -858,6 +886,19 @@ mod tests {
         let start: u64 = wm.serialize().parse().unwrap();
         assert_eq!(start, expected);
         assert_eq!(start % 1003, 0, "aligned offset must begin a line");
+    }
+
+    #[test]
+    fn test_alignment_failure_falls_back_to_eof_not_raw_offset() {
+        // A failed alignment must never persist the raw capped offset (it can
+        // split a UTF-8 character or begin mid-record); the safe degradation
+        // is skipping the existing content entirely.
+        let err = std::io::Error::other("injected alignment failure");
+        let start = backfill_start_from_alignment(Err(err), 12345, std::path::Path::new("t"));
+        assert_eq!(start, 12345);
+
+        let start = backfill_start_from_alignment(Ok(777), 12345, std::path::Path::new("t"));
+        assert_eq!(start, 777);
     }
 
     #[test]

--- a/src/streams/watermark.rs
+++ b/src/streams/watermark.rs
@@ -80,6 +80,89 @@ impl WatermarkType {
             WatermarkType::TimestampCursor => Box::new(TimestampCursorWatermark::initial()),
         }
     }
+
+    /// Initial watermark for a newly-registered stream backed by `path`.
+    ///
+    /// Byte-seeking streams (byte-offset and hybrid) clamp the initial
+    /// backfill: a first-seen transcript is otherwise ingested from byte 0,
+    /// and a multi-hundred-MB historical file (long agent sessions embed file
+    /// contents in every event) forces a full re-ingest whose memory cost
+    /// tripped the memory watchdog in production (#2244). Only the newest
+    /// `Config::max_transcript_backfill_bytes()` are ingested; older history
+    /// is skipped — these streams feed best-effort diagnostics, not authorship
+    /// data. The capped offset is aligned to the next line boundary so the
+    /// first read never starts mid-line (a cut inside a multi-byte UTF-8
+    /// character would otherwise fail UTF-8 validation on every retry and
+    /// wedge the stream).
+    pub fn create_initial_watermark_for_file(
+        &self,
+        path: &std::path::Path,
+    ) -> Box<dyn WatermarkStrategy> {
+        let max_backfill_bytes = crate::config::Config::get().max_transcript_backfill_bytes();
+        self.create_initial_watermark_for_file_with(path, max_backfill_bytes)
+    }
+
+    fn create_initial_watermark_for_file_with(
+        &self,
+        path: &std::path::Path,
+        max_backfill_bytes: u64,
+    ) -> Box<dyn WatermarkStrategy> {
+        if let Some(start) = self.capped_backfill_start(path, max_backfill_bytes) {
+            return match self {
+                WatermarkType::Hybrid => Box::new(HybridWatermark::new(start, 0, None)),
+                _ => Box::new(ByteOffsetWatermark::new(start)),
+            };
+        }
+        self.create_initial_watermark()
+    }
+
+    /// For byte-seeking watermark types over a file larger than
+    /// `max_backfill_bytes`, the line-aligned offset where the capped
+    /// backfill starts. `None` means backfill from the type's zero watermark.
+    fn capped_backfill_start(
+        &self,
+        path: &std::path::Path,
+        max_backfill_bytes: u64,
+    ) -> Option<u64> {
+        if !matches!(self, WatermarkType::ByteOffset | WatermarkType::Hybrid) {
+            return None;
+        }
+        let meta = std::fs::metadata(path).ok()?;
+        if meta.len() <= max_backfill_bytes {
+            return None;
+        }
+        let capped = meta.len() - max_backfill_bytes;
+        let start = align_offset_to_next_line(path, capped).unwrap_or(capped);
+        tracing::warn!(
+            path = %path.display(),
+            file_bytes = meta.len(),
+            start_offset = start,
+            "large first-seen stream: skipping historical backfill beyond cap"
+        );
+        Some(start)
+    }
+}
+
+/// Smallest line-start offset at or after `offset`: `offset` itself when it
+/// already begins a line, otherwise the byte after the enclosing line's
+/// newline (the file length when the final line is unterminated).
+fn align_offset_to_next_line(path: &std::path::Path, offset: u64) -> std::io::Result<u64> {
+    use std::io::{BufRead, BufReader, Read, Seek, SeekFrom};
+
+    if offset == 0 {
+        return Ok(0);
+    }
+    let mut file = std::fs::File::open(path)?;
+    file.seek(SeekFrom::Start(offset - 1))?;
+    let mut prev = [0u8; 1];
+    file.read_exact(&mut prev)?;
+    if prev == [b'\n'] {
+        return Ok(offset);
+    }
+    // skip_until discards the enclosing line's remainder without buffering it
+    // and returns the bytes consumed, including the newline when found.
+    let skipped = BufReader::new(file).skip_until(b'\n')?;
+    Ok(offset + skipped as u64)
 }
 
 /// Byte-offset based watermark for append-only files.
@@ -684,5 +767,111 @@ mod tests {
             .deserialize("5000|span_42")
             .unwrap();
         assert_eq!(wm.serialize(), "5000|span_42");
+    }
+
+    /// Backfill cap for fixtures; small so tests stay fast.
+    const TEST_BACKFILL_CAP: u64 = 8 * 1024;
+
+    /// Write a JSONL file of identical lines whose total size exceeds
+    /// [`TEST_BACKFILL_CAP`], returning the file and the expected
+    /// line-aligned capped start offset.
+    fn oversized_jsonl_fixture(line_body: &str) -> (tempfile::NamedTempFile, u64) {
+        use std::io::Write;
+
+        let line = format!("{line_body}\n");
+        let line_len = line.len() as u64;
+        let line_count = TEST_BACKFILL_CAP / line_len + 2;
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        for _ in 0..line_count {
+            file.write_all(line.as_bytes()).unwrap();
+        }
+        file.flush().unwrap();
+
+        let total = line_count * line_len;
+        let capped = total - TEST_BACKFILL_CAP;
+        let expected = capped.div_ceil(line_len) * line_len;
+        (file, expected)
+    }
+
+    #[test]
+    fn test_capped_initial_watermark_aligns_to_next_line_boundary() {
+        // 1003-byte lines guarantee the raw cap offset lands mid-line.
+        let (file, expected) = oversized_jsonl_fixture(&"x".repeat(1002));
+        assert_ne!(
+            expected,
+            std::fs::metadata(file.path()).unwrap().len() - TEST_BACKFILL_CAP,
+            "fixture must exercise the mid-line case"
+        );
+
+        let wm = WatermarkType::ByteOffset
+            .create_initial_watermark_for_file_with(file.path(), TEST_BACKFILL_CAP);
+        assert_eq!(wm.serialize(), expected.to_string());
+    }
+
+    #[test]
+    fn test_capped_initial_watermark_never_splits_multibyte_characters() {
+        // 3-byte characters ensure a naive len-cap offset would slice
+        // mid-character (the 8 KiB cap is not divisible by the 1000-byte line
+        // stride below) and wedge the reader on UTF-8 validation.
+        let (file, expected) = oversized_jsonl_fixture(&"€".repeat(333));
+
+        let wm = WatermarkType::ByteOffset
+            .create_initial_watermark_for_file_with(file.path(), TEST_BACKFILL_CAP);
+        let start: u64 = wm.serialize().parse().unwrap();
+        assert_eq!(start, expected);
+
+        // The first read from the aligned offset must be a complete valid line.
+        use std::io::{Seek, SeekFrom};
+        let mut reader = std::io::BufReader::new(std::fs::File::open(file.path()).unwrap());
+        reader.seek(SeekFrom::Start(start)).unwrap();
+        let mut line = String::new();
+        match crate::streams::types::read_jsonl_line(&mut reader, &mut line, TEST_BACKFILL_CAP)
+            .unwrap()
+        {
+            crate::streams::types::JsonlLineState::Complete(_) => {
+                assert_eq!(line.trim_end(), "€".repeat(333));
+            }
+            other => panic!("expected a complete line at the aligned offset, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_capped_initial_watermark_applies_to_hybrid_streams() {
+        // Droid transcripts seek by byte offset through a Hybrid watermark;
+        // they need the same backfill cap as plain byte-offset streams.
+        let (file, expected) = oversized_jsonl_fixture(&"x".repeat(1002));
+
+        let wm = WatermarkType::Hybrid
+            .create_initial_watermark_for_file_with(file.path(), TEST_BACKFILL_CAP);
+        assert_eq!(wm.serialize(), format!("{expected}|0|"));
+    }
+
+    #[test]
+    fn test_capped_initial_watermark_aligns_across_crlf_line_endings() {
+        // Windows-written transcripts end lines with \r\n; alignment searches
+        // for \n, so the aligned offset must begin the next line (after the
+        // full \r\n pair), never between \r and \n.
+        let (file, expected) = oversized_jsonl_fixture(&format!("{}\r", "x".repeat(1001)));
+
+        let wm = WatermarkType::ByteOffset
+            .create_initial_watermark_for_file_with(file.path(), TEST_BACKFILL_CAP);
+        let start: u64 = wm.serialize().parse().unwrap();
+        assert_eq!(start, expected);
+        assert_eq!(start % 1003, 0, "aligned offset must begin a line");
+    }
+
+    #[test]
+    fn test_small_file_keeps_zero_initial_watermark() {
+        use std::io::Write;
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        file.write_all(b"{\"ok\":1}\n").unwrap();
+        file.flush().unwrap();
+
+        let wm = WatermarkType::ByteOffset
+            .create_initial_watermark_for_file_with(file.path(), TEST_BACKFILL_CAP);
+        assert_eq!(wm.serialize(), "0");
+        let wm = WatermarkType::Hybrid
+            .create_initial_watermark_for_file_with(file.path(), TEST_BACKFILL_CAP);
+        assert_eq!(wm.serialize(), "0|0|");
     }
 }

--- a/tests/daemon_mode.rs
+++ b/tests/daemon_mode.rs
@@ -8279,3 +8279,148 @@ fn await_rejects_zero_timeout() {
         "await should report an input validation error: {error}"
     );
 }
+
+/// Capstone for the #2244 abort loop: a transcript containing one line beyond
+/// `max_transcript_line_bytes` must be ingested with the giant line skipped
+/// (never buffered), its neighbors processed, and the persisted watermark
+/// advanced past it — so a daemon restart never re-reads the line. The
+/// production failure re-read multi-hundred-MB transcripts from watermark 0
+/// after every memory-watchdog abort, blocking traced git until the daemon
+/// was killed by hand.
+#[test]
+#[serial]
+fn oversized_transcript_line_is_skipped_and_never_reread_after_restart() {
+    const BUDGET_ENV: &[(&str, &str)] = &[
+        ("GIT_AI_MAX_TRANSCRIPT_LINE_BYTES", "65536"),
+        ("GIT_AI_MAX_TRANSCRIPT_BATCH_BYTES", "131072"),
+        ("GIT_AI_MAX_TRANSCRIPT_BACKFILL_BYTES", "262144"),
+    ];
+    const SKIP_LOG_LINE: &str = "skipping oversized transcript line";
+
+    let mut repo = TestRepo::new_with_daemon_env(BUDGET_ENV);
+    repo.patch_git_ai_config(|patch| {
+        patch.exclude_prompts_in_repositories = Some(vec![]);
+        patch.prompt_storage = Some("default".to_string());
+        patch.telemetry_oss_disabled = Some(true);
+    });
+
+    let repo_root = repo.canonical_path();
+    let file_path = repo_root.join("test.ts");
+    fs::write(&file_path, "const x = 1;\n").expect("failed to write initial file");
+    repo.stage_all_and_commit("Initial commit")
+        .expect("initial commit should succeed");
+
+    // Claude-style transcript: normal events around one ~256 KiB single-line
+    // event (4x the configured line cap).
+    let session_id = "11111111-2222-3333-4444-555555555555";
+    let claude_event = |uuid: &str, text: &str| {
+        json!({
+            "parentUuid": null,
+            "isSidechain": false,
+            "cwd": repo_root.to_string_lossy().to_string(),
+            "sessionId": session_id,
+            "type": "user",
+            "message": {"role": "user", "content": text},
+            "uuid": uuid,
+            "timestamp": "2026-08-30T12:00:00.000Z"
+        })
+        .to_string()
+    };
+    let transcript_path = repo_root.join("claude-session.jsonl");
+    let transcript_contents = format!(
+        "{}\n{}\n{}\n",
+        claude_event("evt-before", "before the giant line"),
+        claude_event("evt-giant", &"x".repeat(256 * 1024)),
+        claude_event("evt-after", "after the giant line"),
+    );
+    fs::write(&transcript_path, &transcript_contents).expect("failed to write transcript");
+    let transcript_len = fs::metadata(&transcript_path)
+        .expect("transcript metadata")
+        .len();
+
+    let hook_input = json!({
+        "cwd": repo_root.to_string_lossy().to_string(),
+        "hook_event_name": "PostToolUse",
+        "transcript_path": transcript_path.to_string_lossy().to_string(),
+        "tool_input": {"file_path": file_path.to_string_lossy().to_string()}
+    })
+    .to_string();
+
+    fs::write(&file_path, "const x = 1;\n// ai line\n").expect("failed to write AI edit");
+    repo.git_ai(&["checkpoint", "claude", "--hook-input", &hook_input])
+        .expect("checkpoint should succeed");
+    repo.stage_all_and_commit("AI commit")
+        .expect("AI commit should succeed");
+    repo.git_ai(&["await", "--timeout", "60"])
+        .expect("await should succeed");
+
+    let streams_db_path = DaemonConfig::from_home(&repo.daemon_home_path())
+        .internal_dir
+        .join("transcripts-db");
+    let transcript_watermark = |label: &str| -> String {
+        let db =
+            git_ai::streams::StreamsDatabase::open(&streams_db_path).expect("open transcripts-db");
+        let streams = db.all_streams().expect("list streams");
+        streams
+            .iter()
+            .find(|s| s.stream_path == transcript_path.to_string_lossy())
+            .unwrap_or_else(|| panic!("{label}: transcript stream not registered: {streams:?}"))
+            .watermark_value
+            .clone()
+    };
+
+    // The watermark must land at EOF: the giant line was skipped and consumed,
+    // not wedged on. Poll: transcript processing is asynchronous to `await`'s
+    // certification of metrics/notes.
+    let deadline = std::time::Instant::now() + Duration::from_secs(30);
+    loop {
+        if transcript_watermark("phase 1") == transcript_len.to_string() {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "watermark never reached EOF ({transcript_len}): stuck at {} \ndaemon log:\n{}",
+            transcript_watermark("phase 1"),
+            repo.daemon_stderr_contents()
+        );
+        thread::sleep(Duration::from_millis(100));
+    }
+    let phase1_stderr = repo.daemon_stderr_contents();
+    let phase1_skips = phase1_stderr.matches(SKIP_LOG_LINE).count();
+    assert!(
+        phase1_skips >= 1,
+        "the giant line should be skipped with a warning\ndaemon log:\n{phase1_stderr}"
+    );
+    assert!(
+        !phase1_stderr.contains("memory emergency"),
+        "processing the giant line must not trip the memory watchdog"
+    );
+
+    // A restarted daemon must not re-read the transcript: the watermark is
+    // already past the giant line and the file is unchanged.
+    repo.restart_dedicated_daemon_with_env_for_test(BUDGET_ENV);
+    fs::write(&file_path, "const x = 1;\n// ai line\n// more\n")
+        .expect("failed to write second edit");
+    repo.git_ai(&["checkpoint", "mock_ai", "test.ts"])
+        .expect("second checkpoint should succeed");
+    repo.stage_all_and_commit("Second commit")
+        .expect("second commit should succeed");
+    repo.git_ai(&["await", "--timeout", "60"])
+        .expect("second await should succeed");
+
+    assert_eq!(
+        transcript_watermark("phase 2"),
+        transcript_len.to_string(),
+        "restart must not move the watermark backwards or re-read"
+    );
+    // No new oversized-skip warning: the restarted daemon never touched the
+    // giant line (the log file may be fresh or appended depending on restart).
+    let phase2_skips = repo.daemon_stderr_contents().matches(SKIP_LOG_LINE).count();
+    assert!(
+        phase2_skips == 0 || phase2_skips == phase1_skips,
+        "restarted daemon re-read the oversized line: {} skips before restart, {} after\ndaemon log:\n{}",
+        phase1_skips,
+        phase2_skips,
+        repo.daemon_stderr_contents()
+    );
+}


### PR DESCRIPTION
Four ordering/persistence changes that together stop a memory-watchdog
abort from becoming a livelock (#2244):

- Advance the stream watermark BEFORE converting/persisting a batch.
  Transcript metrics are best-effort diagnostics; when a batch OOM-aborted
  the daemon, a watermark persisted only after processing made the
  respawned daemon re-read the same bytes and die again. Skipping one
  batch of diagnostics on crash is the safer failure mode.
- Cap the initial backfill of first-seen stream files: byte-seeking
  streams (ByteOffset and droid's Hybrid) start at most
  max_transcript_backfill_bytes from the end of the file, with the offset
  aligned forward to a line boundary so the first read never starts
  mid-line (a cut inside a multi-byte UTF-8 character would fail UTF-8
  validation on every retry and wedge the stream). A first-seen
  multi-hundred-MB historical transcript was exactly the production
  trigger.
- Serialize transcript metric events incrementally (one MetricEvent +
  JSON string at a time) instead of holding the whole batch as Value
  trees and a parallel Vec<MetricEvent> at once.
- Leave the stream row untouched on no-op polls, and derive
  is_initial_watermark from last_processed_at == 0 rather than comparing
  against the serialized zero watermark — which would misclassify capped
  first-seen streams and let an empty first poll clear initial status.

The daemon-level capstone test drives a real daemon with scaled-down env
budgets over a transcript containing a 256 KiB single-line event: the line
is skipped, its neighbors ingest, the watermark lands at EOF, and a
restarted daemon never re-reads it.

Ported from #2246, #2248, and #2251 with the backfill cap converted from a
hardcoded const to the config budget.

Co-Authored-By: Sandesh Devaraju <sandesh.devaraju@robinhood.com>
Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

## Stack

Part 3/4 of the fresh #2244 stack (stack #2264), which replaces #2245–#2251 at the layer level: config-driven byte budgets that every ingestion path inherits, instead of per-reader hardcoded caps. Ports the sound pieces of the original stack with credit.

1. #2260 — config: transcript ingestion byte budgets (env > file > default)
2. #2261 — streams: one shared bounded JSONL reader for all line-oriented agents
3. #2262 — daemon: break the transcript watermark abort loop
4. #2263 — streams/daemon: bound the whole-file, SQLite, and metrics-flush readers

## Verification

- Full suite at the stack head: 2,433 lib + 3,327 integration + 107 daemon_mode tests green. Two pre-existing failures (`conflict_resolution_note_read_errors…`, `test_load_ai_touched_files_for_specific_commits`) reproduce identically on clean `main` in this environment.
- Daemon-level capstone test (part 3) drives a real daemon with env-scaled budgets over a transcript containing a giant single-line event: the line is skipped, neighbors ingest, the watermark lands at EOF, and a restarted daemon never re-reads it.
- `task fmt` / `task lint` clean per part.

Fixes #2244 together with a small follow-up stack (socket line caps + ingest-loss accounting, watchdog current-RSS decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
