### PR TITLE
streams/daemon: bound the whole-file, SQLite, and metrics-flush readers

### DIFF
--- a/src/commands/flush_metrics_db.rs
+++ b/src/commands/flush_metrics_db.rs
@@ -44,7 +44,10 @@ pub fn handle_flush_metrics_db(_args: &[String]) {
                     break;
                 }
             };
-            match db_lock.dequeue_pending_batch(MAX_BATCH_SIZE) {
+            match db_lock.dequeue_pending_batch(
+                MAX_BATCH_SIZE,
+                crate::config::Config::get().max_metrics_flush_chunk_bytes(),
+            ) {
                 Ok(batch) => batch,
                 Err(e) => {
                     eprintln!("flush-metrics-db: failed to read batch: {}", e);

--- a/src/daemon/telemetry_worker.rs
+++ b/src/daemon/telemetry_worker.rs
@@ -1015,6 +1015,7 @@ fn flush_pending_metrics_from_db(
         mark_metric_records_delivered,
         mark_metric_records_failed,
         mark_metric_records_undeliverable,
+        release_metric_processing_locks,
         |batch| client.upload_metrics(batch),
         deadline,
         MAX_METRICS_PER_ENVELOPE,
@@ -1026,12 +1027,23 @@ fn flush_pending_metrics_from_db(
     )
 }
 
-fn read_pending_metrics_batch(limit: usize) -> Result<Vec<MetricRecord>, GitAiError> {
+fn read_pending_metrics_batch(
+    limit: usize,
+    max_bytes: usize,
+) -> Result<Vec<MetricRecord>, GitAiError> {
     let db = MetricsDatabase::global()?;
     let mut db_lock = db
         .lock()
         .map_err(|_| GitAiError::Generic("metrics DB lock poisoned".to_string()))?;
-    db_lock.dequeue_pending_batch(limit)
+    db_lock.dequeue_pending_batch(limit, max_bytes)
+}
+
+fn release_metric_processing_locks(ids: &[i64]) -> Result<(), GitAiError> {
+    let db = MetricsDatabase::global()?;
+    let mut db_lock = db
+        .lock()
+        .map_err(|_| GitAiError::Generic("metrics DB lock poisoned".to_string()))?;
+    db_lock.release_processing_locks(ids)
 }
 
 fn mark_metric_records_delivered(ids: &[i64]) -> Result<(), GitAiError> {
@@ -1065,41 +1077,51 @@ fn flush_pending_metric_records_with<
     MarkDelivered,
     MarkFailed,
     MarkUndeliverable,
+    ReleaseLocks,
     UploadBatch,
 >(
     mut dequeue_batch: DequeueBatch,
     mut mark_delivered: MarkDelivered,
     mut mark_failed: MarkFailed,
     mut mark_undeliverable: MarkUndeliverable,
+    mut release_locks: ReleaseLocks,
     mut upload_batch: UploadBatch,
     deadline: std::time::Instant,
     max_batch_size: usize,
     max_chunk_bytes: usize,
 ) -> Result<PendingMetricsFlushResult, GitAiError>
 where
-    DequeueBatch: FnMut(usize) -> Result<Vec<MetricRecord>, GitAiError>,
+    DequeueBatch: FnMut(usize, usize) -> Result<Vec<MetricRecord>, GitAiError>,
     MarkDelivered: FnMut(&[i64]) -> Result<(), GitAiError>,
     MarkFailed: FnMut(&[i64], &GitAiError) -> Result<(), GitAiError>,
     MarkUndeliverable: FnMut(&[(i64, String)]) -> Result<(), GitAiError>,
+    ReleaseLocks: FnMut(&[i64]) -> Result<(), GitAiError>,
     UploadBatch: FnMut(&MetricsBatch) -> Result<MetricsUploadResponse, GitAiError>,
 {
     let mut result = PendingMetricsFlushResult::default();
     let config = Config::fresh();
 
     while std::time::Instant::now() < deadline {
-        let batch = dequeue_batch(max_batch_size)?;
+        // The dequeue itself is byte-bounded: transcript-derived rows can be
+        // MBs each, so a count-only dequeue could materialize GBs of raw
+        // JSON strings before any downstream chunking applies — the
+        // flush-path variant of the #2244 memory balloon (re-created on
+        // every restart while the rows stay undelivered). The sub-chunk
+        // split below keeps the parsed MetricEvent trees byte-bounded too.
+        let batch = dequeue_batch(max_batch_size, max_chunk_bytes)?;
         if batch.is_empty() {
             break;
         }
 
-        // Dequeueing is count-bounded, but transcript-derived rows can be
-        // MBs each, and inflating a full count-bounded chunk into
-        // MetricEvent trees at once re-creates the #2244 memory balloon on
-        // the flush path (and re-creates it on every restart while the rows
-        // stay undelivered). Parse and upload in byte-bounded sub-chunks so
-        // peak memory tracks `max_chunk_bytes`, not row count.
         let mut remaining = batch.as_slice();
         while !remaining.is_empty() {
+            // Deadline: rows not yet attempted have their locks released
+            // without being charged a delivery attempt.
+            if std::time::Instant::now() >= deadline {
+                let rest_ids: Vec<i64> = remaining.iter().map(|r| r.id).collect();
+                release_locks(&rest_ids)?;
+                return Ok(result);
+            }
             let mut sub_len = 0usize;
             let mut sub_bytes = 0usize;
             for record in remaining {
@@ -1145,15 +1167,20 @@ where
                 continue;
             }
 
-            // On upload failure, every dequeued-but-unprocessed row must
-            // still be marked (dequeued rows hold processing locks); mark
-            // them failed alongside the failed sub-chunk before bailing.
-            let mark_rest_failed_and_bail =
-                |mark_failed: &mut MarkFailed, e: GitAiError, record_ids: &[i64]| {
+            // On upload failure, only the attempted sub-chunk is charged a
+            // delivery attempt. The dequeued-but-never-attempted remainder
+            // still holds processing locks: release them without an attempt,
+            // or repeated failures of one chunk would exhaust the retries of
+            // rows that were never uploaded at all.
+            let fail_chunk_release_rest_and_bail =
+                |mark_failed: &mut MarkFailed,
+                 release_locks: &mut ReleaseLocks,
+                 e: GitAiError,
+                 record_ids: &[i64]| {
                     mark_failed(record_ids, &e)?;
                     if !remaining.is_empty() {
                         let rest_ids: Vec<i64> = remaining.iter().map(|r| r.id).collect();
-                        mark_failed(&rest_ids, &e)?;
+                        release_locks(&rest_ids)?;
                     }
                     Err(e)
                 };
@@ -1176,7 +1203,12 @@ where
                         error = %e,
                         "metrics upload batch failed"
                     );
-                    return mark_rest_failed_and_bail(&mut mark_failed, e, &record_ids);
+                    return fail_chunk_release_rest_and_bail(
+                        &mut mark_failed,
+                        &mut release_locks,
+                        e,
+                        &record_ids,
+                    );
                 }
             };
 
@@ -1188,7 +1220,12 @@ where
                     error = %e,
                     "metrics upload batch returned invalid response"
                 );
-                return mark_rest_failed_and_bail(&mut mark_failed, e, &record_ids);
+                return fail_chunk_release_rest_and_bail(
+                    &mut mark_failed,
+                    &mut release_locks,
+                    e,
+                    &record_ids,
+                );
             }
 
             let successful_ids: Vec<i64> = response
@@ -2092,7 +2129,7 @@ mod tests {
         let result = flush_pending_metric_records_with(
             {
                 let db = Rc::clone(&db);
-                move |limit| db.borrow_mut().dequeue_pending_batch(limit)
+                move |limit, max_bytes| db.borrow_mut().dequeue_pending_batch(limit, max_bytes)
             },
             {
                 let db = Rc::clone(&db);
@@ -2112,6 +2149,10 @@ mod tests {
                     db.borrow_mut()
                         .mark_records_undeliverable(records, unix_now())
                 }
+            },
+            {
+                let db = Rc::clone(&db);
+                move |ids: &[i64]| db.borrow_mut().release_processing_locks(ids)
             },
             {
                 let uploaded = Rc::clone(&uploaded);
@@ -2145,22 +2186,23 @@ mod tests {
     }
 
     #[test]
-    fn flush_pending_metric_records_splits_count_batches_by_bytes() {
-        // A count-bounded dequeue of fat rows must not inflate them all at
-        // once (#2244): the byte budget splits parsing/uploading into
-        // sub-chunks while still delivering every row.
+    fn flush_failure_releases_unattempted_rows_without_charging_attempts() {
+        // When one sub-chunk's upload fails, only that sub-chunk may be
+        // charged a delivery attempt: the dequeued-but-never-attempted
+        // remainder must have its locks released with attempts untouched,
+        // or repeated failures of one chunk would exhaust the retries of
+        // rows that were never uploaded at all.
         let (metrics_db, _metrics_db_dir) = MetricsDatabase::new_temp_for_tests().unwrap();
         let db = Rc::new(RefCell::new(metrics_db));
         let ts = now_ts().saturating_sub(3);
         db.borrow_mut()
-            .insert_events(&[event_json(ts), event_json(ts + 1), event_json(ts + 2)])
+            .insert_events(&[event_json(ts), event_json(ts + 1)])
             .unwrap();
 
-        let uploaded = Rc::new(RefCell::new(Vec::<usize>::new()));
         let result = flush_pending_metric_records_with(
             {
                 let db = Rc::clone(&db);
-                move |limit| db.borrow_mut().dequeue_pending_batch(limit)
+                move |limit, max_bytes| db.borrow_mut().dequeue_pending_batch(limit, max_bytes)
             },
             {
                 let db = Rc::clone(&db);
@@ -2180,6 +2222,137 @@ mod tests {
                     db.borrow_mut()
                         .mark_records_undeliverable(records, unix_now())
                 }
+            },
+            {
+                let db = Rc::clone(&db);
+                move |ids: &[i64]| db.borrow_mut().release_processing_locks(ids)
+            },
+            |_batch| -> Result<MetricsUploadResponse, GitAiError> {
+                Err(GitAiError::Generic("upload down".to_string()))
+            },
+            std::time::Instant::now() + std::time::Duration::from_secs(60),
+            10,
+            // 1-byte chunk budget: each sub-chunk holds exactly one row.
+            1,
+        );
+        assert!(result.is_err(), "the failed flush must surface its error");
+
+        // The first row was attempted (attempts = 1, retry backoff applied);
+        // the second must still be immediately dequeueable with attempts 0.
+        let releasable = db
+            .borrow_mut()
+            .dequeue_pending_batch(10, usize::MAX)
+            .unwrap();
+        assert_eq!(releasable.len(), 1);
+        assert_eq!(
+            releasable[0].attempts, 0,
+            "a never-attempted row must not be charged a delivery attempt"
+        );
+    }
+
+    #[test]
+    fn flush_deadline_releases_remaining_rows_without_charging_attempts() {
+        let (metrics_db, _metrics_db_dir) = MetricsDatabase::new_temp_for_tests().unwrap();
+        let db = Rc::new(RefCell::new(metrics_db));
+        let ts = now_ts().saturating_sub(3);
+        db.borrow_mut()
+            .insert_events(&[event_json(ts), event_json(ts + 1)])
+            .unwrap();
+
+        // The deadline expires during the first sub-chunk's upload; the
+        // second row must be released, not failed, and stay dequeueable.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_millis(30);
+        let result = flush_pending_metric_records_with(
+            {
+                let db = Rc::clone(&db);
+                move |limit, max_bytes| db.borrow_mut().dequeue_pending_batch(limit, max_bytes)
+            },
+            {
+                let db = Rc::clone(&db);
+                move |ids| db.borrow_mut().mark_records_delivered(ids, unix_now())
+            },
+            {
+                let db = Rc::clone(&db);
+                move |ids, err| {
+                    let now = unix_now();
+                    db.borrow_mut()
+                        .mark_records_failed(ids, &err.to_string(), now)
+                }
+            },
+            {
+                let db = Rc::clone(&db);
+                move |records| {
+                    db.borrow_mut()
+                        .mark_records_undeliverable(records, unix_now())
+                }
+            },
+            {
+                let db = Rc::clone(&db);
+                move |ids: &[i64]| db.borrow_mut().release_processing_locks(ids)
+            },
+            |_batch| {
+                std::thread::sleep(std::time::Duration::from_millis(60));
+                Ok(MetricsUploadResponse { errors: vec![] })
+            },
+            deadline,
+            10,
+            1,
+        )
+        .unwrap();
+
+        assert_eq!(result.uploaded_events, 1);
+        let remaining = db
+            .borrow_mut()
+            .dequeue_pending_batch(10, usize::MAX)
+            .unwrap();
+        assert_eq!(
+            remaining.len(),
+            1,
+            "the un-attempted row must stay dequeueable"
+        );
+        assert_eq!(remaining[0].attempts, 0);
+    }
+
+    #[test]
+    fn flush_pending_metric_records_splits_count_batches_by_bytes() {
+        // A count-bounded dequeue of fat rows must not inflate them all at
+        // once (#2244): the byte budget splits parsing/uploading into
+        // sub-chunks while still delivering every row.
+        let (metrics_db, _metrics_db_dir) = MetricsDatabase::new_temp_for_tests().unwrap();
+        let db = Rc::new(RefCell::new(metrics_db));
+        let ts = now_ts().saturating_sub(3);
+        db.borrow_mut()
+            .insert_events(&[event_json(ts), event_json(ts + 1), event_json(ts + 2)])
+            .unwrap();
+
+        let uploaded = Rc::new(RefCell::new(Vec::<usize>::new()));
+        let result = flush_pending_metric_records_with(
+            {
+                let db = Rc::clone(&db);
+                move |limit, max_bytes| db.borrow_mut().dequeue_pending_batch(limit, max_bytes)
+            },
+            {
+                let db = Rc::clone(&db);
+                move |ids| db.borrow_mut().mark_records_delivered(ids, unix_now())
+            },
+            {
+                let db = Rc::clone(&db);
+                move |ids, err| {
+                    let now = unix_now();
+                    db.borrow_mut()
+                        .mark_records_failed(ids, &err.to_string(), now)
+                }
+            },
+            {
+                let db = Rc::clone(&db);
+                move |records| {
+                    db.borrow_mut()
+                        .mark_records_undeliverable(records, unix_now())
+                }
+            },
+            {
+                let db = Rc::clone(&db);
+                move |ids: &[i64]| db.borrow_mut().release_processing_locks(ids)
             },
             {
                 let uploaded = Rc::clone(&uploaded);
@@ -2221,7 +2394,7 @@ mod tests {
         let result = flush_pending_metric_records_with(
             {
                 let db = Rc::clone(&db);
-                move |limit| db.borrow_mut().dequeue_pending_batch(limit)
+                move |limit, max_bytes| db.borrow_mut().dequeue_pending_batch(limit, max_bytes)
             },
             {
                 let db = Rc::clone(&db);
@@ -2241,6 +2414,10 @@ mod tests {
                     db.borrow_mut()
                         .mark_records_undeliverable(records, unix_now())
                 }
+            },
+            {
+                let db = Rc::clone(&db);
+                move |ids: &[i64]| db.borrow_mut().release_processing_locks(ids)
             },
             {
                 let uploaded = Rc::clone(&uploaded);
@@ -2288,7 +2465,7 @@ mod tests {
         let result = flush_pending_metric_records_with(
             {
                 let db = Rc::clone(&db);
-                move |limit| db.borrow_mut().dequeue_pending_batch(limit)
+                move |limit, max_bytes| db.borrow_mut().dequeue_pending_batch(limit, max_bytes)
             },
             {
                 let db = Rc::clone(&db);
@@ -2308,6 +2485,10 @@ mod tests {
                     db.borrow_mut()
                         .mark_records_undeliverable(records, unix_now())
                 }
+            },
+            {
+                let db = Rc::clone(&db);
+                move |ids: &[i64]| db.borrow_mut().release_processing_locks(ids)
             },
             {
                 let uploaded = Rc::clone(&uploaded);
@@ -2342,7 +2523,7 @@ mod tests {
         assert_eq!(db.borrow().count_retryable().unwrap(), 0);
         assert!(
             db.borrow_mut()
-                .dequeue_pending_batch(10)
+                .dequeue_pending_batch(10, usize::MAX)
                 .unwrap()
                 .is_empty()
         );
@@ -2365,7 +2546,7 @@ mod tests {
         let result = flush_pending_metric_records_with(
             {
                 let db = Rc::clone(&db);
-                move |limit| db.borrow_mut().dequeue_pending_batch(limit)
+                move |limit, max_bytes| db.borrow_mut().dequeue_pending_batch(limit, max_bytes)
             },
             {
                 let db = Rc::clone(&db);
@@ -2385,6 +2566,10 @@ mod tests {
                     db.borrow_mut()
                         .mark_records_undeliverable(records, unix_now())
                 }
+            },
+            {
+                let db = Rc::clone(&db);
+                move |ids: &[i64]| db.borrow_mut().release_processing_locks(ids)
             },
             |_batch| {
                 Ok(MetricsUploadResponse {
@@ -2418,7 +2603,7 @@ mod tests {
         assert_eq!(db.borrow().count_retryable().unwrap(), 0);
         assert!(
             db.borrow_mut()
-                .dequeue_pending_batch(10)
+                .dequeue_pending_batch(10, usize::MAX)
                 .unwrap()
                 .is_empty()
         );
@@ -2439,7 +2624,7 @@ mod tests {
         let result = flush_pending_metric_records_with(
             {
                 let db = Rc::clone(&db);
-                move |limit| db.borrow_mut().dequeue_pending_batch(limit)
+                move |limit, max_bytes| db.borrow_mut().dequeue_pending_batch(limit, max_bytes)
             },
             {
                 let db = Rc::clone(&db);
@@ -2459,6 +2644,10 @@ mod tests {
                     db.borrow_mut()
                         .mark_records_undeliverable(records, unix_now())
                 }
+            },
+            {
+                let db = Rc::clone(&db);
+                move |ids: &[i64]| db.borrow_mut().release_processing_locks(ids)
             },
             |_batch| {
                 Ok(MetricsUploadResponse {
@@ -2492,7 +2681,7 @@ mod tests {
         let result = flush_pending_metric_records_with(
             {
                 let db = Rc::clone(&db);
-                move |limit| db.borrow_mut().dequeue_pending_batch(limit)
+                move |limit, max_bytes| db.borrow_mut().dequeue_pending_batch(limit, max_bytes)
             },
             {
                 let db = Rc::clone(&db);
@@ -2512,6 +2701,10 @@ mod tests {
                     db.borrow_mut()
                         .mark_records_undeliverable(records, unix_now())
                 }
+            },
+            {
+                let db = Rc::clone(&db);
+                move |ids: &[i64]| db.borrow_mut().release_processing_locks(ids)
             },
             |_batch| Err(GitAiError::Generic("upload failed".to_string())),
             std::time::Instant::now() + std::time::Duration::from_secs(60),
@@ -2536,7 +2729,7 @@ mod tests {
         let failed = flush_pending_metric_records_with(
             {
                 let db = Rc::clone(&db);
-                move |limit| db.borrow_mut().dequeue_pending_batch(limit)
+                move |limit, max_bytes| db.borrow_mut().dequeue_pending_batch(limit, max_bytes)
             },
             {
                 let db = Rc::clone(&db);
@@ -2556,6 +2749,10 @@ mod tests {
                     db.borrow_mut()
                         .mark_records_undeliverable(records, unix_now())
                 }
+            },
+            {
+                let db = Rc::clone(&db);
+                move |ids: &[i64]| db.borrow_mut().release_processing_locks(ids)
             },
             |_batch| Err(GitAiError::Generic("upload failed".to_string())),
             std::time::Instant::now() + std::time::Duration::from_secs(60),
@@ -2575,7 +2772,7 @@ mod tests {
         let result = flush_pending_metric_records_with(
             {
                 let db = Rc::clone(&db);
-                move |limit| db.borrow_mut().dequeue_pending_batch(limit)
+                move |limit, max_bytes| db.borrow_mut().dequeue_pending_batch(limit, max_bytes)
             },
             {
                 let db = Rc::clone(&db);
@@ -2595,6 +2792,10 @@ mod tests {
                     db.borrow_mut()
                         .mark_records_undeliverable(records, unix_now())
                 }
+            },
+            {
+                let db = Rc::clone(&db);
+                move |ids: &[i64]| db.borrow_mut().release_processing_locks(ids)
             },
             {
                 let uploaded = Rc::clone(&uploaded);

--- a/src/daemon/telemetry_worker.rs
+++ b/src/daemon/telemetry_worker.rs
@@ -30,6 +30,7 @@ use tokio::time::{Duration, Instant, sleep_until};
 const FLUSH_INTERVAL: Duration = Duration::from_secs(3);
 const DAEMON_LOG_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(15 * 60);
 const MAX_DAEMON_LOG_EVENTS_PER_UPLOAD: usize = 1000;
+
 const MAX_DAEMON_LOG_BUFFER_EVENTS: usize = 5000;
 
 static METRICS_UPLOAD_AVAILABLE: AtomicBool = AtomicBool::new(false);
@@ -1017,6 +1018,11 @@ fn flush_pending_metrics_from_db(
         |batch| client.upload_metrics(batch),
         deadline,
         MAX_METRICS_PER_ENVELOPE,
+        // Pending-metrics dequeueing is count-bounded (MAX_METRICS_PER_ENVELOPE),
+        // but transcript-derived rows can be MBs each, so a count-only chunk
+        // could inflate GBs of MetricEvent trees at once — the flush-path
+        // variant of the #2244 memory balloon.
+        crate::config::Config::get().max_metrics_flush_chunk_bytes(),
     )
 }
 
@@ -1053,6 +1059,7 @@ fn mark_metric_records_undeliverable(records: &[(i64, String)]) -> Result<(), Gi
     db_lock.mark_records_undeliverable(records, current_unix_ts())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn flush_pending_metric_records_with<
     DequeueBatch,
     MarkDelivered,
@@ -1067,6 +1074,7 @@ fn flush_pending_metric_records_with<
     mut upload_batch: UploadBatch,
     deadline: std::time::Instant,
     max_batch_size: usize,
+    max_chunk_bytes: usize,
 ) -> Result<PendingMetricsFlushResult, GitAiError>
 where
     DequeueBatch: FnMut(usize) -> Result<Vec<MetricRecord>, GitAiError>,
@@ -1084,100 +1092,132 @@ where
             break;
         }
 
-        let mut events = Vec::new();
-        let mut record_ids = Vec::new();
-        let mut invalid_ids = Vec::new();
-        let mut skipped_ids = Vec::new();
-
-        for record in &batch {
-            match serde_json::from_str::<MetricEvent>(&record.event_json) {
-                Ok(event) if should_deliver_metric_event(&config, &event) => {
-                    events.push(event);
-                    record_ids.push(record.id);
-                }
-                Ok(_) => skipped_ids.push(record.id),
-                Err(_) => {
-                    invalid_ids.push(record.id);
+        // Dequeueing is count-bounded, but transcript-derived rows can be
+        // MBs each, and inflating a full count-bounded chunk into
+        // MetricEvent trees at once re-creates the #2244 memory balloon on
+        // the flush path (and re-creates it on every restart while the rows
+        // stay undelivered). Parse and upload in byte-bounded sub-chunks so
+        // peak memory tracks `max_chunk_bytes`, not row count.
+        let mut remaining = batch.as_slice();
+        while !remaining.is_empty() {
+            let mut sub_len = 0usize;
+            let mut sub_bytes = 0usize;
+            for record in remaining {
+                sub_bytes += record.event_json.len();
+                sub_len += 1;
+                if sub_bytes >= max_chunk_bytes {
+                    break;
                 }
             }
-        }
+            let (sub, rest) = remaining.split_at(sub_len);
+            remaining = rest;
 
-        let batch_min_id = record_ids.iter().chain(invalid_ids.iter()).min().copied();
-        let batch_max_id = record_ids.iter().chain(invalid_ids.iter()).max().copied();
+            let mut events = Vec::new();
+            let mut record_ids = Vec::new();
+            let mut invalid_ids = Vec::new();
+            let mut skipped_ids = Vec::new();
 
-        if !invalid_ids.is_empty() {
-            result.invalid_records += invalid_ids.len();
-            mark_delivered(&invalid_ids)?;
-        }
-        if !skipped_ids.is_empty() {
-            mark_delivered(&skipped_ids)?;
-        }
+            for record in sub {
+                match serde_json::from_str::<MetricEvent>(&record.event_json) {
+                    Ok(event) if should_deliver_metric_event(&config, &event) => {
+                        events.push(event);
+                        record_ids.push(record.id);
+                    }
+                    Ok(_) => skipped_ids.push(record.id),
+                    Err(_) => {
+                        invalid_ids.push(record.id);
+                    }
+                }
+            }
 
-        if events.is_empty() {
-            continue;
-        }
+            let batch_min_id = record_ids.iter().chain(invalid_ids.iter()).min().copied();
+            let batch_max_id = record_ids.iter().chain(invalid_ids.iter()).max().copied();
 
-        let metrics_batch = MetricsBatch::new(events);
-        tracing::info!(
-            min_id = ?batch_min_id,
-            max_id = ?batch_max_id,
-            events = record_ids.len(),
-            invalid_records = invalid_ids.len(),
-            "metrics upload batch sending"
-        );
-        let response = match upload_batch(&metrics_batch) {
-            Ok(response) => response,
-            Err(e) => {
+            if !invalid_ids.is_empty() {
+                result.invalid_records += invalid_ids.len();
+                mark_delivered(&invalid_ids)?;
+            }
+            if !skipped_ids.is_empty() {
+                mark_delivered(&skipped_ids)?;
+            }
+
+            if events.is_empty() {
+                continue;
+            }
+
+            // On upload failure, every dequeued-but-unprocessed row must
+            // still be marked (dequeued rows hold processing locks); mark
+            // them failed alongside the failed sub-chunk before bailing.
+            let mark_rest_failed_and_bail =
+                |mark_failed: &mut MarkFailed, e: GitAiError, record_ids: &[i64]| {
+                    mark_failed(record_ids, &e)?;
+                    if !remaining.is_empty() {
+                        let rest_ids: Vec<i64> = remaining.iter().map(|r| r.id).collect();
+                        mark_failed(&rest_ids, &e)?;
+                    }
+                    Err(e)
+                };
+
+            let metrics_batch = MetricsBatch::new(events);
+            tracing::info!(
+                min_id = ?batch_min_id,
+                max_id = ?batch_max_id,
+                events = record_ids.len(),
+                invalid_records = invalid_ids.len(),
+                "metrics upload batch sending"
+            );
+            let response = match upload_batch(&metrics_batch) {
+                Ok(response) => response,
+                Err(e) => {
+                    tracing::info!(
+                        min_id = ?batch_min_id,
+                        max_id = ?batch_max_id,
+                        events = record_ids.len(),
+                        error = %e,
+                        "metrics upload batch failed"
+                    );
+                    return mark_rest_failed_and_bail(&mut mark_failed, e, &record_ids);
+                }
+            };
+
+            if let Err(e) = response.validate_error_indices(record_ids.len()) {
                 tracing::info!(
                     min_id = ?batch_min_id,
                     max_id = ?batch_max_id,
                     events = record_ids.len(),
                     error = %e,
-                    "metrics upload batch failed"
+                    "metrics upload batch returned invalid response"
                 );
-                mark_failed(&record_ids, &e)?;
-                return Err(e);
+                return mark_rest_failed_and_bail(&mut mark_failed, e, &record_ids);
             }
-        };
 
-        if let Err(e) = response.validate_error_indices(record_ids.len()) {
+            let successful_ids: Vec<i64> = response
+                .successful_indices(record_ids.len())
+                .into_iter()
+                .map(|index| record_ids[index])
+                .collect();
+            let undeliverable_records: Vec<(i64, String)> = response
+                .errors
+                .iter()
+                .map(|error| (record_ids[error.index], error.error.clone()))
+                .collect();
+
             tracing::info!(
                 min_id = ?batch_min_id,
                 max_id = ?batch_max_id,
                 events = record_ids.len(),
-                error = %e,
-                "metrics upload batch returned invalid response"
+                delivered_events = successful_ids.len(),
+                errored_events = undeliverable_records.len(),
+                errors = ?response.errors,
+                "metrics upload batch result"
             );
-            mark_failed(&record_ids, &e)?;
-            return Err(e);
+
+            mark_delivered(&successful_ids)?;
+            mark_undeliverable(&undeliverable_records)?;
+
+            result.uploaded_events += successful_ids.len();
+            result.uploaded_batches += 1;
         }
-
-        let successful_ids: Vec<i64> = response
-            .successful_indices(record_ids.len())
-            .into_iter()
-            .map(|index| record_ids[index])
-            .collect();
-        let undeliverable_records: Vec<(i64, String)> = response
-            .errors
-            .iter()
-            .map(|error| (record_ids[error.index], error.error.clone()))
-            .collect();
-
-        tracing::info!(
-            min_id = ?batch_min_id,
-            max_id = ?batch_max_id,
-            events = record_ids.len(),
-            delivered_events = successful_ids.len(),
-            errored_events = undeliverable_records.len(),
-            errors = ?response.errors,
-            "metrics upload batch result"
-        );
-
-        mark_delivered(&successful_ids)?;
-        mark_undeliverable(&undeliverable_records)?;
-
-        result.uploaded_events += successful_ids.len();
-        result.uploaded_batches += 1;
     }
 
     Ok(result)
@@ -2084,6 +2124,7 @@ mod tests {
             },
             std::time::Instant::now() + std::time::Duration::from_secs(60),
             1,
+            usize::MAX,
         )
         .unwrap();
 
@@ -2101,6 +2142,70 @@ mod tests {
             db.borrow().get_metric_history(0, None, &[1]).unwrap().len(),
             2
         );
+    }
+
+    #[test]
+    fn flush_pending_metric_records_splits_count_batches_by_bytes() {
+        // A count-bounded dequeue of fat rows must not inflate them all at
+        // once (#2244): the byte budget splits parsing/uploading into
+        // sub-chunks while still delivering every row.
+        let (metrics_db, _metrics_db_dir) = MetricsDatabase::new_temp_for_tests().unwrap();
+        let db = Rc::new(RefCell::new(metrics_db));
+        let ts = now_ts().saturating_sub(3);
+        db.borrow_mut()
+            .insert_events(&[event_json(ts), event_json(ts + 1), event_json(ts + 2)])
+            .unwrap();
+
+        let uploaded = Rc::new(RefCell::new(Vec::<usize>::new()));
+        let result = flush_pending_metric_records_with(
+            {
+                let db = Rc::clone(&db);
+                move |limit| db.borrow_mut().dequeue_pending_batch(limit)
+            },
+            {
+                let db = Rc::clone(&db);
+                move |ids| db.borrow_mut().mark_records_delivered(ids, unix_now())
+            },
+            {
+                let db = Rc::clone(&db);
+                move |ids, err| {
+                    let now = unix_now();
+                    db.borrow_mut()
+                        .mark_records_failed(ids, &err.to_string(), now)
+                }
+            },
+            {
+                let db = Rc::clone(&db);
+                move |records| {
+                    db.borrow_mut()
+                        .mark_records_undeliverable(records, unix_now())
+                }
+            },
+            {
+                let uploaded = Rc::clone(&uploaded);
+                move |batch| {
+                    uploaded.borrow_mut().push(batch.events.len());
+                    Ok(MetricsUploadResponse { errors: vec![] })
+                }
+            },
+            std::time::Instant::now() + std::time::Duration::from_secs(60),
+            10,
+            // Any single row exhausts this budget, so each sub-chunk holds
+            // exactly one row even though the count batch dequeued all three.
+            1,
+        )
+        .unwrap();
+
+        assert_eq!(
+            result,
+            PendingMetricsFlushResult {
+                uploaded_events: 3,
+                uploaded_batches: 3,
+                invalid_records: 0,
+            }
+        );
+        assert_eq!(*uploaded.borrow(), vec![1, 1, 1]);
+        assert_eq!(db.borrow().count().unwrap(), 0);
     }
 
     #[test]
@@ -2148,6 +2253,7 @@ mod tests {
             },
             std::time::Instant::now() + std::time::Duration::from_secs(60),
             10,
+            usize::MAX,
         )
         .unwrap();
 
@@ -2219,6 +2325,7 @@ mod tests {
             },
             std::time::Instant::now() + std::time::Duration::from_secs(60),
             10,
+            usize::MAX,
         )
         .unwrap();
 
@@ -2295,6 +2402,7 @@ mod tests {
             },
             std::time::Instant::now() + std::time::Duration::from_secs(60),
             10,
+            usize::MAX,
         )
         .unwrap();
 
@@ -2362,6 +2470,7 @@ mod tests {
             },
             std::time::Instant::now() + std::time::Duration::from_secs(60),
             10,
+            usize::MAX,
         );
 
         assert!(result.is_err());
@@ -2407,6 +2516,7 @@ mod tests {
             |_batch| Err(GitAiError::Generic("upload failed".to_string())),
             std::time::Instant::now() + std::time::Duration::from_secs(60),
             10,
+            usize::MAX,
         );
 
         assert!(result.is_err());
@@ -2450,6 +2560,7 @@ mod tests {
             |_batch| Err(GitAiError::Generic("upload failed".to_string())),
             std::time::Instant::now() + std::time::Duration::from_secs(60),
             1,
+            usize::MAX,
         );
         assert!(failed.is_err());
         assert_eq!(db.borrow().count_retryable().unwrap(), 0);
@@ -2496,6 +2607,7 @@ mod tests {
             },
             std::time::Instant::now() + std::time::Duration::from_secs(60),
             1,
+            usize::MAX,
         )
         .unwrap();
 

--- a/src/metrics/db.rs
+++ b/src/metrics/db.rs
@@ -27,7 +27,7 @@ pub(crate) const METADATA_BACKFILL_BATCH_SIZE: usize = 1000;
 const EVENT_METADATA_BACKFILL_COMPLETED_KEY: &str = "event_metadata_backfill_completed";
 const NS_PER_SECOND: u128 = 1_000_000_000;
 
-const RETRYABLE_METRIC_IDS_SQL: &str = "SELECT id FROM metrics \
+const RETRYABLE_METRIC_IDS_SQL: &str = "SELECT id, LENGTH(event_json) FROM metrics \
      WHERE delivered_ts IS NULL \
        AND processing_started_at IS NULL \
        AND next_retry_at <= ?1 \
@@ -578,7 +578,16 @@ impl MetricsDatabase {
     }
 
     /// Atomically claim a due batch of pending metrics for upload.
-    pub fn dequeue_pending_batch(&mut self, limit: usize) -> Result<Vec<MetricRecord>, GitAiError> {
+    ///
+    /// The batch is bounded by row count AND by accumulated `event_json`
+    /// bytes (always at least one row): transcript-derived rows can be MBs
+    /// each, so a count-only dequeue could materialize GBs of JSON strings
+    /// before any downstream chunking applies (#2244).
+    pub fn dequeue_pending_batch(
+        &mut self,
+        limit: usize,
+        max_bytes: usize,
+    ) -> Result<Vec<MetricRecord>, GitAiError> {
         if limit == 0 {
             return Ok(Vec::new());
         }
@@ -590,11 +599,18 @@ impl MetricsDatabase {
         let ids = {
             let mut stmt = tx.prepare(RETRYABLE_METRIC_IDS_SQL)?;
             let rows = stmt.query_map(params![now as i64, limit as i64], |row| {
-                row.get::<_, i64>(0)
+                Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?))
             })?;
             let mut ids = Vec::new();
+            let mut total_bytes = 0usize;
             for row in rows {
-                ids.push(row?);
+                let (id, bytes) = row?;
+                let bytes = bytes.max(0) as usize;
+                if !ids.is_empty() && total_bytes.saturating_add(bytes) > max_bytes {
+                    break;
+                }
+                total_bytes = total_bytes.saturating_add(bytes);
+                ids.push(id);
             }
             ids
         };
@@ -704,6 +720,28 @@ impl MetricsDatabase {
 
             for id in ids {
                 stmt.execute(params![error, failed_at as i64, id])?;
+            }
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
+    /// Release the processing locks of dequeued records WITHOUT counting a
+    /// delivery attempt. For rows that were claimed but never attempted
+    /// (deadline expiry, or an earlier chunk's upload failure): charging them
+    /// an attempt would let repeated failures of other rows exhaust their
+    /// retries before they were ever uploaded.
+    pub fn release_processing_locks(&mut self, ids: &[i64]) -> Result<(), GitAiError> {
+        if ids.is_empty() {
+            return Ok(());
+        }
+
+        let tx = self.conn.transaction()?;
+        {
+            let mut stmt =
+                tx.prepare_cached("UPDATE metrics SET processing_started_at = NULL WHERE id = ?1")?;
+            for id in ids {
+                stmt.execute(params![id])?;
             }
         }
         tx.commit()?;
@@ -2603,7 +2641,7 @@ mod tests {
         let events = vec![event_json(days_ago(2)), event_json(days_ago(1))];
         db.insert_events(&events).unwrap();
 
-        let batch = db.dequeue_pending_batch(1).unwrap();
+        let batch = db.dequeue_pending_batch(1, usize::MAX).unwrap();
         assert_eq!(batch.len(), 1);
         assert_eq!(db.count().unwrap(), 2);
         assert_eq!(db.count_retryable().unwrap(), 1);
@@ -2612,6 +2650,29 @@ mod tests {
             .unwrap();
         assert_eq!(db.count().unwrap(), 1);
         assert_eq!(db.count_retryable().unwrap(), 1);
+    }
+
+    #[test]
+    fn test_dequeue_pending_batch_stops_at_byte_budget() {
+        let (mut db, _dir) = MetricsDatabase::new_temp_for_tests().unwrap();
+        let fat = format!("{{\"pad\":\"{}\"}}", "x".repeat(100));
+        db.insert_events(&[fat.clone(), fat.clone(), fat.clone()])
+            .unwrap();
+
+        // ~110-byte rows against a 250-byte budget: two rows fit (the third
+        // would exceed it), and the excluded row is not locked, so a later
+        // dequeue claims it.
+        let batch = db.dequeue_pending_batch(10, 250).unwrap();
+        assert_eq!(batch.len(), 2);
+
+        let rest = db.dequeue_pending_batch(10, 250).unwrap();
+        assert_eq!(rest.len(), 1);
+
+        // A single row over the budget is still dequeued alone (progress).
+        db.release_processing_locks(&rest.iter().map(|r| r.id).collect::<Vec<_>>())
+            .unwrap();
+        let one = db.dequeue_pending_batch(10, 1).unwrap();
+        assert_eq!(one.len(), 1);
     }
 
     #[test]
@@ -2627,7 +2688,7 @@ mod tests {
         ])
         .unwrap();
 
-        let batch = db.dequeue_pending_batch(2).unwrap();
+        let batch = db.dequeue_pending_batch(2, usize::MAX).unwrap();
         assert_eq!(batch.len(), 2);
         assert!(batch[0].id > batch[1].id);
         assert!(batch[0].event_json.contains(&format!("\"t\":{newest_ts}")));
@@ -2682,7 +2743,7 @@ mod tests {
         db.insert_events(&[event_json(days_ago(2)), event_json(days_ago(1))])
             .unwrap();
 
-        let batch = db.dequeue_pending_batch(1).unwrap();
+        let batch = db.dequeue_pending_batch(1, usize::MAX).unwrap();
         let failed_id = batch[0].id;
         let failed_at = unix_now();
         db.mark_records_failed(&[failed_id], "upload failed", failed_at)
@@ -2691,7 +2752,7 @@ mod tests {
         assert_eq!(db.count().unwrap(), 2);
         assert_eq!(db.count_retryable().unwrap(), 1);
 
-        let retryable_batch = db.dequeue_pending_batch(10).unwrap();
+        let retryable_batch = db.dequeue_pending_batch(10, usize::MAX).unwrap();
         assert_eq!(retryable_batch.len(), 1);
         assert_ne!(retryable_batch[0].id, failed_id);
 
@@ -2712,7 +2773,7 @@ mod tests {
         let (mut db, _temp_dir) = create_test_db();
         db.insert_events(&[event_json(days_ago(1))]).unwrap();
 
-        let first_batch = db.dequeue_pending_batch(1).unwrap();
+        let first_batch = db.dequeue_pending_batch(1, usize::MAX).unwrap();
         assert_eq!(first_batch.len(), 1);
         assert_eq!(db.count_retryable().unwrap(), 0);
 
@@ -2724,7 +2785,7 @@ mod tests {
             )
             .unwrap();
 
-        let second_batch = db.dequeue_pending_batch(1).unwrap();
+        let second_batch = db.dequeue_pending_batch(1, usize::MAX).unwrap();
         assert_eq!(second_batch.len(), 1);
         assert_eq!(second_batch[0].id, first_batch[0].id);
     }
@@ -2742,7 +2803,7 @@ mod tests {
 
         assert_eq!(db.count().unwrap(), 1);
         assert_eq!(db.count_retryable().unwrap(), 0);
-        assert!(db.dequeue_pending_batch(1).unwrap().is_empty());
+        assert!(db.dequeue_pending_batch(1, usize::MAX).unwrap().is_empty());
     }
 
     #[test]
@@ -2831,14 +2892,14 @@ mod tests {
         let event_ts = days_ago(1);
         let ids = db.insert_events(&[event_json(event_ts)]).unwrap();
 
-        let batch = db.dequeue_pending_batch(1).unwrap();
+        let batch = db.dequeue_pending_batch(1, usize::MAX).unwrap();
         assert_eq!(batch.len(), 1);
         db.mark_records_undeliverable(&[(ids[0], "validation failed".to_string())], unix_now())
             .unwrap();
 
         assert_eq!(db.count().unwrap(), 1);
         assert_eq!(db.count_retryable().unwrap(), 0);
-        assert!(db.dequeue_pending_batch(1).unwrap().is_empty());
+        assert!(db.dequeue_pending_batch(1, usize::MAX).unwrap().is_empty());
         assert_eq!(db.get_metric_history(0, None, &[1]).unwrap().len(), 1);
 
         let (delivered_ts, attempts, last_sync_error): (Option<i64>, i64, Option<String>) = db
@@ -3008,7 +3069,7 @@ mod tests {
         db.insert_events(&events).unwrap();
 
         // Dequeue newest rows and mark them delivered.
-        let batch = db.dequeue_pending_batch(2).unwrap();
+        let batch = db.dequeue_pending_batch(2, usize::MAX).unwrap();
         let ids: Vec<i64> = batch.iter().map(|r| r.id).collect();
 
         db.mark_records_delivered(&ids, unix_now()).unwrap();
@@ -3251,7 +3312,7 @@ mod tests {
         db.insert_events(&[]).unwrap();
 
         // Dequeue from empty should return empty.
-        let batch = db.dequeue_pending_batch(10).unwrap();
+        let batch = db.dequeue_pending_batch(10, usize::MAX).unwrap();
         assert!(batch.is_empty());
 
         // Marking an empty set delivered should succeed.

--- a/src/streams/agents/amp.rs
+++ b/src/streams/agents/amp.rs
@@ -136,6 +136,13 @@ impl Agent for AmpAgent {
         watermark: Box<dyn WatermarkStrategy>,
         session_id: &str,
     ) -> Result<StreamBatch, StreamError> {
+        // Whole-file parse below: gate on size first (#2244).
+        if crate::streams::types::skip_whole_file_over_budget(path, "Amp", session_id) {
+            return Ok(StreamBatch {
+                events: Vec::new(),
+                new_watermark: watermark,
+            });
+        }
         // Downcast watermark to RecordIndexWatermark
         let record_watermark = watermark
             .as_any()
@@ -234,6 +241,26 @@ impl Agent for AmpAgent {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_oversized_thread_file_is_skipped_with_watermark_unchanged() {
+        // A sparse file over the 64 MiB default whole-file budget: the gate
+        // must return an empty batch without parsing (a parse would fail on
+        // the zero bytes) and leave the watermark where it was.
+        let file = tempfile::NamedTempFile::new().unwrap();
+        file.as_file().set_len(65 * 1024 * 1024).unwrap();
+
+        let agent = AmpAgent::new();
+        let batch = agent
+            .read_incremental(
+                file.path(),
+                Box::new(crate::streams::watermark::RecordIndexWatermark::new(7)),
+                "session-1",
+            )
+            .expect("over-budget file should be skipped, not an error");
+        assert!(batch.events.is_empty());
+        assert_eq!(batch.new_watermark.serialize(), "7");
+    }
 
     #[test]
     fn test_sweep_strategy() {

--- a/src/streams/agents/continue_cli.rs
+++ b/src/streams/agents/continue_cli.rs
@@ -100,6 +100,13 @@ impl Agent for ContinueAgent {
         watermark: Box<dyn WatermarkStrategy>,
         session_id: &str,
     ) -> Result<StreamBatch, StreamError> {
+        // Whole-file parse below: gate on size first (#2244).
+        if crate::streams::types::skip_whole_file_over_budget(path, "Continue", session_id) {
+            return Ok(StreamBatch {
+                events: Vec::new(),
+                new_watermark: watermark,
+            });
+        }
         // Downcast watermark to RecordIndexWatermark
         let record_watermark = watermark
             .as_any()
@@ -193,6 +200,26 @@ impl Agent for ContinueAgent {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_oversized_thread_file_is_skipped_with_watermark_unchanged() {
+        // A sparse file over the 64 MiB default whole-file budget: the gate
+        // must return an empty batch without parsing (a parse would fail on
+        // the zero bytes) and leave the watermark where it was.
+        let file = tempfile::NamedTempFile::new().unwrap();
+        file.as_file().set_len(65 * 1024 * 1024).unwrap();
+
+        let agent = ContinueAgent::new();
+        let batch = agent
+            .read_incremental(
+                file.path(),
+                Box::new(crate::streams::watermark::RecordIndexWatermark::new(7)),
+                "session-1",
+            )
+            .expect("over-budget file should be skipped, not an error");
+        assert!(batch.events.is_empty());
+        assert_eq!(batch.new_watermark.serialize(), "7");
+    }
 
     #[test]
     fn test_sweep_strategy() {

--- a/src/streams/agents/copilot.rs
+++ b/src/streams/agents/copilot.rs
@@ -396,6 +396,13 @@ fn read_session_json(
     session_id: &str,
     batch_limit: usize,
 ) -> Result<StreamBatch, StreamError> {
+    // Whole-file parse below: gate on size first (#2244).
+    if crate::streams::types::skip_whole_file_over_budget(path, "Copilot session", session_id) {
+        return Ok(StreamBatch {
+            events: Vec::new(),
+            new_watermark: watermark,
+        });
+    }
     let record_watermark = watermark
         .as_any()
         .downcast_ref::<RecordIndexWatermark>()
@@ -495,6 +502,28 @@ pub(super) fn read_event_stream(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_oversized_session_json_is_skipped_with_watermark_unchanged() {
+        // A sparse .json file over the 64 MiB default whole-file budget: the
+        // gate must return an empty batch without parsing and leave the
+        // watermark where it was.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("session.json");
+        let file = std::fs::File::create(&path).unwrap();
+        file.set_len(65 * 1024 * 1024).unwrap();
+
+        let batch = read_session_json(
+            &path,
+            Box::new(RecordIndexWatermark::new(3)),
+            "session-1",
+            1000,
+        )
+        .expect("over-budget session json should be skipped, not an error");
+        assert!(batch.events.is_empty());
+        assert_eq!(batch.new_watermark.serialize(), "3");
+    }
+
     use crate::streams::watermark::ByteOffsetWatermark;
 
     #[test]

--- a/src/streams/agents/copilot_otel.rs
+++ b/src/streams/agents/copilot_otel.rs
@@ -31,6 +31,23 @@ pub fn read_otel_spans_incremental(
     watermark: Box<dyn WatermarkStrategy>,
     batch_size: usize,
 ) -> Result<StreamBatch, StreamError> {
+    let config = crate::config::Config::get();
+    read_otel_spans_incremental_with(
+        path,
+        watermark,
+        batch_size,
+        config.max_transcript_batch_bytes() as u64,
+        config.max_transcript_line_bytes(),
+    )
+}
+
+fn read_otel_spans_incremental_with(
+    path: &Path,
+    watermark: Box<dyn WatermarkStrategy>,
+    batch_size: usize,
+    max_batch_bytes: u64,
+    max_span_bytes: u64,
+) -> Result<StreamBatch, StreamError> {
     let cursor = watermark
         .as_any()
         .downcast_ref::<TimestampCursorWatermark>()
@@ -40,13 +57,55 @@ pub fn read_otel_spans_incremental(
 
     let conn = open_sqlite_readonly(path)?;
 
-    let spans = read_spans_after(&conn, cursor.timestamp_millis, &cursor.last_id, batch_size)?;
+    let mut spans = read_spans_after(&conn, cursor.timestamp_millis, &cursor.last_id, batch_size)?;
     if spans.is_empty() {
         return Ok(StreamBatch {
             events: vec![],
             new_watermark: Box::new(cursor.clone()),
         });
     }
+
+    // Byte-bound the batch: the LIMIT above is count-only, but the attribute
+    // and event TEXT payloads are unbounded, so a count-only batch could
+    // materialize arbitrarily many MBs at once (#2244). Payload sizes come
+    // from SQL LENGTH sums, so nothing is inflated for the estimate.
+    let all_ids: Vec<&str> = spans.iter().map(|s| s.span_id.as_str()).collect();
+    let payload_bytes = read_payload_bytes_for_spans(&conn, &all_ids)?;
+
+    // A single span whose payload alone exceeds the per-line budget is
+    // skipped outright: keyset pagination makes advancing past it exact,
+    // and parsing it would defeat the byte bound.
+    let first_bytes = payload_bytes.get(&spans[0].span_id).copied().unwrap_or(0);
+    if first_bytes > max_span_bytes {
+        let first = &spans[0];
+        tracing::warn!(
+            span_id = %first.span_id,
+            payload_bytes = first_bytes,
+            max_bytes = max_span_bytes,
+            "skipping oversized OTEL span"
+        );
+        return Ok(StreamBatch {
+            events: vec![],
+            new_watermark: Box::new(TimestampCursorWatermark::new(
+                first.end_time_ms,
+                first.span_id.clone(),
+            )),
+        });
+    }
+
+    // Truncate at the batch byte budget (always keeping at least one span);
+    // the remainder arrives next poll via the keyset cursor.
+    let mut cumulative = 0u64;
+    let mut included = 0usize;
+    for span in &spans {
+        let bytes = payload_bytes.get(&span.span_id).copied().unwrap_or(0);
+        if included > 0 && cumulative + bytes > max_batch_bytes {
+            break;
+        }
+        cumulative += bytes;
+        included += 1;
+    }
+    spans.truncate(included);
 
     let span_ids: Vec<&str> = spans.iter().map(|s| s.span_id.as_str()).collect();
     let attributes = read_attributes_for_spans(&conn, &span_ids)?;
@@ -190,6 +249,39 @@ fn read_spans_after(
 
     rows.collect::<Result<Vec<_>, _>>()
         .map_err(|e| map_sqlite_error(e, "Failed to read span row"))
+}
+
+/// Approximate payload bytes per span: attribute values plus event attribute
+/// blobs (the unbounded TEXT columns; the span row itself is small fixed
+/// columns). Computed with SQL LENGTH sums so nothing is materialized.
+fn read_payload_bytes_for_spans(
+    conn: &Connection,
+    span_ids: &[&str],
+) -> Result<HashMap<String, u64>, StreamError> {
+    let mut result: HashMap<String, u64> = HashMap::new();
+    let placeholders: String = span_ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+    for (table, expr) in [
+        ("span_attributes", "LENGTH(COALESCE(value, ''))"),
+        ("span_events", "LENGTH(COALESCE(attributes, ''))"),
+    ] {
+        let sql = format!(
+            "SELECT span_id, SUM({expr}) FROM {table} WHERE span_id IN ({placeholders}) GROUP BY span_id"
+        );
+        let mut stmt = conn
+            .prepare(&sql)
+            .map_err(|e| map_sqlite_error(e, "Failed to prepare payload size query"))?;
+        let rows = stmt
+            .query_map(rusqlite::params_from_iter(span_ids.iter()), |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+            })
+            .map_err(|e| map_sqlite_error(e, "Failed to query payload sizes"))?;
+        for row in rows {
+            let (span_id, bytes) =
+                row.map_err(|e| map_sqlite_error(e, "Failed to read payload size row"))?;
+            *result.entry(span_id).or_insert(0) += bytes.max(0) as u64;
+        }
+    }
+    Ok(result)
 }
 
 fn read_attributes_for_spans(
@@ -391,6 +483,64 @@ mod tests {
             rusqlite::params![span_id, end_time_ms - 1000, end_time_ms, input_tokens, output_tokens],
         )
         .unwrap();
+    }
+
+    fn insert_span_attr(conn: &rusqlite::Connection, span_id: &str, key: &str, value: &str) {
+        conn.execute(
+            "INSERT INTO span_attributes (span_id, key, value) VALUES (?1, ?2, ?3)",
+            rusqlite::params![span_id, key, value],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn test_batch_truncates_at_byte_budget_and_resumes() {
+        let (_dir, db_path) = create_test_otel_db();
+        let conn = crate::sqlite::open_with_memory_limits(&db_path).unwrap();
+        for i in 1..=4 {
+            let span_id = format!("span{}", i);
+            insert_span(&conn, &span_id, i * 1000, 100, 50);
+            insert_span_attr(&conn, &span_id, "payload", &"x".repeat(100));
+        }
+        drop(conn);
+
+        // 250-byte batch budget fits two 100-byte payloads (the check runs
+        // before the third would exceed it); per-span budget stays permissive.
+        let watermark: Box<dyn WatermarkStrategy> = Box::new(TimestampCursorWatermark::initial());
+        let batch = read_otel_spans_incremental_with(&db_path, watermark, 100, 250, 1024).unwrap();
+        assert_eq!(batch.events.len(), 2);
+        assert_eq!(batch.events[1]["span"]["span_id"], "span2");
+
+        // The keyset watermark resumes exactly after the last included span.
+        let batch = read_otel_spans_incremental_with(&db_path, batch.new_watermark, 100, 250, 1024)
+            .unwrap();
+        assert_eq!(batch.events.len(), 2);
+        assert_eq!(batch.events[0]["span"]["span_id"], "span3");
+        assert_eq!(batch.events[1]["span"]["span_id"], "span4");
+    }
+
+    #[test]
+    fn test_oversized_span_is_skipped_with_cursor_advanced() {
+        let (_dir, db_path) = create_test_otel_db();
+        let conn = crate::sqlite::open_with_memory_limits(&db_path).unwrap();
+        insert_span(&conn, "giant", 1000, 100, 50);
+        insert_span_attr(&conn, "giant", "payload", &"x".repeat(2000));
+        insert_span(&conn, "normal", 2000, 100, 50);
+        insert_span_attr(&conn, "normal", "payload", &"y".repeat(10));
+        drop(conn);
+
+        // The giant span exceeds the 1024-byte per-span budget: skipped, with
+        // the cursor advanced past it so it is never re-read.
+        let watermark: Box<dyn WatermarkStrategy> = Box::new(TimestampCursorWatermark::initial());
+        let batch = read_otel_spans_incremental_with(&db_path, watermark, 100, 4096, 1024).unwrap();
+        assert!(batch.events.is_empty());
+        assert_eq!(batch.new_watermark.serialize(), "1000|giant");
+
+        let batch =
+            read_otel_spans_incremental_with(&db_path, batch.new_watermark, 100, 4096, 1024)
+                .unwrap();
+        assert_eq!(batch.events.len(), 1);
+        assert_eq!(batch.events[0]["span"]["span_id"], "normal");
     }
 
     #[test]

--- a/src/streams/agents/copilot_otel.rs
+++ b/src/streams/agents/copilot_otel.rs
@@ -57,41 +57,47 @@ fn read_otel_spans_incremental_with(
 
     let conn = open_sqlite_readonly(path)?;
 
-    let mut spans = read_spans_after(&conn, cursor.timestamp_millis, &cursor.last_id, batch_size)?;
-    if spans.is_empty() {
-        return Ok(StreamBatch {
-            events: vec![],
-            new_watermark: Box::new(cursor.clone()),
-        });
-    }
+    // Oversized spans are skipped by advancing the keyset cursor past them
+    // and re-reading WITHIN this poll: returning early on a skip would let
+    // the caller treat the poll as complete and strand the spans behind the
+    // giant one until the database next changes.
+    let mut cursor_ms = cursor.timestamp_millis;
+    let mut cursor_id = cursor.last_id.clone();
+    let (mut spans, payload_bytes) = loop {
+        let spans = read_spans_after(&conn, cursor_ms, &cursor_id, batch_size)?;
+        if spans.is_empty() {
+            return Ok(StreamBatch {
+                events: vec![],
+                new_watermark: Box::new(TimestampCursorWatermark::new(cursor_ms, cursor_id)),
+            });
+        }
 
-    // Byte-bound the batch: the LIMIT above is count-only, but the attribute
-    // and event TEXT payloads are unbounded, so a count-only batch could
-    // materialize arbitrarily many MBs at once (#2244). Payload sizes come
-    // from SQL LENGTH sums, so nothing is inflated for the estimate.
-    let all_ids: Vec<&str> = spans.iter().map(|s| s.span_id.as_str()).collect();
-    let payload_bytes = read_payload_bytes_for_spans(&conn, &all_ids)?;
+        // Byte-bound the batch: the LIMIT above is count-only, but the
+        // attribute and event TEXT payloads are unbounded, so a count-only
+        // batch could materialize arbitrarily many MBs at once (#2244).
+        // Payload sizes come from SQL LENGTH sums, so nothing is inflated
+        // for the estimate.
+        let all_ids: Vec<&str> = spans.iter().map(|s| s.span_id.as_str()).collect();
+        let payload_bytes = read_payload_bytes_for_spans(&conn, &all_ids)?;
 
-    // A single span whose payload alone exceeds the per-line budget is
-    // skipped outright: keyset pagination makes advancing past it exact,
-    // and parsing it would defeat the byte bound.
-    let first_bytes = payload_bytes.get(&spans[0].span_id).copied().unwrap_or(0);
-    if first_bytes > max_span_bytes {
-        let first = &spans[0];
-        tracing::warn!(
-            span_id = %first.span_id,
-            payload_bytes = first_bytes,
-            max_bytes = max_span_bytes,
-            "skipping oversized OTEL span"
-        );
-        return Ok(StreamBatch {
-            events: vec![],
-            new_watermark: Box::new(TimestampCursorWatermark::new(
-                first.end_time_ms,
-                first.span_id.clone(),
-            )),
-        });
-    }
+        // A single span whose payload alone exceeds the per-line budget is
+        // skipped outright: keyset pagination makes advancing past it exact,
+        // and parsing it would defeat the byte bound.
+        let first_bytes = payload_bytes.get(&spans[0].span_id).copied().unwrap_or(0);
+        if first_bytes > max_span_bytes {
+            let first = &spans[0];
+            tracing::warn!(
+                span_id = %first.span_id,
+                payload_bytes = first_bytes,
+                max_bytes = max_span_bytes,
+                "skipping oversized OTEL span"
+            );
+            cursor_ms = first.end_time_ms;
+            cursor_id = first.span_id.clone();
+            continue;
+        }
+        break (spans, payload_bytes);
+    };
 
     // Truncate at the batch byte budget (always keeping at least one span);
     // the remainder arrives next poll via the keyset cursor.
@@ -529,18 +535,20 @@ mod tests {
         insert_span_attr(&conn, "normal", "payload", &"y".repeat(10));
         drop(conn);
 
-        // The giant span exceeds the 1024-byte per-span budget: skipped, with
-        // the cursor advanced past it so it is never re-read.
+        // The giant span exceeds the 1024-byte per-span budget: skipped with
+        // the cursor advanced past it, and the SAME poll continues to the
+        // spans behind it — an early return would strand them until the
+        // database next changes.
         let watermark: Box<dyn WatermarkStrategy> = Box::new(TimestampCursorWatermark::initial());
         let batch = read_otel_spans_incremental_with(&db_path, watermark, 100, 4096, 1024).unwrap();
-        assert!(batch.events.is_empty());
-        assert_eq!(batch.new_watermark.serialize(), "1000|giant");
+        assert_eq!(batch.events.len(), 1);
+        assert_eq!(batch.events[0]["span"]["span_id"], "normal");
+        assert_eq!(batch.new_watermark.serialize(), "2000|normal");
 
         let batch =
             read_otel_spans_incremental_with(&db_path, batch.new_watermark, 100, 4096, 1024)
                 .unwrap();
-        assert_eq!(batch.events.len(), 1);
-        assert_eq!(batch.events[0]["span"]["span_id"], "normal");
+        assert!(batch.events.is_empty(), "the giant span is never re-read");
     }
 
     #[test]

--- a/src/streams/agents/opencode.rs
+++ b/src/streams/agents/opencode.rs
@@ -24,6 +24,117 @@ impl OpenCodeAgent {
     pub fn with_batch_size(batch_size: usize) -> Self {
         Self { batch_size }
     }
+
+    fn read_incremental_bounded(
+        &self,
+        path: &Path,
+        watermark: Box<dyn WatermarkStrategy>,
+        session_id: &str,
+        max_batch_bytes: u64,
+        max_row_bytes: u64,
+    ) -> Result<StreamBatch, StreamError> {
+        let ts_watermark = watermark
+            .as_any()
+            .downcast_ref::<TimestampWatermark>()
+            .ok_or_else(|| StreamError::Fatal {
+                message: format!(
+                    "OpenCode reader requires TimestampWatermark, got incompatible type for session {}",
+                    session_id
+                ),
+            })?;
+
+        let watermark_millis = ts_watermark.0.timestamp_millis();
+
+        let conn = open_sqlite_readonly(path)?;
+
+        // Decide how far this poll reads before materializing anything: the
+        // LIMIT is count-only, but message/part data columns are unbounded
+        // TEXT, so a count-only batch could inflate arbitrarily many MBs at
+        // once (#2244). Uses strict > on the watermark to avoid re-reading.
+        // Note: messages sharing exact same millisecond as watermark boundary
+        // could theoretically be skipped, but OpenCode writes are interactive
+        // (not concurrent) so millisecond collisions are effectively
+        // impossible in practice.
+        let through_millis = match plan_message_batch(
+            &conn,
+            session_id,
+            watermark_millis,
+            self.batch_size,
+            max_batch_bytes,
+            max_row_bytes,
+        )? {
+            BatchPlan::Empty => {
+                return Ok(StreamBatch {
+                    events: Vec::new(),
+                    new_watermark: Box::new(TimestampWatermark::new(ts_watermark.0)),
+                });
+            }
+            BatchPlan::SkipOversized {
+                through_millis,
+                bytes,
+            } => {
+                tracing::warn!(
+                    path = %path.display(),
+                    session_id,
+                    time_updated = through_millis,
+                    row_bytes = bytes,
+                    max_bytes = max_row_bytes,
+                    "skipping oversized OpenCode message; advancing watermark past it"
+                );
+                let skipped_ts =
+                    DateTime::from_timestamp_millis(through_millis).unwrap_or(ts_watermark.0);
+                return Ok(StreamBatch {
+                    events: Vec::new(),
+                    new_watermark: Box::new(TimestampWatermark::new(skipped_ts)),
+                });
+            }
+            BatchPlan::ReadThrough { through_millis } => through_millis,
+        };
+
+        let messages = read_session_messages_raw_with_limit(
+            &conn,
+            session_id,
+            watermark_millis,
+            through_millis,
+            self.batch_size,
+        )?;
+
+        // Read only parts for the matched messages (IN-subquery, single scan)
+        let mut parts_by_message = read_parts_for_messages_with_limit(
+            &conn,
+            session_id,
+            watermark_millis,
+            through_millis,
+            self.batch_size,
+        )?;
+
+        let mut max_updated: i64 = watermark_millis;
+        let mut events = Vec::with_capacity(messages.len());
+
+        for (msg_id, time_updated, msg_data) in messages {
+            if time_updated > max_updated {
+                max_updated = time_updated;
+            }
+
+            // Use .remove() to move parts out of the HashMap instead of cloning via .get()
+            let mut map = serde_json::Map::with_capacity(2);
+            map.insert("message".into(), msg_data);
+            if let Some(parts) = parts_by_message.remove(&msg_id) {
+                map.insert("parts".into(), serde_json::Value::Array(parts));
+            }
+
+            events.push(serde_json::Value::Object(map));
+        }
+
+        let new_watermark_ts =
+            DateTime::from_timestamp_millis(max_updated).unwrap_or(ts_watermark.0);
+        let new_watermark = Box::new(TimestampWatermark::new(new_watermark_ts));
+
+        Ok(StreamBatch {
+            events,
+            new_watermark,
+        })
+    }
 }
 
 pub fn open_sqlite_readonly(path: &Path) -> Result<Connection, StreamError> {
@@ -41,18 +152,99 @@ pub fn open_sqlite_readonly(path: &Path) -> Result<Connection, StreamError> {
     Ok(conn)
 }
 
+/// How much of the count-limited candidate window one poll should consume,
+/// decided from SQL LENGTH sums before anything is materialized (#2244).
+enum BatchPlan {
+    /// No candidate messages after the watermark.
+    Empty,
+    /// The first candidate timestamp group alone exceeds the per-row budget:
+    /// advance the watermark past it without emitting anything.
+    SkipOversized { through_millis: i64, bytes: u64 },
+    /// Read messages with `time_updated <= through_millis`.
+    ReadThrough { through_millis: i64 },
+}
+
+/// Byte-budget plan over the candidate messages. Truncation happens only at
+/// distinct `time_updated` boundaries: the timestamp watermark's strict `>`
+/// comparison would otherwise skip rows tied with the boundary.
+fn plan_message_batch(
+    conn: &Connection,
+    session_id: &str,
+    after_updated: i64,
+    limit: usize,
+    max_batch_bytes: u64,
+    max_row_bytes: u64,
+) -> Result<BatchPlan, StreamError> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT m.time_updated, \
+                    LENGTH(m.data) + COALESCE( \
+                        (SELECT SUM(LENGTH(p.data)) FROM part p WHERE p.message_id = m.id), 0) \
+             FROM message m \
+             WHERE m.session_id = ? AND m.time_updated > ? \
+             ORDER BY m.time_updated ASC, m.id ASC \
+             LIMIT ?",
+        )
+        .map_err(|e| StreamError::Fatal {
+            message: format!("Failed to prepare message size query: {}", e),
+        })?;
+    let rows = stmt
+        .query_map(rusqlite::params![session_id, after_updated, limit], |row| {
+            Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?))
+        })
+        .map_err(|e| StreamError::Fatal {
+            message: format!("Failed to query message sizes: {}", e),
+        })?;
+
+    // Collapse candidates into (time_updated, bytes) groups.
+    let mut groups: Vec<(i64, u64)> = Vec::new();
+    for row in rows {
+        let (time_updated, bytes) = row.map_err(|e| StreamError::Fatal {
+            message: format!("Failed to read message size row: {}", e),
+        })?;
+        let bytes = bytes.max(0) as u64;
+        match groups.last_mut() {
+            Some((ts, group_bytes)) if *ts == time_updated => *group_bytes += bytes,
+            _ => groups.push((time_updated, bytes)),
+        }
+    }
+
+    let Some(&(first_ts, first_bytes)) = groups.first() else {
+        return Ok(BatchPlan::Empty);
+    };
+    if first_bytes > max_row_bytes {
+        return Ok(BatchPlan::SkipOversized {
+            through_millis: first_ts,
+            bytes: first_bytes,
+        });
+    }
+
+    // Include groups until the batch budget is spent (always at least one).
+    let mut cumulative = 0u64;
+    let mut through_millis = first_ts;
+    for &(ts, bytes) in &groups {
+        if cumulative > 0 && cumulative + bytes > max_batch_bytes {
+            break;
+        }
+        cumulative += bytes;
+        through_millis = ts;
+    }
+    Ok(BatchPlan::ReadThrough { through_millis })
+}
+
 /// Read messages from the database, returning each row as a complete JSON object
 /// containing all columns (id, session_id, time_created, time_updated, data).
 fn read_session_messages_raw_with_limit(
     conn: &Connection,
     session_id: &str,
     after_updated: i64,
+    up_to_updated: i64,
     limit: usize,
 ) -> Result<Vec<(String, i64, serde_json::Value)>, StreamError> {
     let mut stmt = conn
         .prepare(
             "SELECT id, session_id, time_created, time_updated, data FROM message \
-             WHERE session_id = ? AND time_updated > ? \
+             WHERE session_id = ? AND time_updated > ? AND time_updated <= ? \
              ORDER BY time_updated ASC, id ASC \
              LIMIT ?",
         )
@@ -61,14 +253,17 @@ fn read_session_messages_raw_with_limit(
         })?;
 
     let rows = stmt
-        .query_map(rusqlite::params![session_id, after_updated, limit], |row| {
-            let id: String = row.get(0)?;
-            let row_session_id: String = row.get(1)?;
-            let time_created: i64 = row.get(2)?;
-            let time_updated: i64 = row.get(3)?;
-            let data: String = row.get(4)?;
-            Ok((id, row_session_id, time_created, time_updated, data))
-        })
+        .query_map(
+            rusqlite::params![session_id, after_updated, up_to_updated, limit],
+            |row| {
+                let id: String = row.get(0)?;
+                let row_session_id: String = row.get(1)?;
+                let time_created: i64 = row.get(2)?;
+                let time_updated: i64 = row.get(3)?;
+                let data: String = row.get(4)?;
+                Ok((id, row_session_id, time_created, time_updated, data))
+            },
+        )
         .map_err(|e| StreamError::Fatal {
             message: format!("Failed to query messages: {}", e),
         })?;
@@ -117,13 +312,14 @@ fn read_parts_for_messages_with_limit(
     conn: &Connection,
     session_id: &str,
     after_updated: i64,
+    up_to_updated: i64,
     limit: usize,
 ) -> Result<HashMap<String, Vec<serde_json::Value>>, StreamError> {
     let mut stmt = conn
         .prepare(
             "SELECT id, message_id, session_id, time_created, time_updated, data FROM part \
              WHERE message_id IN ( \
-                 SELECT id FROM message WHERE session_id = ? AND time_updated > ? ORDER BY time_updated ASC, id ASC LIMIT ? \
+                 SELECT id FROM message WHERE session_id = ? AND time_updated > ? AND time_updated <= ? ORDER BY time_updated ASC, id ASC LIMIT ? \
              ) \
              ORDER BY message_id ASC, time_updated ASC, id ASC",
         )
@@ -132,22 +328,25 @@ fn read_parts_for_messages_with_limit(
         })?;
 
     let rows = stmt
-        .query_map(rusqlite::params![session_id, after_updated, limit], |row| {
-            let id: String = row.get(0)?;
-            let message_id: String = row.get(1)?;
-            let row_session_id: String = row.get(2)?;
-            let time_created: i64 = row.get(3)?;
-            let time_updated: i64 = row.get(4)?;
-            let data: String = row.get(5)?;
-            Ok((
-                id,
-                message_id,
-                row_session_id,
-                time_created,
-                time_updated,
-                data,
-            ))
-        })
+        .query_map(
+            rusqlite::params![session_id, after_updated, up_to_updated, limit],
+            |row| {
+                let id: String = row.get(0)?;
+                let message_id: String = row.get(1)?;
+                let row_session_id: String = row.get(2)?;
+                let time_created: i64 = row.get(3)?;
+                let time_updated: i64 = row.get(4)?;
+                let data: String = row.get(5)?;
+                Ok((
+                    id,
+                    message_id,
+                    row_session_id,
+                    time_created,
+                    time_updated,
+                    data,
+                ))
+            },
+        )
         .map_err(|e| StreamError::Fatal {
             message: format!("Failed to query parts: {}", e),
         })?;
@@ -215,74 +414,14 @@ impl Agent for OpenCodeAgent {
         watermark: Box<dyn WatermarkStrategy>,
         session_id: &str,
     ) -> Result<StreamBatch, StreamError> {
-        // Downcast to TimestampWatermark
-        let ts_watermark = watermark
-            .as_any()
-            .downcast_ref::<TimestampWatermark>()
-            .ok_or_else(|| StreamError::Fatal {
-                message: format!(
-                    "OpenCode reader requires TimestampWatermark, got incompatible type for session {}",
-                    session_id
-                ),
-            })?;
-
-        let watermark_millis = ts_watermark.0.timestamp_millis();
-
-        // Open SQLite read-only
-        let conn = open_sqlite_readonly(path)?;
-
-        // LIMIT applied for memory safety. Uses strict > to avoid re-reading.
-        // Note: messages sharing exact same millisecond as watermark boundary could
-        // theoretically be skipped, but OpenCode writes are interactive (not concurrent)
-        // so millisecond collisions are effectively impossible in practice.
-        let messages = read_session_messages_raw_with_limit(
-            &conn,
+        let config = crate::config::Config::get();
+        self.read_incremental_bounded(
+            path,
+            watermark,
             session_id,
-            watermark_millis,
-            self.batch_size,
-        )?;
-
-        if messages.is_empty() {
-            return Ok(StreamBatch {
-                events: Vec::new(),
-                new_watermark: Box::new(TimestampWatermark::new(ts_watermark.0)),
-            });
-        }
-
-        // Read only parts for the matched messages (IN-subquery, single scan)
-        let mut parts_by_message = read_parts_for_messages_with_limit(
-            &conn,
-            session_id,
-            watermark_millis,
-            self.batch_size,
-        )?;
-
-        let mut max_updated: i64 = watermark_millis;
-        let mut events = Vec::with_capacity(messages.len());
-
-        for (msg_id, time_updated, msg_data) in messages {
-            if time_updated > max_updated {
-                max_updated = time_updated;
-            }
-
-            // Use .remove() to move parts out of the HashMap instead of cloning via .get()
-            let mut map = serde_json::Map::with_capacity(2);
-            map.insert("message".into(), msg_data);
-            if let Some(parts) = parts_by_message.remove(&msg_id) {
-                map.insert("parts".into(), serde_json::Value::Array(parts));
-            }
-
-            events.push(serde_json::Value::Object(map));
-        }
-
-        let new_watermark_ts =
-            DateTime::from_timestamp_millis(max_updated).unwrap_or(ts_watermark.0);
-        let new_watermark = Box::new(TimestampWatermark::new(new_watermark_ts));
-
-        Ok(StreamBatch {
-            events,
-            new_watermark,
-        })
+            config.max_transcript_batch_bytes() as u64,
+            config.max_transcript_line_bytes(),
+        )
     }
 
     fn extract_event_ids(
@@ -344,6 +483,78 @@ impl Agent for OpenCodeAgent {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_batch_truncates_at_byte_budget_on_timestamp_boundaries_and_resumes() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("opencode.db");
+        // Four messages of ~55 bytes each (message data + part data).
+        create_test_db(&db_path, 4);
+
+        let agent = OpenCodeAgent::new();
+        // A 120-byte batch budget fits two message groups; per-row budget
+        // stays permissive.
+        let batch = agent
+            .read_incremental_bounded(
+                &db_path,
+                Box::new(TimestampWatermark::new(
+                    chrono::DateTime::<chrono::Utc>::UNIX_EPOCH,
+                )),
+                "test-session",
+                120,
+                4096,
+            )
+            .unwrap();
+        assert_eq!(batch.events.len(), 2);
+
+        // The timestamp watermark resumes exactly after the last included row.
+        let batch = agent
+            .read_incremental_bounded(&db_path, batch.new_watermark, "test-session", 120, 4096)
+            .unwrap();
+        assert_eq!(batch.events.len(), 2);
+        assert_eq!(batch.events[0]["message"]["id"], "msg-2");
+    }
+
+    #[test]
+    fn test_oversized_message_is_skipped_with_watermark_advanced() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("opencode.db");
+        create_test_db(&db_path, 0);
+        let conn = crate::sqlite::open_with_memory_limits(&db_path).unwrap();
+        conn.execute(
+            "INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES ('giant', 'test-session', 1000, 1000, ?1)",
+            rusqlite::params![format!(r#"{{"role":"user","pad":"{}"}}"#, "x".repeat(2000))],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES ('normal', 'test-session', 2000, 2000, '{\"role\":\"user\",\"id\":1}')",
+            [],
+        )
+        .unwrap();
+        drop(conn);
+
+        let agent = OpenCodeAgent::new();
+        // The giant row exceeds the 1024-byte per-row budget: skipped, with
+        // the watermark advanced past its timestamp so it is never re-read.
+        let batch = agent
+            .read_incremental_bounded(
+                &db_path,
+                Box::new(TimestampWatermark::new(
+                    chrono::DateTime::<chrono::Utc>::UNIX_EPOCH,
+                )),
+                "test-session",
+                4096,
+                1024,
+            )
+            .unwrap();
+        assert!(batch.events.is_empty());
+
+        let batch = agent
+            .read_incremental_bounded(&db_path, batch.new_watermark, "test-session", 4096, 1024)
+            .unwrap();
+        assert_eq!(batch.events.len(), 1);
+        assert_eq!(batch.events[0]["message"]["id"], "normal");
+    }
 
     #[test]
     fn test_sweep_strategy() {
@@ -591,7 +802,9 @@ mod tests {
             .join("tests/fixtures/opencode-sqlite/opencode.db");
         let conn = open_sqlite_readonly(&db_path).unwrap();
         // watermark=0 matches all messages in the fixture
-        let parts = read_parts_for_messages_with_limit(&conn, "test-session-123", 0, 1000).unwrap();
+        let parts =
+            read_parts_for_messages_with_limit(&conn, "test-session-123", 0, i64::MAX, 1000)
+                .unwrap();
         // Verify IN-subquery loading returns parts grouped by message_id.
         // Single query with IN-subquery instead of one per message,
         // prevents full-table-scan memory blowup on large unindexed databases.

--- a/src/streams/agents/opencode.rs
+++ b/src/streams/agents/opencode.rs
@@ -55,46 +55,62 @@ impl OpenCodeAgent {
         // could theoretically be skipped, but OpenCode writes are interactive
         // (not concurrent) so millisecond collisions are effectively
         // impossible in practice.
-        let through_millis = match plan_message_batch(
-            &conn,
-            session_id,
-            watermark_millis,
-            self.batch_size,
-            max_batch_bytes,
-            max_row_bytes,
-        )? {
-            BatchPlan::Empty => {
-                return Ok(StreamBatch {
-                    events: Vec::new(),
-                    new_watermark: Box::new(TimestampWatermark::new(ts_watermark.0)),
-                });
+        //
+        // Oversized rows are skipped by advancing the effective watermark
+        // past them and re-planning WITHIN this poll: returning early on a
+        // skip would let the caller treat the poll as complete and stamp the
+        // file's size/mtime, stranding the history behind the giant row
+        // until the database next changes.
+        let mut effective_after = watermark_millis;
+        let through_millis = loop {
+            match plan_message_batch(
+                &conn,
+                session_id,
+                effective_after,
+                self.batch_size,
+                max_batch_bytes,
+                max_row_bytes,
+            )? {
+                BatchPlan::Empty => {
+                    // A true no-op poll must return the original watermark
+                    // object: reconstructing it from truncated milliseconds
+                    // would serialize differently and defeat the caller's
+                    // no-op-poll detection.
+                    let new_watermark: Box<dyn WatermarkStrategy> =
+                        if effective_after == watermark_millis {
+                            Box::new(TimestampWatermark::new(ts_watermark.0))
+                        } else {
+                            let skipped_ts = DateTime::from_timestamp_millis(effective_after)
+                                .unwrap_or(ts_watermark.0);
+                            Box::new(TimestampWatermark::new(skipped_ts))
+                        };
+                    return Ok(StreamBatch {
+                        events: Vec::new(),
+                        new_watermark,
+                    });
+                }
+                BatchPlan::SkipOversized {
+                    through_millis,
+                    bytes,
+                } => {
+                    tracing::warn!(
+                        path = %path.display(),
+                        session_id,
+                        time_updated = through_millis,
+                        row_bytes = bytes,
+                        max_bytes = max_row_bytes,
+                        "skipping oversized OpenCode message; advancing watermark past it"
+                    );
+                    effective_after = through_millis;
+                }
+                BatchPlan::ReadThrough { through_millis } => break through_millis,
             }
-            BatchPlan::SkipOversized {
-                through_millis,
-                bytes,
-            } => {
-                tracing::warn!(
-                    path = %path.display(),
-                    session_id,
-                    time_updated = through_millis,
-                    row_bytes = bytes,
-                    max_bytes = max_row_bytes,
-                    "skipping oversized OpenCode message; advancing watermark past it"
-                );
-                let skipped_ts =
-                    DateTime::from_timestamp_millis(through_millis).unwrap_or(ts_watermark.0);
-                return Ok(StreamBatch {
-                    events: Vec::new(),
-                    new_watermark: Box::new(TimestampWatermark::new(skipped_ts)),
-                });
-            }
-            BatchPlan::ReadThrough { through_millis } => through_millis,
         };
 
         let messages = read_session_messages_raw_with_limit(
             &conn,
             session_id,
-            watermark_millis,
+            effective_after,
             through_millis,
             self.batch_size,
         )?;
@@ -103,12 +119,12 @@ impl OpenCodeAgent {
         let mut parts_by_message = read_parts_for_messages_with_limit(
             &conn,
             session_id,
-            watermark_millis,
+            effective_after,
             through_millis,
             self.batch_size,
         )?;
 
-        let mut max_updated: i64 = watermark_millis;
+        let mut max_updated: i64 = effective_after;
         let mut events = Vec::with_capacity(messages.len());
 
         for (msg_id, time_updated, msg_data) in messages {
@@ -534,8 +550,10 @@ mod tests {
         drop(conn);
 
         let agent = OpenCodeAgent::new();
-        // The giant row exceeds the 1024-byte per-row budget: skipped, with
-        // the watermark advanced past its timestamp so it is never re-read.
+        // The giant row exceeds the 1024-byte per-row budget: skipped with
+        // the watermark advanced past its timestamp, and the SAME poll
+        // continues to the rows behind it — an early return would strand
+        // them until the database next changes.
         let batch = agent
             .read_incremental_bounded(
                 &db_path,
@@ -547,13 +565,13 @@ mod tests {
                 1024,
             )
             .unwrap();
-        assert!(batch.events.is_empty());
+        assert_eq!(batch.events.len(), 1);
+        assert_eq!(batch.events[0]["message"]["id"], "normal");
 
         let batch = agent
             .read_incremental_bounded(&db_path, batch.new_watermark, "test-session", 4096, 1024)
             .unwrap();
-        assert_eq!(batch.events.len(), 1);
-        assert_eq!(batch.events[0]["message"]["id"], "normal");
+        assert!(batch.events.is_empty(), "the giant row is never re-read");
     }
 
     #[test]

--- a/src/streams/types.rs
+++ b/src/streams/types.rs
@@ -149,6 +149,44 @@ fn read_leading_jsonl_lines_with(
     lines
 }
 
+/// Gate for readers that must parse a whole file in one piece (JSON
+/// thread/session files with record-index watermarks — there is no byte
+/// offset to seek to, so the per-line and backfill caps cannot apply).
+/// Returns true, logging an error, when the file exceeds
+/// `Config::max_transcript_file_bytes()`: the caller should return an empty
+/// batch with its watermark unchanged. Nothing is falsely marked processed,
+/// and the sweep's size/mtime stamp stops re-enqueueing the stream until the
+/// file changes, so the error log stays bounded; raising the budget resumes
+/// ingestion naturally.
+pub fn skip_whole_file_over_budget(path: &std::path::Path, agent: &str, session_id: &str) -> bool {
+    let max_bytes = crate::config::Config::get().max_transcript_file_bytes();
+    skip_whole_file_over_budget_with(path, agent, session_id, max_bytes)
+}
+
+fn skip_whole_file_over_budget_with(
+    path: &std::path::Path,
+    agent: &str,
+    session_id: &str,
+    max_bytes: u64,
+) -> bool {
+    let Ok(meta) = std::fs::metadata(path) else {
+        return false;
+    };
+    if meta.len() <= max_bytes {
+        return false;
+    }
+    tracing::error!(
+        path = %path.display(),
+        size_bytes = meta.len(),
+        max_bytes,
+        agent,
+        session_id,
+        "transcript exceeds the whole-file ingest budget; skipping \
+         (raise max_transcript_file_bytes to ingest it)"
+    );
+    true
+}
+
 /// Errors that can occur during transcript processing.
 #[derive(Debug, Clone)]
 pub enum StreamError {
@@ -407,6 +445,34 @@ mod tests {
             JsonlLineState::Complete(_) => assert_eq!(line.trim_end(), "{\"ok\":1}"),
             other => panic!("expected the next line to parse normally, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn test_skip_whole_file_over_budget_gates_on_size() {
+        use std::io::Write;
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        write!(file, "{}", "x".repeat(100)).unwrap();
+        file.flush().unwrap();
+
+        assert!(!skip_whole_file_over_budget_with(
+            file.path(),
+            "Test",
+            "s",
+            100
+        ));
+        assert!(skip_whole_file_over_budget_with(
+            file.path(),
+            "Test",
+            "s",
+            99
+        ));
+        // Missing files are not the gate's concern; the reader reports those.
+        assert!(!skip_whole_file_over_budget_with(
+            std::path::Path::new("/nonexistent/thread.json"),
+            "Test",
+            "s",
+            1
+        ));
     }
 
     #[test]


### PR DESCRIPTION
The remaining ingestion paths the per-line caps could not reach (#2244):

- Whole-file JSON readers (amp, continue, copilot session json) parse the
  entire file with serde_json::from_reader on every poll — RecordIndex
  watermarks have no byte offset to seek to. Gate them on file size: over
  max_transcript_file_bytes, log an error (path, size, agent, session id)
  and return an empty batch with the watermark unchanged. Nothing is
  falsely marked processed; the sweep's size/mtime stamp stops
  re-enqueueing until the file changes, and raising the budget resumes
  ingestion naturally.

- SQLite readers (opencode, copilot otel) batched by row count only, with
  unbounded data/parts/attribute TEXT columns. Plan each poll from SQL
  LENGTH sums before materializing anything: truncate the batch at
  max_transcript_batch_bytes (opencode only at distinct-timestamp
  boundaries — the timestamp watermark's strict > would skip tied rows;
  otel exactly, via the keyset cursor), and skip a single row whose
  payload alone exceeds max_transcript_line_bytes with the cursor
  advanced past it.

- The pending-metrics flush loop dequeued 1000 rows and inflated them all
  into MetricEvent trees at once; since undelivered rows survive
  restarts, this re-created the memory balloon on every respawn. Split
  each dequeue into max_metrics_flush_chunk_bytes sub-chunks of raw
  event_json per parse/upload; on failure the failed sub-chunk and all
  remaining dequeued rows are still marked so no row is stranded behind
  the 10-minute processing lock.

Flush sub-chunking ported from the #2251 review branch; the reader gates
and SQL byte-planning are new in this stack.

Co-Authored-By: Sandesh Devaraju <sandesh.devaraju@robinhood.com>
Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

## Stack

Part 4/4 of the fresh #2244 stack (stack #2264), which replaces #2245–#2251 at the layer level: config-driven byte budgets that every ingestion path inherits, instead of per-reader hardcoded caps. Ports the sound pieces of the original stack with credit.

1. #2260 — config: transcript ingestion byte budgets (env > file > default)
2. #2261 — streams: one shared bounded JSONL reader for all line-oriented agents
3. #2262 — daemon: break the transcript watermark abort loop
4. #2263 — streams/daemon: bound the whole-file, SQLite, and metrics-flush readers

## Verification

- Full suite at the stack head: 2,433 lib + 3,327 integration + 107 daemon_mode tests green. Two pre-existing failures (`conflict_resolution_note_read_errors…`, `test_load_ai_touched_files_for_specific_commits`) reproduce identically on clean `main` in this environment.
- Daemon-level capstone test (part 3) drives a real daemon with env-scaled budgets over a transcript containing a giant single-line event: the line is skipped, neighbors ingest, the watermark lands at EOF, and a restarted daemon never re-reads it.
- `task fmt` / `task lint` clean per part.

Fixes #2244 together with a small follow-up stack (socket line caps + ingest-loss accounting, watchdog current-RSS decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
