### PR TITLE
fix(streams): exclude Continue's sessions.json index file from transcript discovery

### DIFF
--- a/src/streams/agents/continue_cli.rs
+++ b/src/streams/agents/continue_cli.rs
@@ -31,17 +31,23 @@ impl ContinueAgent {
     fn scan_session_files() -> Vec<PathBuf> {
         let mut paths = Vec::new();
 
-        if let Some(home) = dirs::home_dir() {
-            let pattern = home
-                .join(".continue/sessions/**/*.json")
-                .to_string_lossy()
-                .to_string();
+        let pattern = crate::mdm::utils::home_dir()
+            .join(".continue/sessions/**/*.json")
+            .to_string_lossy()
+            .to_string();
 
-            if let Ok(entries) = glob::glob(&pattern) {
-                for entry in entries.flatten() {
-                    if entry.is_file() {
-                        paths.push(entry);
-                    }
+        if let Ok(entries) = glob::glob(&pattern) {
+            for entry in entries.flatten() {
+                // Skip Continue's own session index file (a JSON array listing
+                // sessions) -- it is not a transcript and has no "history".
+                if entry
+                    .file_name()
+                    .is_some_and(|name| name == "sessions.json")
+                {
+                    continue;
+                }
+                if entry.is_file() {
+                    paths.push(entry);
                 }
             }
         }
@@ -193,6 +199,83 @@ impl Agent for ContinueAgent {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
+
+    /// Temporarily override HOME (and USERPROFILE on Windows) to a temp directory
+    /// for the duration of the closure. Must only be called from `#[serial]` tests
+    /// to avoid racing with other tests that read HOME.
+    fn with_temp_home<F: FnOnce(&Path)>(f: F) {
+        /// Restores HOME/USERPROFILE on drop so a panicking test closure
+        /// cannot leave the environment poisoned for subsequent tests.
+        struct RestoreHomeGuard {
+            prev_home: Option<std::ffi::OsString>,
+            prev_userprofile: Option<std::ffi::OsString>,
+        }
+
+        impl Drop for RestoreHomeGuard {
+            fn drop(&mut self) {
+                // SAFETY: tests using this helper are serialized via #[serial],
+                // so restoring the process environment is safe.
+                unsafe {
+                    match self.prev_home.take() {
+                        Some(v) => std::env::set_var("HOME", v),
+                        None => std::env::remove_var("HOME"),
+                    }
+                    match self.prev_userprofile.take() {
+                        Some(v) => std::env::set_var("USERPROFILE", v),
+                        None => std::env::remove_var("USERPROFILE"),
+                    }
+                }
+            }
+        }
+
+        let temp = tempfile::tempdir().unwrap();
+        let home = temp.path().to_path_buf();
+
+        let _guard = RestoreHomeGuard {
+            prev_home: std::env::var_os("HOME"),
+            prev_userprofile: std::env::var_os("USERPROFILE"),
+        };
+
+        // SAFETY: tests using this helper are serialized via #[serial],
+        // so mutating the process environment is safe.
+        unsafe {
+            std::env::set_var("HOME", &home);
+            std::env::set_var("USERPROFILE", &home);
+        }
+
+        f(&home);
+    }
+
+    #[test]
+    #[serial]
+    fn test_discover_sessions_skips_sessions_index_file() {
+        with_temp_home(|home| {
+            let sessions_dir = home.join(".continue").join("sessions");
+            std::fs::create_dir_all(&sessions_dir).unwrap();
+
+            // Continue's own index file: a JSON array of session summaries.
+            // It is not a transcript and has no "history" array.
+            std::fs::write(
+                sessions_dir.join("sessions.json"),
+                r#"[{"sessionId":"1cf47bde-0f18-4934-8b23-43b0829f0b37","title":"Fix a bug","dateCreated":"2026-08-30T12:00:00.000Z","workspaceDirectory":"/tmp/project"}]"#,
+            )
+            .unwrap();
+
+            let transcript_path = sessions_dir.join("1cf47bde-0f18-4934-8b23-43b0829f0b37.json");
+            std::fs::write(&transcript_path, make_continue_json(2)).unwrap();
+
+            let agent = ContinueAgent::new();
+            let sessions = agent.discover_sessions().unwrap();
+
+            let external_ids: Vec<&str> = sessions
+                .iter()
+                .map(|s| s.external_session_id.as_str())
+                .collect();
+            assert_eq!(external_ids, vec!["1cf47bde-0f18-4934-8b23-43b0829f0b37"]);
+            assert_eq!(sessions[0].stream_path, transcript_path);
+        });
+    }
 
     #[test]
     fn test_sweep_strategy() {


### PR DESCRIPTION
## Bug

The Continue agent discovers session transcripts with the glob `~/.continue/sessions/**/*.json`. That glob also matches `~/.continue/sessions/sessions.json` — Continue's own index file, which is a JSON array listing sessions, not a transcript, and has no `history` array.

Every time the index file changed, the stream worker hit a fatal error (`Missing 'history' array in Continue transcript: .../sessions.json`) and skipped the "session". Worse, the stream session id is derived from the file stem (`"sessions"`), so every affected user produced the exact same session id — a deterministic cross-user session-id collision.

## Fix

- Skip files named `sessions.json` in `ContinueAgent::scan_session_files`, so the index is never discovered or ingested. Sweep tasks originate solely from `discover_sessions()`, so this also stops re-enqueuing of previously tracked index files.
- Resolve the home directory via the shared env-respecting `mdm::utils::home_dir()` helper (already used by the codex agent) instead of `dirs::home_dir()`, which ignores `HOME`/`USERPROFILE` on Windows. This keeps home resolution consistent across agents and makes discovery testable with a HOME override on all platforms.

## Testing

TDD: added `test_discover_sessions_skips_sessions_index_file`, which builds a fake `~/.continue/sessions` dir containing a realistic `sessions.json` index (JSON array of `{"sessionId", "title", ...}` objects) plus a sibling `<uuid>.json` transcript, and asserts only the transcript is discovered. The test failed before the fix (both files were discovered, including the bogus `"sessions"` session) and passes after. Uses the existing `#[serial]` + temp-HOME pattern, with a drop guard so a panicking closure cannot leave the environment poisoned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/2265" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->