### PR TITLE
fix(streams): tolerate invalid UTF-8 in agent transcripts

### DIFF
--- a/src/streams/agents/claude.rs
+++ b/src/streams/agents/claude.rs
@@ -382,6 +382,52 @@ mod tests {
     }
 
     #[test]
+    fn test_read_incremental_tolerates_invalid_utf8_lines() {
+        use std::io::Write;
+        use tempfile::NamedTempFile;
+
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(b"{\"type\":\"user\",\"message\":{\"content\":\"Hello\"}}\n")
+            .unwrap();
+        // Invalid UTF-8 lines must not fail the session. This one is also
+        // structurally broken JSON, so it is skipped as malformed.
+        file.write_all(b"{\"type\":\"user\",\"message\":{\"content\":\"\xff\xfe garbage\n")
+            .unwrap();
+        // Invalid UTF-8 inside structurally valid JSON is ingested with the
+        // bad bytes replaced by U+FFFD.
+        file.write_all(b"{\"type\":\"user\",\"message\":{\"content\":\"caf\xff\"}}\n")
+            .unwrap();
+        file.write_all(b"{\"type\":\"user\",\"message\":{\"content\":\"After\"}}\n")
+            .unwrap();
+        file.flush().unwrap();
+        let total_len = std::fs::metadata(file.path()).unwrap().len();
+
+        let agent = ClaudeAgent::new();
+        let watermark = Box::new(ByteOffsetWatermark::new(0));
+        let result = agent
+            .read_incremental(file.path(), watermark, "test-session")
+            .unwrap();
+
+        assert_eq!(result.events.len(), 3);
+        assert_eq!(
+            result.events[1]["message"]["content"].as_str(),
+            Some("caf\u{FFFD}")
+        );
+        assert_eq!(
+            result.events[2]["message"]["content"].as_str(),
+            Some("After")
+        );
+        // Watermark must advance past every line by raw byte count, not the
+        // (longer) lossily-decoded lengths.
+        let wm = result
+            .new_watermark
+            .as_any()
+            .downcast_ref::<ByteOffsetWatermark>()
+            .unwrap();
+        assert_eq!(wm.0, total_len);
+    }
+
+    #[test]
     fn test_scan_discovers_real_claude_files() {
         let paths = ClaudeAgent::scan_conversation_files();
         // On this machine we have files in ~/.claude/projects/

--- a/src/streams/types.rs
+++ b/src/streams/types.rs
@@ -16,17 +16,26 @@ pub enum JsonlLineState {
 /// Read a line from a BufReader, detecting partial writes from concurrent writers.
 ///
 /// Returns `Eof` if no more data, `Partial` if the line lacks a trailing newline,
-/// or `Complete(bytes)` on success.
+/// or `Complete(bytes)` on success, where `bytes` is the raw byte count read
+/// (including the newline). Invalid UTF-8 never fails the read: invalid bytes
+/// are replaced with U+FFFD, so a corrupt line either fails JSON parsing (and
+/// is skipped by callers) or parses with replacement characters.
 pub fn read_jsonl_line(
     reader: &mut impl BufRead,
     line: &mut String,
 ) -> std::io::Result<JsonlLineState> {
-    line.clear();
-    let bytes_read = reader.read_line(line)?;
+    // Reuse the caller's String allocation as the byte buffer so the per-line
+    // read loop stays allocation-free for valid UTF-8 (the common case).
+    let mut buf = std::mem::take(line).into_bytes();
+    buf.clear();
+    let bytes_read = reader.read_until(b'\n', &mut buf)?;
+    let complete = buf.ends_with(b"\n");
+    *line = String::from_utf8(buf)
+        .unwrap_or_else(|e| String::from_utf8_lossy(e.as_bytes()).into_owned());
     if bytes_read == 0 {
         return Ok(JsonlLineState::Eof);
     }
-    if !line.ends_with('\n') {
+    if !complete {
         return Ok(JsonlLineState::Partial);
     }
     Ok(JsonlLineState::Complete(bytes_read))
@@ -186,6 +195,54 @@ mod tests {
     #[test]
     fn test_read_jsonl_line_complete_then_partial() {
         let data = b"{\"a\":1}\n{\"b\":2}";
+        let mut reader = std::io::BufReader::new(&data[..]);
+        let mut line = String::new();
+
+        let r1 = read_jsonl_line(&mut reader, &mut line).unwrap();
+        assert!(matches!(r1, JsonlLineState::Complete(8)));
+
+        let r2 = read_jsonl_line(&mut reader, &mut line).unwrap();
+        assert!(matches!(r2, JsonlLineState::Partial));
+    }
+
+    #[test]
+    fn test_read_jsonl_line_invalid_utf8_line_advances() {
+        // Middle line contains invalid UTF-8 bytes; reading must not error,
+        // must advance past it, and the following valid line must still parse.
+        let mut data = Vec::new();
+        data.extend_from_slice(b"{\"a\":1}\n");
+        data.extend_from_slice(b"{\"bad\":\"\xff\xfe\"}\n");
+        data.extend_from_slice(b"{\"c\":3}\n");
+        let mut reader = std::io::BufReader::new(&data[..]);
+        let mut line = String::new();
+
+        let r1 = read_jsonl_line(&mut reader, &mut line).unwrap();
+        assert!(matches!(r1, JsonlLineState::Complete(8)));
+        assert_eq!(line, "{\"a\":1}\n");
+
+        // Byte count must be the raw byte count (13), not the length of the
+        // lossily-decoded string (replacement chars are 3 bytes each).
+        let r2 = read_jsonl_line(&mut reader, &mut line).unwrap();
+        assert!(matches!(r2, JsonlLineState::Complete(13)));
+        // Invalid bytes decode to U+FFFD. Note the result here is still valid
+        // JSON, so callers ingest such a line rather than skip it.
+        assert_eq!(line, "{\"bad\":\"\u{FFFD}\u{FFFD}\"}\n");
+
+        let r3 = read_jsonl_line(&mut reader, &mut line).unwrap();
+        assert!(matches!(r3, JsonlLineState::Complete(8)));
+        let parsed: serde_json::Value = serde_json::from_str(&line).unwrap();
+        assert_eq!(parsed["c"].as_i64(), Some(3));
+
+        let r4 = read_jsonl_line(&mut reader, &mut line).unwrap();
+        assert!(matches!(r4, JsonlLineState::Eof));
+    }
+
+    #[test]
+    fn test_read_jsonl_line_partial_mid_multibyte() {
+        // File ends mid-write, in the middle of a multi-byte UTF-8 sequence
+        // ("€" is \xe2\x82\xac; only the first two bytes are present). This
+        // must be reported as Partial, not an error.
+        let data = b"{\"a\":1}\n{\"x\":\"\xe2\x82";
         let mut reader = std::io::BufReader::new(&data[..]);
         let mut line = String::new();
 


### PR DESCRIPTION
## Bug

A single invalid UTF-8 byte in an agent transcript permanently blocks that session's ingestion. All agent transcript readers go through `read_jsonl_line`, which used `BufRead::read_line` — it hard-fails on any invalid UTF-8 byte. The error was classified `Transient`, retried to exhaustion by the stream worker, and because the byte-offset watermark sits right before the bad byte, every future processing attempt re-failed at exactly the same spot. One durable corrupt byte = that session never ingests again.

## Fix

Fix once in the shared JSONL reader so all agents benefit: read raw bytes with `read_until(b'\n')` and decode each line lossily (invalid bytes become U+FFFD). The `Eof`/`Partial`/`Complete(bytes)` contract is preserved exactly — `bytes` remains the raw byte count so watermarks stay correct, and a partial line ending mid-multibyte-UTF-8-sequence still reports `Partial` (in-progress writes keep working). Lines whose JSON breaks after lossy decoding flow through the existing per-line parse-error skip path instead of aborting the session.

## Tests

- Unit tests on `read_jsonl_line`: an invalid-UTF-8 line does not error, advances by raw byte count, and subsequent valid lines still parse; partial-line-at-EOF semantics unchanged, including mid-multibyte truncation.
- Agent-level test (`ClaudeAgent::read_incremental`): a transcript with a corrupt line still ingests surrounding events, skips the broken line, and the watermark advances past it by raw bytes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/2268" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->