### PR TITLE
fix(daemon): suppress repeated-identical error storms and expected repo-gone log noise

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -3715,11 +3715,46 @@ impl ActorDaemonCoordinator {
         Ok(())
     }
 
-    /// Records a side-effect error and logs it at a level decided by
+    /// Records a side-effect error and returns how it should be logged per
     /// `error_log_policy`: expected repo-gone conditions and repeated
     /// identical failures are downgraded to debug (with a rate-limited warn
     /// summary) so a persistently broken git environment cannot flood the
     /// logs with one error per traced command.
+    fn record_side_effect_error_and_decide(
+        &self,
+        family: &str,
+        record_seq: u64,
+        error: &GitAiError,
+    ) -> crate::daemon::error_log_policy::SideEffectErrorLog {
+        use crate::daemon::error_log_policy::{SideEffectErrorLog, is_expected_missing_repo_error};
+
+        let _ = self.record_side_effect_error(family, record_seq, error);
+        // Stat the family root before taking the tracker lock so a slow
+        // filesystem cannot stall other families' error logging. Only a
+        // definitive NotFound counts as gone: EACCES/EIO and similar keep the
+        // error loud rather than misclassifying it as an expected deletion.
+        let family_root_exists = !matches!(
+            std::fs::metadata(family),
+            Err(ref io_error) if io_error.kind() == std::io::ErrorKind::NotFound
+        );
+        if is_expected_missing_repo_error(error, family_root_exists) {
+            // Short-circuit without touching the tracker map: deleted temp
+            // repos are the high-cardinality case and must not leave entries.
+            return SideEffectErrorLog::ExpectedRepoGoneDebug;
+        }
+        self.side_effect_error_log_trackers
+            .lock()
+            .map(|mut trackers| {
+                trackers
+                    .entry(family.to_string())
+                    .or_default()
+                    .on_error(error, std::time::Instant::now())
+            })
+            .unwrap_or(SideEffectErrorLog::Error)
+    }
+
+    /// Records a side-effect error and logs it at the level decided by
+    /// [`Self::record_side_effect_error_and_decide`].
     ///
     /// `record_seq` keys the recorded error (the drain/completion keyspace);
     /// `log_seq` is the sequence reported in the log line, which some call
@@ -3732,32 +3767,9 @@ impl ActorDaemonCoordinator {
         error: &GitAiError,
         context: &'static str,
     ) {
-        use crate::daemon::error_log_policy::{SideEffectErrorLog, is_expected_missing_repo_error};
+        use crate::daemon::error_log_policy::SideEffectErrorLog;
 
-        let _ = self.record_side_effect_error(family, record_seq, error);
-        // Stat the family root before taking the tracker lock so a slow
-        // filesystem cannot stall other families' error logging. Only a
-        // definitive NotFound counts as gone: EACCES/EIO and similar keep the
-        // error loud rather than misclassifying it as an expected deletion.
-        let family_root_exists = !matches!(
-            std::fs::metadata(family),
-            Err(ref io_error) if io_error.kind() == std::io::ErrorKind::NotFound
-        );
-        let decision = if is_expected_missing_repo_error(error, family_root_exists) {
-            // Short-circuit without touching the tracker map: deleted temp
-            // repos are the high-cardinality case and must not leave entries.
-            SideEffectErrorLog::ExpectedRepoGoneDebug
-        } else {
-            self.side_effect_error_log_trackers
-                .lock()
-                .map(|mut trackers| {
-                    trackers
-                        .entry(family.to_string())
-                        .or_default()
-                        .on_error(error, std::time::Instant::now())
-                })
-                .unwrap_or(SideEffectErrorLog::Error)
-        };
+        let decision = self.record_side_effect_error_and_decide(family, record_seq, error);
         match decision {
             SideEffectErrorLog::Error => {
                 tracing::error!(%error, %family, seq = log_seq, "{context}")
@@ -3777,6 +3789,72 @@ impl ActorDaemonCoordinator {
                     "{context} (repeated identical error; earlier occurrences downgraded to debug)"
                 )
             }
+        }
+    }
+
+    /// Checkpoint variant of [`Self::record_and_log_side_effect_error`] that
+    /// preserves the checkpoint log sites' structured fields (reason,
+    /// receipt_seq, trace_id).
+    #[allow(clippy::too_many_arguments)]
+    fn record_and_log_checkpoint_side_effect_error(
+        &self,
+        family: &str,
+        order: u64,
+        receipt_seq: u64,
+        trace_id: &str,
+        reason: &'static str,
+        error: &GitAiError,
+        context: &'static str,
+    ) {
+        use crate::daemon::error_log_policy::SideEffectErrorLog;
+
+        let decision = self.record_side_effect_error_and_decide(family, order, error);
+        match decision {
+            SideEffectErrorLog::Error => tracing::error!(
+                component = "daemon",
+                phase = "checkpoint_processing",
+                reason,
+                receipt_seq,
+                trace_id = %trace_id,
+                %error,
+                %family,
+                order,
+                "{context}"
+            ),
+            SideEffectErrorLog::ExpectedRepoGoneDebug => tracing::debug!(
+                component = "daemon",
+                phase = "checkpoint_processing",
+                reason,
+                receipt_seq,
+                trace_id = %trace_id,
+                %error,
+                %family,
+                order,
+                "{context} (repo removed before processing)"
+            ),
+            SideEffectErrorLog::RepeatedDebug => tracing::debug!(
+                component = "daemon",
+                phase = "checkpoint_processing",
+                reason,
+                receipt_seq,
+                trace_id = %trace_id,
+                %error,
+                %family,
+                order,
+                "{context} (repeated identical error)"
+            ),
+            SideEffectErrorLog::RepeatedSummaryWarn { suppressed_count } => tracing::warn!(
+                component = "daemon",
+                phase = "checkpoint_processing",
+                reason,
+                receipt_seq,
+                trace_id = %trace_id,
+                %error,
+                %family,
+                order,
+                suppressed_count,
+                "{context} (repeated identical error; earlier occurrences downgraded to debug)"
+            ),
         }
     }
 
@@ -5214,7 +5292,10 @@ impl ActorDaemonCoordinator {
                             "checkpoint done"
                         );
                     } else {
-                        tracing::warn!(
+                        // Status line only: the failure itself is logged below
+                        // via the error-log policy, which keeps genuine errors
+                        // loud without letting repeated failures storm.
+                        tracing::debug!(
                             kind = %checkpoint_kind_str,
                             repo = %repo_wd,
                             duration_ms = checkpoint_duration_ms as u64,
@@ -5259,10 +5340,12 @@ impl ActorDaemonCoordinator {
                                 .await
                         {
                             watermark_update_failed = true;
-                            self.record_and_log_side_effect_error(
+                            self.record_and_log_checkpoint_side_effect_error(
                                 family,
                                 order,
-                                order,
+                                receipt_seq,
+                                &checkpoint_trace_id,
+                                "watermark_update_failed",
                                 &error,
                                 "checkpoint watermark update failed",
                             );
@@ -5272,10 +5355,12 @@ impl ActorDaemonCoordinator {
                     match &result {
                         Ok(_) if !watermark_update_failed => self.note_side_effect_success(family),
                         Ok(_) => {}
-                        Err(error) => self.record_and_log_side_effect_error(
+                        Err(error) => self.record_and_log_checkpoint_side_effect_error(
                             family,
                             order,
-                            order,
+                            receipt_seq,
+                            &checkpoint_trace_id,
+                            "side_effect_failed",
                             error,
                             "checkpoint side effect failed",
                         ),

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -60,6 +60,7 @@ pub mod control_api;
 pub mod coordinator;
 pub mod daemon_log_layer;
 pub mod domain;
+pub(crate) mod error_log_policy;
 pub mod family_actor;
 pub mod git_backend;
 pub mod global_actor;
@@ -2767,6 +2768,8 @@ pub struct ActorDaemonCoordinator {
     recent_replay_prerequisites_by_family:
         Mutex<HashMap<String, VecDeque<RecentReplayPrerequisite>>>,
     side_effect_errors_by_family: Mutex<HashMap<String, BTreeMap<u64, String>>>,
+    side_effect_error_log_trackers:
+        Mutex<HashMap<String, crate::daemon::error_log_policy::RepeatedErrorTracker>>,
     side_effect_exec_locks: Mutex<HashMap<String, Arc<AsyncMutex<()>>>>,
     checkpoint_side_effect_semaphore: Semaphore,
     checkpoint_ingress_quota: Arc<CheckpointIngressQuota>,
@@ -2891,6 +2894,7 @@ impl ActorDaemonCoordinator {
             commit_file_timestamp_snapshots_by_root: Mutex::new(HashMap::new()),
             recent_replay_prerequisites_by_family: Mutex::new(HashMap::new()),
             side_effect_errors_by_family: Mutex::new(HashMap::new()),
+            side_effect_error_log_trackers: Mutex::new(HashMap::new()),
             side_effect_exec_locks: Mutex::new(HashMap::new()),
             checkpoint_side_effect_semaphore: Semaphore::new(CHECKPOINT_FAMILY_DRAIN_CONCURRENCY),
             checkpoint_ingress_quota: Arc::new(CheckpointIngressQuota::new(
@@ -3322,6 +3326,13 @@ impl ActorDaemonCoordinator {
         if let Ok(mut map) = self.side_effect_errors_by_family.lock() {
             map.retain(|_, errors| !errors.is_empty());
         }
+        if let Ok(mut map) = self.side_effect_error_log_trackers.lock() {
+            // Drop trackers idle past the eviction window (e.g. for deleted
+            // repos that will never re-arm). Recently active trackers are kept
+            // so repeated-error suppression stays continuous across GC passes.
+            let now = std::time::Instant::now();
+            map.retain(|_, tracker| !tracker.is_stale(now));
+        }
         if let Ok(mut map) = self.family_sequencers_by_family.lock() {
             map.retain(|_, state| !state.entries.is_empty());
         }
@@ -3702,6 +3713,80 @@ impl ActorDaemonCoordinator {
             }
         }
         Ok(())
+    }
+
+    /// Records a side-effect error and logs it at a level decided by
+    /// `error_log_policy`: expected repo-gone conditions and repeated
+    /// identical failures are downgraded to debug (with a rate-limited warn
+    /// summary) so a persistently broken git environment cannot flood the
+    /// logs with one error per traced command.
+    ///
+    /// `record_seq` keys the recorded error (the drain/completion keyspace);
+    /// `log_seq` is the sequence reported in the log line, which some call
+    /// sites take from the applied command instead.
+    fn record_and_log_side_effect_error(
+        &self,
+        family: &str,
+        record_seq: u64,
+        log_seq: u64,
+        error: &GitAiError,
+        context: &'static str,
+    ) {
+        use crate::daemon::error_log_policy::{SideEffectErrorLog, is_expected_missing_repo_error};
+
+        let _ = self.record_side_effect_error(family, record_seq, error);
+        // Stat the family root before taking the tracker lock so a slow
+        // filesystem cannot stall other families' error logging. Only a
+        // definitive NotFound counts as gone: EACCES/EIO and similar keep the
+        // error loud rather than misclassifying it as an expected deletion.
+        let family_root_exists = !matches!(
+            std::fs::metadata(family),
+            Err(ref io_error) if io_error.kind() == std::io::ErrorKind::NotFound
+        );
+        let decision = if is_expected_missing_repo_error(error, family_root_exists) {
+            // Short-circuit without touching the tracker map: deleted temp
+            // repos are the high-cardinality case and must not leave entries.
+            SideEffectErrorLog::ExpectedRepoGoneDebug
+        } else {
+            self.side_effect_error_log_trackers
+                .lock()
+                .map(|mut trackers| {
+                    trackers
+                        .entry(family.to_string())
+                        .or_default()
+                        .on_error(error, std::time::Instant::now())
+                })
+                .unwrap_or(SideEffectErrorLog::Error)
+        };
+        match decision {
+            SideEffectErrorLog::Error => {
+                tracing::error!(%error, %family, seq = log_seq, "{context}")
+            }
+            SideEffectErrorLog::ExpectedRepoGoneDebug => {
+                tracing::debug!(%error, %family, seq = log_seq, "{context} (repo removed before processing)")
+            }
+            SideEffectErrorLog::RepeatedDebug => {
+                tracing::debug!(%error, %family, seq = log_seq, "{context} (repeated identical error)")
+            }
+            SideEffectErrorLog::RepeatedSummaryWarn { suppressed_count } => {
+                tracing::warn!(
+                    %error,
+                    %family,
+                    seq = log_seq,
+                    suppressed_count,
+                    "{context} (repeated identical error; earlier occurrences downgraded to debug)"
+                )
+            }
+        }
+    }
+
+    /// Re-arms error-level logging for the family after a successful
+    /// side-effect pass. Removes the tracker entry entirely so retired
+    /// families do not accumulate in the map.
+    fn note_side_effect_success(&self, family: &str) {
+        if let Ok(mut trackers) = self.side_effect_error_log_trackers.lock() {
+            trackers.remove(family);
+        }
     }
 
     fn latest_side_effect_error(&self, family: &str) -> Result<Option<String>, GitAiError> {
@@ -4097,15 +4182,30 @@ impl ActorDaemonCoordinator {
                         match futures::FutureExt::catch_unwind(caught).await {
                             Ok(Ok(())) => Ok(()),
                             Ok(Err(error)) => {
-                                tracing::error!(
-                                    component = "daemon",
-                                    phase = "trace_ingest_worker",
-                                    reason = "ingest_error",
-                                    sequence = processed_seq,
-                                    root_sid = ?ordered_payload_root,
-                                    %error,
-                                    "trace ingest error"
-                                );
+                                // Traced commands can run outside any repo or
+                                // in a temp repo deleted before async
+                                // processing; that is expected, not an error.
+                                if crate::daemon::error_log_policy::is_repo_discovery_miss_without_exec(&error) {
+                                    tracing::debug!(
+                                        component = "daemon",
+                                        phase = "trace_ingest_worker",
+                                        reason = "repo_gone_before_processing",
+                                        sequence = processed_seq,
+                                        root_sid = ?ordered_payload_root,
+                                        %error,
+                                        "trace ingest skipped: repo removed before processing"
+                                    );
+                                } else {
+                                    tracing::error!(
+                                        component = "daemon",
+                                        phase = "trace_ingest_worker",
+                                        reason = "ingest_error",
+                                        sequence = processed_seq,
+                                        root_sid = ?ordered_payload_root,
+                                        %error,
+                                        "trace ingest error"
+                                    );
+                                }
                                 Err(error)
                             }
                             Err(panic_payload) => {
@@ -4897,14 +4997,15 @@ impl ActorDaemonCoordinator {
                     };
                     match side_effect_result {
                         Ok(Ok((applied, side_effect_result))) => {
-                            if let Err(error) = &side_effect_result {
-                                let _ = self.record_side_effect_error(family, order, error);
-                                tracing::error!(
-                                    %error,
-                                    %family,
-                                    seq = applied.seq,
-                                    "command side effect failed"
-                                );
+                            match &side_effect_result {
+                                Ok(()) => self.note_side_effect_success(family),
+                                Err(error) => self.record_and_log_side_effect_error(
+                                    family,
+                                    order,
+                                    applied.seq,
+                                    error,
+                                    "command side effect failed",
+                                ),
                             }
                             if let Err(error) = self.append_command_completion_log(
                                 family,
@@ -4922,12 +5023,12 @@ impl ActorDaemonCoordinator {
                             }
                         }
                         Ok(Err(error)) => {
-                            let _ = self.record_side_effect_error(family, order, &error);
-                            tracing::error!(
-                                %error,
-                                %family,
+                            self.record_and_log_side_effect_error(
+                                family,
                                 order,
-                                "command apply failed"
+                                order,
+                                &error,
+                                "command apply failed",
                             );
                         }
                         Err(panic_payload) => {
@@ -5120,6 +5221,7 @@ impl ActorDaemonCoordinator {
                             "checkpoint failed"
                         );
                     }
+                    let mut watermark_update_failed = false;
                     if result.is_ok() {
                         // Clear pending AI edit state once the PostFileEdit completes.
                         if checkpoint_kind.is_ai()
@@ -5156,33 +5258,27 @@ impl ActorDaemonCoordinator {
                                 )
                                 .await
                         {
-                            let _ = self.record_side_effect_error(family, order, &error);
-                            tracing::error!(
-                                component = "daemon",
-                                phase = "checkpoint_processing",
-                                reason = "watermark_update_failed",
-                                receipt_seq,
-                                %family,
+                            watermark_update_failed = true;
+                            self.record_and_log_side_effect_error(
+                                family,
                                 order,
-                                %error,
-                                "checkpoint watermark update failed"
+                                order,
+                                &error,
+                                "checkpoint watermark update failed",
                             );
                         }
                     }
                     // Removed captured_checkpoint_id cleanup - no more captured checkpoints
-                    if let Err(error) = &result {
-                        let _ = self.record_side_effect_error(family, order, error);
-                        tracing::error!(
-                            component = "daemon",
-                            phase = "checkpoint_processing",
-                            reason = "side_effect_failed",
-                            receipt_seq,
-                            trace_id = %checkpoint_trace_id,
-                            %error,
-                            %family,
+                    match &result {
+                        Ok(_) if !watermark_update_failed => self.note_side_effect_success(family),
+                        Ok(_) => {}
+                        Err(error) => self.record_and_log_side_effect_error(
+                            family,
                             order,
-                            "checkpoint side effect failed"
-                        );
+                            order,
+                            error,
+                            "checkpoint side effect failed",
+                        ),
                     }
                     if should_log_completion {
                         let log_entry = TestCompletionLogEntry {
@@ -6848,14 +6944,15 @@ impl ActorDaemonCoordinator {
                         )
                         .await;
                     let _ = self.end_family_effect(&family);
-                    if let Err(error) = &result {
-                        let _ = self.record_side_effect_error(&family, applied.seq, error);
-                        tracing::error!(
-                            %error,
-                            %family,
-                            seq = applied.seq,
-                            "async side-effect error"
-                        );
+                    match &result {
+                        Ok(()) => self.note_side_effect_success(&family),
+                        Err(error) => self.record_and_log_side_effect_error(
+                            &family,
+                            applied.seq,
+                            applied.seq,
+                            error,
+                            "async side-effect error",
+                        ),
                     }
                     if let Err(error) =
                         self.append_command_completion_log(&family, &applied, &result, applied.seq)

--- a/src/daemon/error_log_policy.rs
+++ b/src/daemon/error_log_policy.rs
@@ -1,0 +1,388 @@
+//! Log-level policy for daemon side-effect and trace-ingest errors.
+//!
+//! All git processing is trace2-driven and asynchronous, so two error classes
+//! are noise rather than actionable failures:
+//!
+//! - A machine whose git environment is persistently broken fails every
+//!   side-effect pass with the identical error. Without suppression this
+//!   produces one error log per user git invocation, indefinitely.
+//! - A repository can be deleted between trace ingestion and async
+//!   processing (temp repos created by tooling). The resulting failures are
+//!   inherent to the async design and expected.
+//!
+//! The first few occurrences of a genuine failure still log at error level;
+//! repeated identical failures downgrade to debug with a rate-limited warn
+//! summary, and expected repo-gone conditions always log at debug.
+
+use crate::error::GitAiError;
+use std::time::{Duration, Instant};
+
+/// Consecutive identical errors logged at error level before suppression.
+const REPEATED_ERROR_LOG_LIMIT: u64 = 3;
+/// Minimum interval between warn summaries of suppressed repeated errors.
+const REPEATED_ERROR_SUMMARY_INTERVAL: Duration = Duration::from_secs(30 * 60);
+/// Idle time after which a family's tracker is garbage-collected. Long enough
+/// that an active storm never loses its suppression state between events.
+const TRACKER_IDLE_EVICTION: Duration =
+    Duration::from_secs(2 * REPEATED_ERROR_SUMMARY_INTERVAL.as_secs());
+
+/// How a side-effect error should be logged.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SideEffectErrorLog {
+    /// Genuine failure that has not repeated: log at error level.
+    Error,
+    /// Expected consequence of the repository vanishing before async
+    /// processing: log at debug level.
+    ExpectedRepoGoneDebug,
+    /// Identical error already logged `REPEATED_ERROR_LOG_LIMIT` times in a
+    /// row: log at debug level.
+    RepeatedDebug,
+    /// Repeated identical error whose summary interval elapsed: log a warn
+    /// summary including the occurrences downgraded since the last summary.
+    RepeatedSummaryWarn { suppressed_count: u64 },
+}
+
+/// Tracks consecutive identical errors for one repo family.
+#[derive(Debug, Default)]
+pub(crate) struct RepeatedErrorTracker {
+    last_key: Option<String>,
+    consecutive_identical: u64,
+    suppressed_since_summary: u64,
+    last_summary_at: Option<Instant>,
+    last_event_at: Option<Instant>,
+}
+
+impl RepeatedErrorTracker {
+    pub(crate) fn on_error(&mut self, error: &GitAiError, now: Instant) -> SideEffectErrorLog {
+        let key = suppression_key(error);
+        if self.last_key.as_deref() != Some(key.as_str()) {
+            *self = Self {
+                last_key: Some(key),
+                ..Self::default()
+            };
+        }
+        self.last_event_at = Some(now);
+        self.consecutive_identical = self.consecutive_identical.saturating_add(1);
+        if self.consecutive_identical <= REPEATED_ERROR_LOG_LIMIT {
+            if self.consecutive_identical == REPEATED_ERROR_LOG_LIMIT {
+                // Suppression starts now; the first summary is due one full
+                // interval later.
+                self.last_summary_at = Some(now);
+            }
+            return SideEffectErrorLog::Error;
+        }
+        if self
+            .last_summary_at
+            .is_none_or(|at| now.duration_since(at) >= REPEATED_ERROR_SUMMARY_INTERVAL)
+        {
+            let suppressed_count = self.suppressed_since_summary;
+            self.suppressed_since_summary = 0;
+            self.last_summary_at = Some(now);
+            return SideEffectErrorLog::RepeatedSummaryWarn { suppressed_count };
+        }
+        self.suppressed_since_summary = self.suppressed_since_summary.saturating_add(1);
+        SideEffectErrorLog::RepeatedDebug
+    }
+
+    /// True once the tracker has been idle long enough to garbage-collect.
+    pub(crate) fn is_stale(&self, now: Instant) -> bool {
+        self.last_event_at
+            .is_none_or(|at| now.duration_since(at) >= TRACKER_IDLE_EVICTION)
+    }
+}
+
+/// Key under which errors are considered "identical" for suppression.
+///
+/// Git CLI failures are keyed on exit code and stderr only: argv embeds
+/// per-invocation values (commit OIDs, `-C <path>`), so a persistently broken
+/// environment would otherwise produce a distinct signature per command and
+/// never be suppressed. Volatile hex runs (OIDs, pids, timestamps) inside the
+/// text are normalized away for the same reason.
+fn suppression_key(error: &GitAiError) -> String {
+    match error {
+        GitAiError::GitCliError { code, stderr, .. } => {
+            format!("git:{:?}:{}", code, normalize_volatile_runs(stderr))
+        }
+        other => normalize_volatile_runs(&other.to_string()),
+    }
+}
+
+/// Replaces runs of 7+ hex digits (commit OIDs, pids, timestamps) with `#` so
+/// otherwise-identical errors that embed per-invocation values compare equal.
+fn normalize_volatile_runs(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut run = String::new();
+    let flush = |out: &mut String, run: &mut String| {
+        if run.len() >= 7 {
+            out.push('#');
+        } else {
+            out.push_str(run);
+        }
+        run.clear();
+    };
+    for c in text.chars() {
+        if c.is_ascii_hexdigit() {
+            run.push(c);
+        } else {
+            flush(&mut out, &mut run);
+            out.push(c);
+        }
+    }
+    flush(&mut out, &mut run);
+    out
+}
+
+/// Stderr fragments git emits when the repository directory vanished between
+/// trace ingestion and async processing.
+const VANISHED_REPO_GIT_STDERR_MARKERS: &[&str] =
+    &["cannot change to", "not a git repository", "failed to stat"];
+
+/// True for the error `discover_repository_paths_no_git_exec` returns when a
+/// traced command ran outside any repository, or in one deleted before async
+/// processing.
+pub(crate) fn is_repo_discovery_miss_without_exec(error: &GitAiError) -> bool {
+    matches!(
+        error,
+        GitAiError::Generic(message)
+            if message.starts_with(crate::git::repository::NO_REPO_WITHOUT_EXEC_ERROR_PREFIX)
+    )
+}
+
+/// True when the error is an expected consequence of the repository being
+/// removed before async processing: a repo-discovery miss without exec, or a
+/// git CLI failure whose stderr indicates a missing repository while the
+/// family root no longer exists on disk.
+pub(crate) fn is_expected_missing_repo_error(error: &GitAiError, family_root_exists: bool) -> bool {
+    if is_repo_discovery_miss_without_exec(error) {
+        return true;
+    }
+    if family_root_exists {
+        return false;
+    }
+    matches!(
+        error,
+        GitAiError::GitCliError { stderr, .. }
+            if VANISHED_REPO_GIT_STDERR_MARKERS
+                .iter()
+                .any(|marker| stderr.contains(marker))
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn git_cli_error(stderr: &str) -> GitAiError {
+        git_cli_error_with_args(stderr, &["rev-parse"])
+    }
+
+    fn git_cli_error_with_args(stderr: &str, args: &[&str]) -> GitAiError {
+        GitAiError::GitCliError {
+            code: Some(128),
+            stderr: stderr.to_string(),
+            args: args.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    fn generic(message: &str) -> GitAiError {
+        GitAiError::Generic(message.to_string())
+    }
+
+    fn discovery_miss_error() -> GitAiError {
+        GitAiError::Generic(format!(
+            "{}: /tmp/gone-repo",
+            crate::git::repository::NO_REPO_WITHOUT_EXEC_ERROR_PREFIX
+        ))
+    }
+
+    #[test]
+    fn first_identical_errors_log_at_error_level() {
+        let mut tracker = RepeatedErrorTracker::default();
+        let now = Instant::now();
+        for _ in 0..REPEATED_ERROR_LOG_LIMIT {
+            assert_eq!(
+                tracker.on_error(&generic("boom"), now),
+                SideEffectErrorLog::Error
+            );
+        }
+    }
+
+    #[test]
+    fn repeated_identical_errors_downgrade_to_debug() {
+        let mut tracker = RepeatedErrorTracker::default();
+        let now = Instant::now();
+        for _ in 0..REPEATED_ERROR_LOG_LIMIT {
+            tracker.on_error(&generic("boom"), now);
+        }
+        assert_eq!(
+            tracker.on_error(&generic("boom"), now),
+            SideEffectErrorLog::RepeatedDebug
+        );
+        assert_eq!(
+            tracker.on_error(&generic("boom"), now + Duration::from_secs(60)),
+            SideEffectErrorLog::RepeatedDebug
+        );
+    }
+
+    #[test]
+    fn summary_fires_once_per_interval_with_suppressed_count() {
+        let mut tracker = RepeatedErrorTracker::default();
+        let start = Instant::now();
+        for _ in 0..REPEATED_ERROR_LOG_LIMIT {
+            tracker.on_error(&generic("boom"), start);
+        }
+        // Two occurrences suppressed inside the interval.
+        assert_eq!(
+            tracker.on_error(&generic("boom"), start + Duration::from_secs(60)),
+            SideEffectErrorLog::RepeatedDebug
+        );
+        assert_eq!(
+            tracker.on_error(&generic("boom"), start + Duration::from_secs(120)),
+            SideEffectErrorLog::RepeatedDebug
+        );
+        // Interval elapsed: summary reports the two suppressed occurrences.
+        let summary_at = start + REPEATED_ERROR_SUMMARY_INTERVAL;
+        assert_eq!(
+            tracker.on_error(&generic("boom"), summary_at),
+            SideEffectErrorLog::RepeatedSummaryWarn {
+                suppressed_count: 2
+            }
+        );
+        // Counter reset: the next occurrence inside the new interval is
+        // suppressed again, and the next summary reports only it.
+        assert_eq!(
+            tracker.on_error(&generic("boom"), summary_at + Duration::from_secs(60)),
+            SideEffectErrorLog::RepeatedDebug
+        );
+        assert_eq!(
+            tracker.on_error(
+                &generic("boom"),
+                summary_at + REPEATED_ERROR_SUMMARY_INTERVAL
+            ),
+            SideEffectErrorLog::RepeatedSummaryWarn {
+                suppressed_count: 1
+            }
+        );
+    }
+
+    #[test]
+    fn different_error_resets_suppression() {
+        let mut tracker = RepeatedErrorTracker::default();
+        let now = Instant::now();
+        for _ in 0..=REPEATED_ERROR_LOG_LIMIT {
+            tracker.on_error(&generic("boom"), now);
+        }
+        assert_eq!(
+            tracker.on_error(&generic("other"), now),
+            SideEffectErrorLog::Error
+        );
+        // And the original error starts a fresh run too.
+        assert_eq!(
+            tracker.on_error(&generic("boom"), now),
+            SideEffectErrorLog::Error
+        );
+    }
+
+    #[test]
+    fn git_cli_errors_with_differing_argv_are_identical() {
+        // A persistently broken environment fails commands whose argv embeds
+        // per-invocation values (OIDs, paths); suppression must still engage.
+        let mut tracker = RepeatedErrorTracker::default();
+        let now = Instant::now();
+        let stderr = "fatal: unable to write new index file";
+        for i in 0..REPEATED_ERROR_LOG_LIMIT {
+            let error =
+                git_cli_error_with_args(stderr, &["notes", "append", &format!("oid{i}aaaaaa")]);
+            assert_eq!(tracker.on_error(&error, now), SideEffectErrorLog::Error);
+        }
+        let error = git_cli_error_with_args(stderr, &["notes", "append", "1234567abcdef"]);
+        assert_eq!(
+            tracker.on_error(&error, now),
+            SideEffectErrorLog::RepeatedDebug
+        );
+    }
+
+    #[test]
+    fn volatile_hex_runs_in_error_text_are_normalized() {
+        let mut tracker = RepeatedErrorTracker::default();
+        let now = Instant::now();
+        for oid in ["1234567890abcdef", "fedcba0987654321", "0123456aabbccdd"] {
+            assert_eq!(
+                tracker.on_error(&git_cli_error(&format!("fatal: bad object {oid}")), now),
+                SideEffectErrorLog::Error
+            );
+        }
+        assert_eq!(
+            tracker.on_error(&git_cli_error("fatal: bad object aaaaaaabbbbbbb"), now),
+            SideEffectErrorLog::RepeatedDebug
+        );
+        // Short hex-like words are preserved, so distinct errors stay distinct.
+        assert_eq!(
+            tracker.on_error(&git_cli_error("fatal: bad ref abc"), now),
+            SideEffectErrorLog::Error
+        );
+    }
+
+    #[test]
+    fn tracker_staleness_follows_idle_eviction_window() {
+        let mut tracker = RepeatedErrorTracker::default();
+        let now = Instant::now();
+        assert!(tracker.is_stale(now));
+        tracker.on_error(&generic("boom"), now);
+        assert!(!tracker.is_stale(now + TRACKER_IDLE_EVICTION / 2));
+        assert!(tracker.is_stale(now + TRACKER_IDLE_EVICTION));
+    }
+
+    #[test]
+    fn discovery_miss_is_expected_regardless_of_root() {
+        assert!(is_repo_discovery_miss_without_exec(&discovery_miss_error()));
+        assert!(is_expected_missing_repo_error(
+            &discovery_miss_error(),
+            true
+        ));
+        assert!(is_expected_missing_repo_error(
+            &discovery_miss_error(),
+            false
+        ));
+    }
+
+    #[test]
+    fn vanished_repo_git_errors_are_expected_only_when_root_is_gone() {
+        for stderr in [
+            "fatal: cannot change to '/tmp/gone': No such file or directory",
+            "fatal: not a git repository (or any of the parent directories): .git",
+            "fatal: failed to stat '/tmp/gone': No such file or directory",
+        ] {
+            let error = git_cli_error(stderr);
+            assert!(is_expected_missing_repo_error(&error, false), "{stderr}");
+            assert!(!is_expected_missing_repo_error(&error, true), "{stderr}");
+        }
+    }
+
+    #[test]
+    fn genuine_errors_are_not_expected() {
+        let merge_conflict =
+            git_cli_error("error: Your local changes to the following files would be overwritten");
+        assert!(!is_expected_missing_repo_error(&merge_conflict, false));
+        assert!(!is_expected_missing_repo_error(&merge_conflict, true));
+
+        let generic = generic("side effect panic");
+        assert!(!is_repo_discovery_miss_without_exec(&generic));
+        assert!(!is_expected_missing_repo_error(&generic, false));
+    }
+
+    #[test]
+    fn expected_condition_does_not_consume_the_error_budget() {
+        // Mirrors the daemon call site: expected repo-gone errors short-circuit
+        // before the tracker, so genuine errors still get their loud run.
+        let mut tracker = RepeatedErrorTracker::default();
+        let now = Instant::now();
+        let gone = git_cli_error("fatal: cannot change to '/tmp/gone': No such file or directory");
+        for _ in 0..10 {
+            assert!(is_expected_missing_repo_error(&gone, false));
+        }
+        let genuine = git_cli_error("fatal: bad object HEAD");
+        assert!(!is_expected_missing_repo_error(&genuine, false));
+        assert_eq!(tracker.on_error(&genuine, now), SideEffectErrorLog::Error);
+    }
+}

--- a/src/daemon/error_log_policy.rs
+++ b/src/daemon/error_log_policy.rs
@@ -151,21 +151,46 @@ pub(crate) fn is_repo_discovery_miss_without_exec(error: &GitAiError) -> bool {
 /// True when the error is an expected consequence of the repository being
 /// removed before async processing: a repo-discovery miss without exec, or a
 /// git CLI failure whose stderr indicates a missing repository while the
-/// family root no longer exists on disk.
+/// path git names (or, failing that, the family root) no longer exists on
+/// disk. Checking the named path covers deleted linked worktrees, whose
+/// shared common dir (the family root) survives the worktree's deletion.
 pub(crate) fn is_expected_missing_repo_error(error: &GitAiError, family_root_exists: bool) -> bool {
     if is_repo_discovery_miss_without_exec(error) {
         return true;
     }
-    if family_root_exists {
+    let GitAiError::GitCliError { stderr, .. } = error else {
         return false;
+    };
+    if stderr_names_missing_path(stderr) {
+        return true;
     }
-    matches!(
-        error,
-        GitAiError::GitCliError { stderr, .. }
-            if VANISHED_REPO_GIT_STDERR_MARKERS
-                .iter()
-                .any(|marker| stderr.contains(marker))
-    )
+    !family_root_exists
+        && VANISHED_REPO_GIT_STDERR_MARKERS
+            .iter()
+            .any(|marker| stderr.contains(marker))
+}
+
+/// True when git's stderr quotes a concrete path (`cannot change to '<p>'`,
+/// `failed to stat '<p>'`) that no longer exists on disk. Only a definitive
+/// NotFound counts as gone, mirroring the family-root check.
+fn stderr_names_missing_path(stderr: &str) -> bool {
+    ["cannot change to ", "failed to stat "]
+        .iter()
+        .filter_map(|marker| quoted_path_after(stderr, marker))
+        .any(|path| {
+            matches!(
+                std::fs::metadata(path),
+                Err(ref io_error) if io_error.kind() == std::io::ErrorKind::NotFound
+            )
+        })
+}
+
+/// Extracts the single-quoted path following `marker` in git stderr, e.g.
+/// `fatal: cannot change to '/tmp/gone': No such file or directory`.
+fn quoted_path_after<'a>(stderr: &'a str, marker: &str) -> Option<&'a str> {
+    let after = &stderr[stderr.find(marker)? + marker.len()..];
+    let after = after.strip_prefix('\'')?;
+    after.split('\'').next()
 }
 
 #[cfg(test)]
@@ -347,15 +372,33 @@ mod tests {
     }
 
     #[test]
-    fn vanished_repo_git_errors_are_expected_only_when_root_is_gone() {
+    fn vanished_repo_git_errors_are_expected_when_root_is_gone() {
+        let existing = tempfile::tempdir().unwrap();
+        let existing = existing.path().display().to_string();
         for stderr in [
-            "fatal: cannot change to '/tmp/gone': No such file or directory",
-            "fatal: not a git repository (or any of the parent directories): .git",
-            "fatal: failed to stat '/tmp/gone': No such file or directory",
+            format!("fatal: cannot change to '{existing}': Permission denied"),
+            "fatal: not a git repository (or any of the parent directories): .git".to_string(),
+            format!("fatal: failed to stat '{existing}': Permission denied"),
         ] {
-            let error = git_cli_error(stderr);
+            let error = git_cli_error(&stderr);
             assert!(is_expected_missing_repo_error(&error, false), "{stderr}");
             assert!(!is_expected_missing_repo_error(&error, true), "{stderr}");
+        }
+    }
+
+    #[test]
+    fn errors_naming_a_deleted_path_are_expected_even_if_root_survives() {
+        // A deleted linked worktree leaves the shared common dir (the family
+        // root) in place; the path git names in stderr is the tell.
+        let dir = tempfile::tempdir().unwrap();
+        let gone = dir.path().join("gone-worktree");
+        let gone = gone.display().to_string();
+        for stderr in [
+            format!("fatal: cannot change to '{gone}': No such file or directory"),
+            format!("fatal: failed to stat '{gone}': No such file or directory"),
+        ] {
+            let error = git_cli_error(&stderr);
+            assert!(is_expected_missing_repo_error(&error, true), "{stderr}");
         }
     }
 

--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -2159,6 +2159,12 @@ struct DiscoveredRepositoryPaths {
     git_common_dir: PathBuf,
 }
 
+/// Message prefix of the error returned when repository discovery without
+/// spawning git finds no repository. The daemon treats these as expected:
+/// traced commands can run outside any repo or in a temp repo deleted before
+/// async processing.
+pub const NO_REPO_WITHOUT_EXEC_ERROR_PREFIX: &str = "No git repository found for path without exec";
+
 fn discover_repository_paths_no_git_exec(
     path: &Path,
 ) -> Result<DiscoveredRepositoryPaths, GitAiError> {
@@ -2259,7 +2265,8 @@ fn discover_repository_paths_no_git_exec(
     }
 
     Err(GitAiError::Generic(format!(
-        "No git repository found for path without exec: {}",
+        "{}: {}",
+        NO_REPO_WITHOUT_EXEC_ERROR_PREFIX,
         path.display()
     )))
 }


### PR DESCRIPTION
## Issue

Two classes of daemon error logs are noise rather than actionable failures:

1. **Repeated-identical-failure storms.** On a machine whose daemon-side git environment is persistently broken (e.g. a broken Xcode CLT shim, or the daemon being denied read access to an included gitconfig), every traced command's side-effect pass fails with the identical error. Each failure logs at error level, producing an unbounded stream of identical error logs for as long as the environment stays broken.

2. **Expected async-race conditions logged at error level.** Git processing is trace2-driven and fully async, so the repo state at processing time need not match state at command time. Traced commands can run outside any repository, or in a temp repo (created by plugins/tooling) that is deleted before async processing. The resulting failures ("No git repository found for path without exec", `fatal: cannot change to '<path>'`, `fatal: not a git repository`, `failed to stat`) are inherent to the design, not errors.

## Fix

Add `src/daemon/error_log_policy.rs` and route the daemon's side-effect error log sites (command apply/side-effect, async side-effect, checkpoint side-effect/watermark) through a shared `record_and_log_side_effect_error` helper:

- **Repeated-error suppression (per repo family):** the first 3 consecutive identical errors still log at error level; subsequent identical occurrences downgrade to debug, with a rate-limited warn summary at most once per 30 minutes that includes the suppressed count. A success or a differing error re-arms error-level logging. Identity is keyed on git exit code + stderr with volatile hex runs (OIDs, pids) normalized away, so storms whose messages embed per-invocation values are still suppressed.
- **Expected-condition classification:** repo-discovery misses without exec, and git CLI failures whose stderr indicates a missing repository while the family root no longer exists on disk (only a definitive `NotFound` counts), log at debug as "repo removed before processing" instead of error. The trace-ingest worker's error site applies the same classification for repo-discovery misses.
- Trackers are tiny, in-memory, and garbage-collected after an idle window; expected conditions short-circuit before the tracker map so high-cardinality deleted temp repos never leave entries. Nothing is added to the trace-ingest hot path's happy path.

Intentionally left loud: panic sites (genuine bugs) and test-only completion-log write failures still log unconditionally at error level, and the ingest-site downgrade only applies to the no-repo discovery miss (traced commands legitimately run outside repos constantly, so no error budget there).

## Testing

- New unit tests for the suppression state machine (identical-run counting, reset on differing error/success, summary timing via injected `Instant`, argv/OID-varying storm keys, idle eviction) and the expected-condition classifier (positive and negative cases; genuine git errors stay at error level).
- `task fmt`, `task lint`, full `task test` (lib + integration) pass locally; the two pre-existing env-dependent lib test failures on this machine reproduce identically on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/2269" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->