### PR TITLE
fix(daemon): strip git global options before parsing update-ref argv

### DIFF
--- a/src/daemon/analyzers/mod.rs
+++ b/src/daemon/analyzers/mod.rs
@@ -102,10 +102,35 @@ pub(crate) fn normalized_args(argv: &[String]) -> Vec<String> {
     let start = argv
         .first()
         .and_then(|arg| Path::new(arg).file_name().and_then(|name| name.to_str()))
-        .is_some_and(|name| name == "git" || name == "git.exe");
+        .is_some_and(|name| {
+            name.eq_ignore_ascii_case("git") || name.eq_ignore_ascii_case("git.exe")
+        });
     if start {
         argv[1..].to_vec()
     } else {
         argv.to_vec()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalized_args;
+
+    #[test]
+    fn normalized_args_strips_git_executable_prefix_case_insensitively() {
+        let argv: Vec<String> = ["/usr/local/bin/Git.EXE", "update-ref", "refs/heads/x"]
+            .iter()
+            .map(|arg| arg.to_string())
+            .collect();
+        assert_eq!(normalized_args(&argv), argv[1..].to_vec());
+    }
+
+    #[test]
+    fn normalized_args_keeps_argv_without_git_prefix() {
+        let argv: Vec<String> = ["update-ref", "refs/heads/x"]
+            .iter()
+            .map(|arg| arg.to_string())
+            .collect();
+        assert_eq!(normalized_args(&argv), argv);
     }
 }

--- a/src/daemon/ref_cursor.rs
+++ b/src/daemon/ref_cursor.rs
@@ -3267,6 +3267,19 @@ fn discover_reflog_refs(
 }
 
 fn parse_update_ref_spec(args: &[String]) -> Result<Option<UpdateRefSpec>, GitAiError> {
+    // `args` may still carry git global options that precede the subcommand
+    // (e.g. `git -c key=val update-ref ...` or `git -C path update-ref ...`):
+    // when a command has no `invoked_args` (already global-stripped during
+    // trace normalization), `command_args` falls back to the raw argv minus
+    // the executable. Strip the globals with the CLI parser, which knows which
+    // global options consume a value, so they are not misread as update-ref
+    // options/positionals.
+    let parsed = parse_git_cli_args(args);
+    let args: &[String] = if parsed.command.as_deref() == Some("update-ref") {
+        &parsed.command_args
+    } else {
+        args
+    };
     let mut positionals = Vec::new();
     let mut delete = false;
     let mut idx = 0usize;
@@ -3290,10 +3303,15 @@ fn parse_update_ref_spec(args: &[String]) -> Result<Option<UpdateRefSpec>, GitAi
                 }
                 idx += 2;
             }
-            "--create-reflog" | "--no-deref" => {
+            "-z" | "--create-reflog" | "--no-create-reflog" | "--no-deref" => {
                 idx += 1;
             }
             value if value.starts_with("--message=") => {
+                idx += 1;
+            }
+            // git's parse-options also accepts the reason attached to the
+            // short flag (`-m<reason>`).
+            value if value.starts_with("-m") && value.len() > 2 => {
                 idx += 1;
             }
             value if value.starts_with('-') => {
@@ -3890,6 +3908,68 @@ mod tests {
             cherry_pick_source_args(&["-Smy-key".to_string(), "HEAD~1".to_string()]),
             vec!["HEAD~1"]
         );
+    }
+
+    fn parse_update_ref_args(args: &[&str]) -> Result<Option<UpdateRefSpec>, GitAiError> {
+        let args: Vec<String> = args.iter().map(|arg| arg.to_string()).collect();
+        parse_update_ref_spec(&args)
+    }
+
+    #[test]
+    fn parse_update_ref_spec_skips_global_config_flag_before_subcommand() {
+        let spec = parse_update_ref_args(&["-c", "some.key=val", "update-ref", "refs/heads/x", A])
+            .unwrap()
+            .unwrap();
+        assert_eq!(spec.reference, "refs/heads/x");
+        assert_eq!(spec.new_oid, A);
+        assert_eq!(spec.old_oid, None);
+    }
+
+    #[test]
+    fn parse_update_ref_spec_skips_global_chdir_flag_before_subcommand() {
+        let spec = parse_update_ref_args(&["-C", "/path", "update-ref", "refs/heads/x", A, B])
+            .unwrap()
+            .unwrap();
+        assert_eq!(spec.reference, "refs/heads/x");
+        assert_eq!(spec.new_oid, A);
+        assert_eq!(spec.old_oid, Some(B.to_string()));
+    }
+
+    #[test]
+    fn parse_update_ref_spec_parses_plain_delete() {
+        let spec = parse_update_ref_args(&["update-ref", "-d", "refs/heads/x"])
+            .unwrap()
+            .unwrap();
+        assert_eq!(spec.reference, "refs/heads/x");
+        assert_eq!(spec.new_oid, zero_oid());
+        assert_eq!(spec.old_oid, None);
+    }
+
+    #[test]
+    fn parse_update_ref_spec_accepts_z_and_negated_create_reflog_flags() {
+        // git's parse-options accepts `-z` in any position relative to
+        // `--stdin` and auto-negates boolean long options.
+        assert!(
+            parse_update_ref_args(&["update-ref", "-z", "--stdin"])
+                .unwrap()
+                .is_none()
+        );
+        let spec = parse_update_ref_args(&["update-ref", "--no-create-reflog", "refs/heads/x", A])
+            .unwrap()
+            .unwrap();
+        assert_eq!(spec.reference, "refs/heads/x");
+        assert_eq!(spec.new_oid, A);
+        assert_eq!(spec.old_oid, None);
+    }
+
+    #[test]
+    fn parse_update_ref_spec_consumes_sticky_short_message_value() {
+        let spec = parse_update_ref_args(&["update-ref", "-mreason", "refs/heads/x", A, B])
+            .unwrap()
+            .unwrap();
+        assert_eq!(spec.reference, "refs/heads/x");
+        assert_eq!(spec.new_oid, A);
+        assert_eq!(spec.old_oid, Some(B.to_string()));
     }
 
     fn family_state(family: &FamilyKey) -> FamilyState {
@@ -4531,6 +4611,58 @@ mod tests {
         let mut cursor = RefCursor::new(family.clone());
         let mut cmd =
             command_with_worktree(&family, Some(worktree), &["update-ref", reference, D, C]);
+        cmd.reflog_start_offsets
+            .insert(common_key(reference), branch_line.len() as u64);
+        cmd.reflog_start_offsets
+            .insert(head_key(&git_dir), head_line.len() as u64);
+
+        cursor.enrich_command(&mut cmd, &state).unwrap();
+
+        assert_eq!(
+            cmd.ref_changes,
+            vec![
+                RefChange {
+                    reference: reference.to_string(),
+                    old: C.to_string(),
+                    new: D.to_string(),
+                },
+                RefChange {
+                    reference: "HEAD".to_string(),
+                    old: C.to_string(),
+                    new: D.to_string(),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn direct_branch_update_ref_strips_global_options_on_raw_argv_fallback() {
+        // The production shape for the global-option stripping in
+        // `parse_update_ref_spec`: when a command carries no `invoked_args`,
+        // `command_args` falls back to the raw argv minus the executable,
+        // which retains global options and the subcommand token.
+        let temp = tempfile::tempdir().unwrap();
+        let worktree = temp.path().join("repo");
+        let git_dir = create_git_dir(&worktree);
+        let reference = "refs/heads/feature";
+        fs::create_dir_all(git_dir.join("logs").join("refs/heads")).unwrap();
+
+        let branch_line = format!("{C} {D} Test User <test@example.com> 0 +0000\t\n");
+        let head_line = format!("{C} {D} Test User <test@example.com> 0 +0000\t\n");
+        fs::write(git_dir.join("logs").join(reference), &branch_line).unwrap();
+        fs::write(git_dir.join("logs").join("HEAD"), &head_line).unwrap();
+
+        let family = FamilyKey::new(git_dir.to_string_lossy().to_string());
+        let state = family_state(&family);
+        let mut cursor = RefCursor::new(family.clone());
+        let mut cmd =
+            command_with_worktree(&family, Some(worktree), &["update-ref", reference, D, C]);
+        cmd.invoked_command = None;
+        cmd.invoked_args = Vec::new();
+        cmd.raw_argv = ["git", "-c", "foo.bar=1", "update-ref", reference, D, C]
+            .iter()
+            .map(|arg| arg.to_string())
+            .collect();
         cmd.reflog_start_offsets
             .insert(common_key(reference), branch_line.len() as u64);
         cmd.reflog_start_offsets

--- a/tests/commit_tree_update_ref.rs
+++ b/tests/commit_tree_update_ref.rs
@@ -1919,6 +1919,50 @@ fn test_update_ref_current_branch_with_new_content_preserves_attribution() {
 }
 
 #[test]
+fn test_update_ref_with_global_config_flag_preserves_attribution() {
+    let repo = TestRepo::new();
+    setup_initial_commit(&repo);
+
+    repo.git(&["checkout", "-b", "feature"])
+        .expect("checkout feature should succeed");
+
+    fs::write(repo.path().join("global-flag-plumbing.txt"), "branch ai\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "global-flag-plumbing.txt"])
+        .unwrap();
+    repo.git(&["add", "-A"]).unwrap();
+
+    let parent_sha = head_sha(&repo);
+    let tree_sha = repo.git(&["write-tree"]).unwrap().trim().to_string();
+    let commit_sha = repo
+        .git(&[
+            "commit-tree",
+            &tree_sha,
+            "-p",
+            &parent_sha,
+            "-m",
+            "global flag plumbing commit",
+        ])
+        .unwrap()
+        .trim()
+        .to_string();
+    // A global option before the subcommand (`git -c ... update-ref`) must not
+    // break trace2 cursor enrichment of the update-ref command.
+    repo.git(&[
+        "-c",
+        "foo.bar=1",
+        "update-ref",
+        "refs/heads/feature",
+        &commit_sha,
+        &parent_sha,
+    ])
+    .unwrap();
+
+    assert_note_has_ai_for_file(&repo, &commit_sha, "global-flag-plumbing.txt");
+    let mut feature_file = repo.filename("global-flag-plumbing.txt");
+    feature_file.assert_lines_and_blame(lines!["branch ai".ai()]);
+}
+
+#[test]
 fn test_update_ref_fast_forward_bounds_committed_hunks_to_final_commit() {
     let repo = TestRepo::new();
     setup_initial_commit(&repo);


### PR DESCRIPTION
## Bug

`git -c key=val update-ref ...` and `git -C path update-ref ...` fail trace2 cursor enrichment. `parse_update_ref_spec` receives the command argv, which can still include git global options that precede the subcommand (via `command_args`' raw-argv fallback when a command carries no `invoked_args`); the parser only skipped the literal `update-ref` token, so the leading global flag hit the catch-all arm and errored with:

```
trace2 cursor does not support update-ref option '-c'
```

Enrichment then fails, and the command fails closed for attribution (working-log/notes migration is skipped).

## Fix

- Reuse `parse_git_cli_args` (which knows git's global options and which of them consume a value) in `parse_update_ref_spec` to slice off everything up to and including the `update-ref` subcommand before option parsing. Argv shapes without a leading `update-ref` command are passed through unchanged.
- Accept valid `update-ref` forms the option loop previously rejected for the same fail-closed reason: `-z`, `--no-create-reflog`, and the sticky short-message form `-m<reason>`.
- Make `normalized_args`' executable-prefix check case-insensitive (`Git.EXE`), matching the trace normalizer's `is_git_binary`, so the raw-argv fallback is sliced consistently on Windows.

## Tests

- Unit tests for `parse_update_ref_spec` covering `-c k=v update-ref`, `-C path update-ref`, plain `update-ref -d`, `-z`/`--no-create-reflog`, and `-m<reason>` (the first two reproduced the exact production error before the fix).
- An enrich-level test (`direct_branch_update_ref_strips_global_options_on_raw_argv_fallback`) pinning the raw-argv fallback shape (empty `invoked_args`, raw argv `git -c foo.bar=1 update-ref ...`), which fails without the fix.
- A `TestRepo` integration test running `git -c foo.bar=1 update-ref refs/heads/feature <new> <old>` end-to-end and asserting the authorship note migrates and blame attribution is preserved.

## Note

`parse_branch_command_spec` (and `pull_reflog_action`'s fallback) have the same latent exposure to argv shapes that still carry global options — e.g. a leading `-c` would be misread as branch `--copy`. Left out of scope here; can be handled in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/2271" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->