### PR TITLE
fix: attribute Copilot-created new files to the AI agent (#2221)

### DIFF
--- a/src/commands/checkpoint_agent/presets/github_copilot/ide.rs
+++ b/src/commands/checkpoint_agent/presets/github_copilot/ide.rs
@@ -292,12 +292,41 @@ pub(super) fn parse_vscode_native_hooks(
         )));
     }
 
-    // Workaround: VS Code Copilot fires PostToolUse before the file is written to disk.
-    // https://github.com/microsoft/vscode/issues/315926
-    tracing::debug!(
-        "Sleeping 80ms for VS Code Copilot PostToolUse file-write race (vscode#315926)"
-    );
-    std::thread::sleep(std::time::Duration::from_millis(80));
+    // Prefer explicit create_file content from the payload over a disk re-read.
+    // VS Code Copilot often fires PostToolUse before the new file is flushed
+    // (microsoft/vscode#315926); the full text is already in tool_input.content.
+    // VS Code's native create_file tool_input always uses "content" (see the
+    // PreToolUse branch above and captured real payloads in tests below).
+    // "file_text" is a different tool's field (Copilot CLI's create) and is
+    // never populated here, so it is intentionally not checked as a fallback.
+    let create_file_payload_content = tool_name
+        .eq_ignore_ascii_case("create_file")
+        .then(|| {
+            tool_input
+                .and_then(|ti| ti.get("content"))
+                .and_then(|v| v.as_str())
+        })
+        .flatten();
+
+    let dirty_files = if let Some(content) = create_file_payload_content {
+        let mut map = dirty_files.unwrap_or_default();
+        for path in &extracted_paths {
+            // Unconditionally override: the payload content is authoritative for
+            // create_file, regardless of any stale entry from a legacy dirty_files
+            // hook field.
+            map.insert(path.clone(), content.to_string());
+        }
+        Some(map)
+    } else {
+        // Fallback: wait briefly for the write to land on disk. Applies both to
+        // create_file without payload content and to all other edit tools.
+        // https://github.com/microsoft/vscode/issues/315926
+        tracing::debug!(
+            "Sleeping 80ms for VS Code Copilot PostToolUse file-write race (vscode#315926)"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(80));
+        dirty_files
+    };
 
     Ok(vec![ParsedHookEvent::PostFileEdit(PostFileEdit {
         context,
@@ -718,6 +747,39 @@ mod tests {
                 );
             }
             _ => panic!("Expected PreFileEdit"),
+        }
+    }
+
+    #[test]
+    fn test_copilot_native_create_file_post_uses_tool_input_content() {
+        let input = json!({
+            "hook_event_name": "PostToolUse",
+            "cwd": "/home/user/project",
+            "tool_name": "create_file",
+            "session_id": "sess-456",
+            "tool_input": {
+                "file_path": "/home/user/project/src/new_file.rs",
+                "content": "fn main() {}\n"
+            },
+            "tool_response": "",
+            "transcript_path": "/home/user/.vscode/data/github.copilot-chat/transcripts/sess-456.json"
+        })
+        .to_string();
+        let events = GithubCopilotPreset
+            .parse(&input, "t_test123456789a")
+            .unwrap();
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            ParsedHookEvent::PostFileEdit(e) => {
+                assert_eq!(
+                    e.dirty_files
+                        .as_ref()
+                        .unwrap()
+                        .get(&PathBuf::from("/home/user/project/src/new_file.rs")),
+                    Some(&"fn main() {}\n".to_string())
+                );
+            }
+            _ => panic!("Expected PostFileEdit"),
         }
     }
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -3364,9 +3364,7 @@ impl ActorDaemonCoordinator {
     }
 
     fn canonicalize_path(path: &str) -> String {
-        std::fs::canonicalize(path)
-            .map(|p| p.to_string_lossy().to_string())
-            .unwrap_or_else(|_| path.to_string())
+        crate::utils::canonicalize_path_key(path)
     }
 
     fn register_pending_ai_edits(&self, family: &str, file_paths: &[String]) {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -18,28 +18,64 @@ pub fn normalize_to_posix(path: &str) -> String {
 /// `/var` → `/private/var`, or an explicit workdir symlink. Walk up to the
 /// longest existing ancestor, canonicalize that, and re-join the missing
 /// suffix so both sides share the same key.
+///
+/// Dangling symlink components are followed via `read_link` without requiring
+/// the target to exist (relative targets are resolved against the symlink's
+/// parent). Symlink loops are ignored so the walk can continue.
 pub fn canonicalize_path_key(path: &str) -> String {
-    let path = Path::new(path);
-    let mut suffix: Vec<std::ffi::OsString> = Vec::new();
-    let mut cursor = path;
-    loop {
-        if let Ok(canonical) = std::fs::canonicalize(cursor) {
-            let mut result = canonical;
-            for part in suffix.iter().rev() {
-                result.push(part);
+    fn resolve(
+        path: &Path,
+        visited: &mut std::collections::HashSet<PathBuf>,
+        depth: usize,
+    ) -> PathBuf {
+        const MAX_SYMLINKS: usize = 256;
+        let mut suffix: Vec<std::ffi::OsString> = Vec::new();
+        let mut cursor = path.to_path_buf();
+        loop {
+            if let Ok(canonical) = std::fs::canonicalize(&cursor) {
+                let mut result = canonical;
+                for part in suffix.iter().rev() {
+                    result.push(part);
+                }
+                return result;
             }
-            return result.to_string_lossy().into_owned();
-        }
-        match (cursor.file_name(), cursor.parent()) {
-            (Some(name), Some(parent)) if !parent.as_os_str().is_empty() => {
-                suffix.push(name.to_owned());
-                cursor = parent;
+
+            // `canonicalize` requires the target to exist. A dangling symlink
+            // still has a readable target; follow it so Pre/Post keys match.
+            if depth < MAX_SYMLINKS
+                && let Ok(target) = std::fs::read_link(&cursor)
+                && visited.insert(cursor.clone())
+            {
+                let parent = cursor
+                    .parent()
+                    .filter(|p| !p.as_os_str().is_empty())
+                    .unwrap_or_else(|| Path::new("."));
+                let mut continued = if target.is_absolute() {
+                    target
+                } else {
+                    parent.join(target)
+                };
+                for part in suffix.iter().rev() {
+                    continued.push(part);
+                }
+                return resolve(&continued, visited, depth + 1);
             }
-            _ => break,
+
+            match (cursor.file_name(), cursor.parent()) {
+                (Some(name), Some(parent)) if !parent.as_os_str().is_empty() => {
+                    suffix.push(name.to_owned());
+                    cursor = parent.to_path_buf();
+                }
+                _ => break,
+            }
         }
+
+        path.to_path_buf()
     }
 
-    path.to_string_lossy().into_owned()
+    resolve(Path::new(path), &mut std::collections::HashSet::new(), 0)
+        .to_string_lossy()
+        .into_owned()
 }
 
 fn resolve_git_ai_exe_from_invocation_path(path: PathBuf) -> PathBuf {
@@ -555,6 +591,52 @@ mod tests {
 
         assert_eq!(key_before, expected);
         assert_eq!(key_after, expected);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_canonicalize_path_key_dangling_symlink_matches_after_target_create() {
+        let dir = tempfile::tempdir().unwrap();
+        let sub = dir.path().join("sub");
+        std::fs::create_dir(&sub).unwrap();
+        let link = sub.join("link");
+        // Relative dangling symlink: the final component exists, the target does not.
+        std::os::unix::fs::symlink("../target.txt", &link).unwrap();
+
+        let key_before = canonicalize_path_key(link.to_str().unwrap());
+        // Creating through the symlink materializes the relative target.
+        std::fs::write(&link, "x\n").unwrap();
+        let key_after = canonicalize_path_key(link.to_str().unwrap());
+        let expected = dir
+            .path()
+            .join("target.txt")
+            .canonicalize()
+            .unwrap()
+            .to_string_lossy()
+            .into_owned();
+
+        assert_eq!(key_before, expected);
+        assert_eq!(key_after, expected);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_canonicalize_path_key_symlink_loop_does_not_hang() {
+        let dir = tempfile::tempdir().unwrap();
+        let a = dir.path().join("a");
+        let b = dir.path().join("b");
+        std::os::unix::fs::symlink(&b, &a).unwrap();
+        std::os::unix::fs::symlink(&a, &b).unwrap();
+
+        let key = canonicalize_path_key(a.to_str().unwrap());
+        let expected = dir
+            .path()
+            .canonicalize()
+            .unwrap()
+            .join("a")
+            .to_string_lossy()
+            .into_owned();
+        assert_eq!(key, expected);
     }
 
     // =========================================================================

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,6 @@
 use crate::error::GitAiError;
 use std::io::IsTerminal;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
 static IS_TERMINAL: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
@@ -8,6 +8,38 @@ static IS_TERMINAL: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
 #[inline]
 pub fn normalize_to_posix(path: &str) -> String {
     path.replace('\\', "/")
+}
+
+/// Stable path key for maps that must match before and after a file is created.
+///
+/// `std::fs::canonicalize` fails for paths that do not exist yet, so a naive
+/// `canonicalize(...).unwrap_or(raw)` stores the raw path at AI PreToolUse and a
+/// resolved path (symlink-expanded) once the file exists — e.g. macOS
+/// `/var` → `/private/var`, or an explicit workdir symlink. Walk up to the
+/// longest existing ancestor, canonicalize that, and re-join the missing
+/// suffix so both sides share the same key.
+pub fn canonicalize_path_key(path: &str) -> String {
+    let path = Path::new(path);
+    let mut suffix: Vec<std::ffi::OsString> = Vec::new();
+    let mut cursor = path;
+    loop {
+        if let Ok(canonical) = std::fs::canonicalize(cursor) {
+            let mut result = canonical;
+            for part in suffix.iter().rev() {
+                result.push(part);
+            }
+            return result.to_string_lossy().into_owned();
+        }
+        match (cursor.file_name(), cursor.parent()) {
+            (Some(name), Some(parent)) if !parent.as_os_str().is_empty() => {
+                suffix.push(name.to_owned());
+                cursor = parent;
+            }
+            _ => break,
+        }
+    }
+
+    path.to_string_lossy().into_owned()
 }
 
 fn resolve_git_ai_exe_from_invocation_path(path: PathBuf) -> PathBuf {
@@ -481,6 +513,49 @@ pub fn write_json_file<T: serde::Serialize>(path: &std::path::Path, value: &T) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // =========================================================================
+    // canonicalize_path_key
+    // =========================================================================
+
+    #[test]
+    fn test_canonicalize_path_key_matches_before_and_after_create() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("new.txt");
+        let before = canonicalize_path_key(file.to_str().unwrap());
+        assert!(!file.exists());
+        std::fs::write(&file, "hi\n").unwrap();
+        let after = canonicalize_path_key(file.to_str().unwrap());
+        assert_eq!(
+            before, after,
+            "pending-AI path keys must match across file creation"
+        );
+        assert_eq!(after, file.canonicalize().unwrap().to_string_lossy());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_canonicalize_path_key_resolves_symlink_parent_for_missing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let real = dir.path().join("real");
+        std::fs::create_dir(&real).unwrap();
+        let link = dir.path().join("link");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        let via_link = link.join("created.txt");
+        let key_before = canonicalize_path_key(via_link.to_str().unwrap());
+        std::fs::write(real.join("created.txt"), "x\n").unwrap();
+        let key_after = canonicalize_path_key(via_link.to_str().unwrap());
+        let expected = real
+            .join("created.txt")
+            .canonicalize()
+            .unwrap()
+            .to_string_lossy()
+            .into_owned();
+
+        assert_eq!(key_before, expected);
+        assert_eq!(key_after, expected);
+    }
 
     // =========================================================================
     // JSON cache file helpers

--- a/tests/integration/github_copilot_create_file.rs
+++ b/tests/integration/github_copilot_create_file.rs
@@ -420,3 +420,80 @@ fn test_create_file_ignores_top_level_edited_filepaths() {
     new_file.assert_lines_and_blame(crate::lines!["print(\"new\")".ai()]);
     old_file.assert_lines_and_blame(crate::lines!["print(\"old\")".human()]);
 }
+
+/// Regression for #2221: Copilot create_file Pre fires before the file exists,
+/// then a KnownHuman save lands before Post. The new file must still be AI.
+#[cfg(unix)]
+#[test]
+fn test_create_file_known_human_race_before_disk_write() {
+    use std::fs;
+
+    let repo = TestRepo::new();
+    let mut initial_file = repo.filename("README.md");
+    initial_file.set_contents(crate::lines!["# Test repo"]);
+    repo.stage_all_and_commit("Initial commit").unwrap();
+
+    let real_dir = repo.path().join("realdir");
+    fs::create_dir(&real_dir).unwrap();
+    let link_dir = repo.path().join("linkdir");
+    std::os::unix::fs::symlink(&real_dir, &link_dir).unwrap();
+
+    let via_link = link_dir.join("new_file.py");
+    let content = "print(\"hello world\")\n";
+    assert!(!via_link.exists());
+
+    let pre_hook_input = json!({
+        "timestamp": "2026-04-09T17:36:05.881Z",
+        "hook_event_name": "PreToolUse",
+        "session_id": "b4a517c6-b9f0-4787-af3a-7c002539b448",
+        "transcript_path": fake_copilot_transcript_path(&repo),
+        "tool_name": "create_file",
+        "tool_input": {
+            "filePath": via_link.to_str().unwrap(),
+            "content": content,
+        },
+        "tool_use_id": "call_create_race_pre",
+        "cwd": repo.path().to_str().unwrap()
+    });
+    repo.git_ai(&[
+        "checkpoint",
+        "github-copilot",
+        "--hook-input",
+        &pre_hook_input.to_string(),
+    ])
+    .unwrap();
+
+    // Disk write + spurious KnownHuman save (VS Code onDidSave) before Post.
+    fs::write(real_dir.join("new_file.py"), content).unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", via_link.to_str().unwrap()])
+        .unwrap();
+
+    let post_hook_input = json!({
+        "timestamp": "2026-04-09T17:36:05.970Z",
+        "hook_event_name": "PostToolUse",
+        "session_id": "b4a517c6-b9f0-4787-af3a-7c002539b448",
+        "transcript_path": fake_copilot_transcript_path(&repo),
+        "tool_name": "create_file",
+        "tool_input": {
+            "filePath": via_link.to_str().unwrap(),
+            "content": content,
+        },
+        "tool_response": "",
+        "tool_use_id": "call_create_race_post",
+        "cwd": repo.path().to_str().unwrap()
+    });
+    repo.git_ai(&[
+        "checkpoint",
+        "github-copilot",
+        "--hook-input",
+        &post_hook_input.to_string(),
+    ])
+    .unwrap();
+
+    repo.sync_daemon();
+    repo.git(&["add", "realdir/new_file.py"]).unwrap();
+    repo.commit("Create new file via Copilot").unwrap();
+
+    let mut file = repo.filename("realdir/new_file.py");
+    file.assert_committed_lines(crate::lines!["print(\"hello world\")".ai()]);
+}

--- a/tests/integration/pending_ai_edit_suppression.rs
+++ b/tests/integration/pending_ai_edit_suppression.rs
@@ -11,6 +11,10 @@ fn fire_pre_edit_checkpoint(repo: &TestRepo, file_paths: &[&str]) {
         .iter()
         .map(|p| repo.path().join(p).to_string_lossy().to_string())
         .collect();
+    fire_pre_edit_checkpoint_abs(repo, &abs_paths);
+}
+
+fn fire_pre_edit_checkpoint_abs(repo: &TestRepo, abs_paths: &[String]) {
     let payload = json!({
         "type": "human",
         "repo_working_dir": repo.path().to_string_lossy().to_string(),
@@ -313,4 +317,50 @@ fn test_multi_file_known_human_partial_suppression() {
         "human_file.txt's new line should be KnownHuman-attributed (not suppressed). Stats: {}",
         serde_json::to_string_pretty(&stats).unwrap()
     );
+}
+
+/// Regression for #2221: agent creates a *new* file under a symlinked path.
+/// Pre-edit registers pending state while the file does not exist yet
+/// (`canonicalize` fails); after the write, KnownHuman's path resolves through
+/// the symlink to a different string. Suppression must still match so the AI
+/// post-edit owns the lines instead of KnownHuman.
+#[cfg(unix)]
+#[test]
+fn test_known_human_suppressed_for_new_file_under_symlinked_path() {
+    let repo = TestRepo::new();
+    fs::write(repo.path().join("README.md"), "# init\n").unwrap();
+    repo.stage_all_and_commit("Initial commit").unwrap();
+
+    let real_dir = repo.path().join("realdir");
+    fs::create_dir(&real_dir).unwrap();
+    let link_dir = repo.path().join("linkdir");
+    std::os::unix::fs::symlink(&real_dir, &link_dir).unwrap();
+
+    let via_link = link_dir.join("created.txt");
+    assert!(
+        !via_link.exists(),
+        "file must not exist yet when Pre registers pending AI edit"
+    );
+
+    // Pre through the symlink path — canonicalize fails, historically stored the raw path.
+    fire_pre_edit_checkpoint_abs(&repo, &[via_link.to_string_lossy().to_string()]);
+
+    // Agent writes the new file (content visible via both link and real path).
+    fs::write(real_dir.join("created.txt"), "ai created\n").unwrap();
+
+    // Spurious IDE save after the write: path now canonicalizes through the symlink.
+    repo.git_ai(&[
+        "checkpoint",
+        "mock_known_human",
+        via_link.to_str().expect("utf-8 path"),
+    ])
+    .unwrap();
+
+    fire_post_edit_checkpoint(&repo, &[via_link.to_str().expect("utf-8 path")]);
+
+    repo.git(&["add", "realdir/created.txt"]).unwrap();
+    repo.commit("AI created new file").unwrap();
+
+    let mut file = repo.filename("realdir/created.txt");
+    file.assert_committed_lines(lines!["ai created".ai()]);
 }


### PR DESCRIPTION
## Summary
- Stable pending-AI path keys for not-yet-created files (`canonicalize_path_key`) so KnownHuman saves after `create_file` no longer miss suppression on symlink / macOS `/var` paths.
- Prefer `tool_input.content` on VS Code Copilot `create_file` PostToolUse instead of relying on the 80ms disk-flush race.
- Add regression tests covering the Pre → write → KnownHuman → Post race for new files under a symlinked path.

Fixes #2221.

## Follow-ups (out of scope)
- Harden `build_checkpoint_files` so missing files are not silently treated as empty for AI checkpoints.
- Restrict `should_recover_remaining_as_known_human` so mixed commits with AI attestations do not stamp remaining lines as `h_`.

## Test plan
- [x] `cargo fmt -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --lib canonicalize_path_key`
- [x] `cargo test --lib test_copilot_native_create_file`
- [x] `cargo test --test integration github_copilot_create_file`
- [x] `cargo test --test integration pending_ai_edit_suppression`
- [ ] CI Ubuntu lint / tests


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/2289" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->