### PR TITLE
fix(daemon): retry lock acquisition to survive transient lock-file holders

### DIFF
--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -256,6 +256,14 @@ pub(crate) fn ensure_daemon_running(
     }
 }
 
+/// How long the pre-spawn probe tolerates a held lock before reporting the
+/// daemon as blocked. Transient holders (Windows antivirus/indexer opens of
+/// the lock file) clear within milliseconds; a live daemon holds the lock for
+/// its lifetime, so a genuinely blocked start still reports quickly. Kept
+/// well below the daemon's own 3s acquire budget: the probe only avoids
+/// spawning a doomed process, it is not the correctness gate.
+const DAEMON_STARTUP_PROBE_LOCK_TIMEOUT: Duration = Duration::from_millis(500);
+
 fn daemon_startup_is_blocked(config: &DaemonConfig) -> bool {
     if let Some(parent) = config.lock_path.parent()
         && std::fs::create_dir_all(parent).is_err()
@@ -263,7 +271,7 @@ fn daemon_startup_is_blocked(config: &DaemonConfig) -> bool {
         return false;
     }
 
-    match LockFile::try_acquire(&config.lock_path) {
+    match LockFile::acquire_with_timeout(&config.lock_path, DAEMON_STARTUP_PROBE_LOCK_TIMEOUT) {
         Some(lock) => {
             drop(lock);
             false

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -474,16 +474,26 @@ pub struct DaemonLock {
     _lock: LockFile,
 }
 
+/// How long daemon startup keeps retrying the lock before concluding another
+/// daemon genuinely holds it. Transient holders (Windows antivirus/indexer
+/// scans of the freshly created lock file, the previous daemon's handle a
+/// beat away from release during a restart handover) clear within
+/// milliseconds; a live daemon holds the lock for its entire lifetime, so a
+/// few seconds cleanly separates the two. Startup is not latency-sensitive,
+/// and the happy path still acquires on the first attempt with no delay.
+const DAEMON_LOCK_ACQUIRE_TIMEOUT: Duration = Duration::from_secs(3);
+
 impl DaemonLock {
     pub fn acquire(path: &Path) -> Result<Self, GitAiError> {
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent)?;
         }
-        let lock = LockFile::try_acquire(path).ok_or_else(|| {
-            GitAiError::Generic(
-                "git-ai background service is already running (lock held)".to_string(),
-            )
-        })?;
+        let lock =
+            LockFile::acquire_with_timeout(path, DAEMON_LOCK_ACQUIRE_TIMEOUT).ok_or_else(|| {
+                GitAiError::Generic(
+                    "git-ai background service is already running (lock held)".to_string(),
+                )
+            })?;
         Ok(Self { _lock: lock })
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -299,6 +299,36 @@ impl LockFile {
         let file = try_lock_exclusive(path)?;
         Some(Self { _file: file })
     }
+
+    /// As [`Self::try_acquire`], but retries until `timeout` elapses.
+    ///
+    /// A failed acquisition does not necessarily mean a competing holder of
+    /// the *lock*: on Windows the exclusive-share open loses to any transient
+    /// reader of the file — antivirus and indexer services routinely open
+    /// freshly created files for a few milliseconds — and on every platform a
+    /// process handover can race the previous holder's release by a beat. A
+    /// genuinely held lock stays held for far longer than any sane `timeout`,
+    /// so retrying cleanly separates transient opens from real contention.
+    /// Costs nothing when the first attempt succeeds.
+    pub fn acquire_with_timeout(
+        path: &std::path::Path,
+        timeout: std::time::Duration,
+    ) -> Option<Self> {
+        const RETRY_INTERVAL: std::time::Duration = std::time::Duration::from_millis(25);
+        let deadline = std::time::Instant::now() + timeout;
+        loop {
+            if let Some(lock) = Self::try_acquire(path) {
+                return Some(lock);
+            }
+            let now = std::time::Instant::now();
+            if now >= deadline {
+                return None;
+            }
+            // Cap the sleep to the remaining budget so the wait cannot
+            // overshoot `timeout` by more than one final attempt.
+            std::thread::sleep(RETRY_INTERVAL.min(deadline - now));
+        }
+    }
 }
 
 #[cfg(unix)]
@@ -548,6 +578,72 @@ mod tests {
         assert!(
             second.is_some(),
             "should acquire lock after previous holder is dropped"
+        );
+    }
+
+    #[test]
+    fn test_lockfile_acquire_with_timeout_survives_transient_holder() {
+        let dir = tempfile::tempdir().unwrap();
+        let lock_path = dir.path().join("test.lock");
+        let held = LockFile::try_acquire(&lock_path).expect("first acquire should succeed");
+        let release = std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_millis(200));
+            drop(held);
+        });
+
+        let started = std::time::Instant::now();
+        let lock = LockFile::acquire_with_timeout(&lock_path, std::time::Duration::from_secs(5));
+        release.join().expect("release thread panicked");
+        assert!(
+            lock.is_some(),
+            "acquisition should succeed once the transient holder releases"
+        );
+        assert!(
+            started.elapsed() < std::time::Duration::from_secs(5),
+            "acquisition should not exhaust the timeout"
+        );
+    }
+
+    #[test]
+    fn test_lockfile_acquire_with_timeout_fails_against_persistent_holder() {
+        let dir = tempfile::tempdir().unwrap();
+        let lock_path = dir.path().join("test.lock");
+        let _held = LockFile::try_acquire(&lock_path).expect("first acquire should succeed");
+
+        let budget = std::time::Duration::from_millis(200);
+        let started = std::time::Instant::now();
+        let lock = LockFile::acquire_with_timeout(&lock_path, budget);
+        assert!(
+            lock.is_none(),
+            "acquisition must fail while the lock stays held"
+        );
+        assert!(
+            started.elapsed() >= budget,
+            "acquisition should keep retrying until the timeout elapses"
+        );
+    }
+
+    #[test]
+    fn test_lockfile_acquire_with_timeout_shorter_than_retry_interval() {
+        let dir = tempfile::tempdir().unwrap();
+        let lock_path = dir.path().join("test.lock");
+
+        // A free lock must still acquire immediately regardless of budget.
+        let tiny = std::time::Duration::from_millis(5);
+        assert!(
+            LockFile::acquire_with_timeout(&lock_path, tiny).is_some(),
+            "free lock should acquire on the first attempt"
+        );
+
+        // A held lock with a budget below the retry interval must fail
+        // without overshooting the budget by more than one capped sleep.
+        let _held = LockFile::try_acquire(&lock_path).expect("first acquire should succeed");
+        let started = std::time::Instant::now();
+        let lock = LockFile::acquire_with_timeout(&lock_path, tiny);
+        assert!(lock.is_none(), "held lock must fail within a tiny budget");
+        assert!(
+            started.elapsed() < std::time::Duration::from_millis(100),
+            "tiny budgets must not stretch to a full retry interval cycle"
         );
     }
 

--- a/tests/daemon_mode.rs
+++ b/tests/daemon_mode.rs
@@ -1199,6 +1199,41 @@ fn checkpoint_fails_hard_when_daemon_startup_is_blocked() {
     drop(held_lock);
 }
 
+/// The daemon's lock acquisition must tolerate a transient holder of the
+/// lock file. On Windows CI the exclusive-share open loses to antivirus and
+/// indexer scans of the freshly created `daemon.lock` (any open of the file
+/// defeats `share_mode(0)`), which made cold daemon starts flake with
+/// "background service is already running (lock held)" even though no other
+/// daemon existed; a self-restart handover can race the previous holder's
+/// release the same way. A short-lived holder must not abort startup.
+#[test]
+fn daemon_startup_tolerates_transient_lock_file_holder() {
+    let mut repo = TestRepo::new_with_daemon_scope(DaemonTestScope::NoDaemon);
+
+    let lock_path = daemon_lock_path(&repo);
+    fs::create_dir_all(
+        lock_path
+            .parent()
+            .expect("daemon lock path should have a parent"),
+    )
+    .expect("failed to create daemon lock parent directory");
+    let held = git_ai::utils::LockFile::try_acquire(&lock_path)
+        .expect("test should pre-hold the daemon lock");
+    let release = thread::spawn(move || {
+        thread::sleep(Duration::from_millis(750));
+        drop(held);
+    });
+
+    // Panics "daemon exited before becoming ready ... lock held" without the
+    // bounded startup retry.
+    repo.start_dedicated_daemon_for_test();
+    release.join().expect("lock release thread panicked");
+
+    let response = send_control_request(&daemon_control_socket_path(&repo), &ControlRequest::Ping)
+        .expect("daemon should serve control requests after the transient holder released");
+    assert!(response.ok, "ping failed: {response:?}");
+}
+
 #[test]
 #[cfg(windows)]
 #[serial]


### PR DESCRIPTION
## Problem

Windows CI intermittently fails random `cold_trace2_repo` tests with the harness panic:

```
daemon exited before becoming ready (pid …, status exit code: 1): …
Failed to run: Generic error: git-ai background service is already running (lock held)
```

Observed on `main` ([run 32980538590](https://github.com/git-ai-project/git-ai/actions/runs/32980538590), 2026-08-26) and repeatedly on PR shards ([#2255 attempt 1](https://github.com/git-ai-project/git-ai/actions/runs/33424164679/job/99593578797) and [attempt 2](https://github.com/git-ai-project/git-ai/actions/runs/33424164679/job/100416626391) — different tests each time, same signature). Each occurrence costs a ~28-minute shard rerun.

## Root cause

There is no competing daemon: the failing homes are fresh per-test temp directories, test builds never auto-spawn daemons, and pipe names/lock paths are per-home. The culprit is `LockFile`'s Windows implementation: `try_lock_exclusive` opens the lock file with `share_mode(0)` and maps **any** open failure to "another process holds the lock". With zero sharing, the open fails with a sharing violation whenever *anything* has the file open — and on Windows CI runners, antivirus/indexer services routinely open freshly created files for a few milliseconds. The daemon's one-shot `DaemonLock::acquire` then aborts startup with "already running (lock held)".

This explains every property of the flake: Windows-only (Unix `flock` doesn't conflict with mere opens), brand-new homes, random distribution across whichever cold-start tests lose the race, load-correlated, and present on `main` long before recent changes. The same one-shot acquire can also race a self-restart handover (previous holder a beat away from releasing) on any platform.

## Fix

`LockFile::acquire_with_timeout(path, timeout)`: retry `try_acquire` at 25ms intervals until the budget elapses. Daemon startup (`DaemonLock::acquire`) uses it with a 3s budget. A genuinely held lock stays held for the owner's entire lifetime, so the budget cleanly separates transient opens from real contention — a real double-start still fails, just 3s later on that already-failing path.

**CI cost: zero on the happy path, net negative overall.** The first attempt succeeding (the normal case) takes exactly one open, same as before; a transient scan now costs one-or-two 25ms retries instead of a failed test and a 28-minute shard rerun. Sleeps are capped to the remaining budget, so short timeouts cannot overshoot. The launcher-side probe (`daemon_startup_is_blocked`) gets the same tolerance with a smaller 500ms budget, so a transient open cannot make `ensure_daemon_running` bail before ever spawning; a genuinely blocked start still reports within 500ms.

## Tests (TDD — red before the fix)

- `daemon_startup_tolerates_transient_lock_file_holder` (integration, runs on all platforms including Windows): pre-holds the daemon home's `daemon.lock`, releases it after 750ms, and starts a dedicated daemon through the same harness path the flaking cold tests use. Reproduces the exact CI panic without the fix; daemon comes up and serves pings with it.
- `test_lockfile_acquire_with_timeout_survives_transient_holder` / `…_fails_against_persistent_holder` / `…_shorter_than_retry_interval` (unit): deterministic coverage of the retry semantics, the bounded failure, and sub-interval budgets.
