### PR TITLE
fix(attribution): stop cross-repo Cursor session borrowing, backfill known model

### DIFF
--- a/src/authorship/attribution_recovery.rs
+++ b/src/authorship/attribution_recovery.rs
@@ -553,7 +553,8 @@ fn recover_session_event_mtime(
         insert_session_event_record(authorship_log, candidate, human_author);
         add_attestation(authorship_log, &file_path, &author_id, &unknown_lines);
 
-        let selected_model = session_event_model(candidate);
+        let selected_model = recovery_model_for_session(authorship_log, &candidate.session_id)
+            .unwrap_or_else(|| session_event_model(candidate));
         let metadata = json!({
             "solver": "session_event_mtime",
             "file_path": file_path.as_str(),
@@ -641,6 +642,8 @@ fn recover_commit_metadata(
             human_author: Some(human_author.to_string()),
             custom_attributes: None,
         });
+    let selected_model = recovery_model_for_session(authorship_log, &selection.session_id)
+        .unwrap_or_else(|| selection.agent_id.model.clone());
 
     let detected_agents = detections
         .iter()
@@ -672,7 +675,7 @@ fn recover_commit_metadata(
             "selection_tier": selection.tier,
             "selected_session_id": selection.session_id.as_str(),
             "selected_tool": selection.agent_id.tool.as_str(),
-            "selected_model": selection.agent_id.model.as_str(),
+            "selected_model": selected_model.as_str(),
             "selected_external_session_id": selection.agent_id.id.as_str(),
             "selected_external_tool_use_id": selection.external_tool_use_id.as_deref(),
             "selected_repo_url": selection.repo_url.as_deref(),
@@ -692,7 +695,7 @@ fn recover_commit_metadata(
             session_id: &selection.session_id,
             trace_id: &trace_id,
             tool: &selection.agent_id.tool,
-            model: &selection.agent_id.model,
+            model: &selected_model,
             external_session_id: &selection.agent_id.id,
             external_tool_use_id: selection.external_tool_use_id.as_deref(),
             edit_kind: "attribution_recovery_commit_metadata",
@@ -1209,21 +1212,20 @@ fn select_latest_commit_metadata_metric_session(
                 return Ok(None);
             }
         };
-        if let Some((candidate, _)) = candidates
+        // Only an exact repo_url match is safe here: this fallback has no
+        // time window. Unscoped Cursor session events (no repo_url) would
+        // otherwise attach whatever Cursor session last ran on the machine.
+        if let Some(candidate) = candidates
             .iter()
-            .filter_map(|candidate| {
-                let repo_tier = commit_metadata_metric_repo_tier(candidate, target_repo_url)?;
-                Some((candidate, repo_tier))
+            .filter(|candidate| {
+                commit_metadata_metric_repo_tier(candidate, target_repo_url)
+                    == Some(CommitMetadataMetricRepoTier::SameRepoUrl)
             })
-            .min_by(
-                |(left_candidate, left_tier), (right_candidate, right_tier)| {
-                    left_tier
-                        .score()
-                        .cmp(&right_tier.score())
-                        .then_with(|| right_candidate.event_ts.cmp(&left_candidate.event_ts))
-                        .then_with(|| right_candidate.row_id.cmp(&left_candidate.row_id))
-                },
-            )
+            .max_by(|left, right| {
+                left.event_ts
+                    .cmp(&right.event_ts)
+                    .then_with(|| left.row_id.cmp(&right.row_id))
+            })
         {
             return Ok(Some(commit_metadata_selection_from_metric_candidate(
                 candidate,
@@ -1686,6 +1688,15 @@ fn session_event_model(candidate: &SessionEventRecoveryCandidate) -> String {
         .clone()
         .filter(|model| !model.is_empty())
         .unwrap_or_else(|| "unknown".to_string())
+}
+
+fn recovery_model_for_session(authorship_log: &AuthorshipLog, session_id: &str) -> Option<String> {
+    authorship_log
+        .metadata
+        .sessions
+        .get(session_id)
+        .map(|session| session.agent_id.model.clone())
+        .filter(|model| !model.is_empty() && model != "unknown")
 }
 
 fn unknown_lines_by_file(
@@ -2541,6 +2552,79 @@ mod tests {
         assert!(
             should_recover_remaining_as_known_human(&log),
             "a landed known-human attestation must enable recovery"
+        );
+    }
+
+    /// Session-event candidates for Cursor rarely carry a model, but the
+    /// session they belong to is often already known from other lines in
+    /// the same commit (recorded via a normal checkpoint). Recovery must
+    /// reuse that already-known model instead of writing "unknown" into the
+    /// recovery metric when a real model is on record for the session.
+    #[test]
+    fn recovery_model_for_session_reuses_known_model() {
+        let mut log = AuthorshipLog::new();
+        log.metadata.sessions.insert(
+            "s_known".to_string(),
+            SessionRecord {
+                agent_id: AgentId {
+                    tool: "cursor".to_string(),
+                    id: "cursor-session".to_string(),
+                    model: "grok-4.5".to_string(),
+                },
+                human_author: None,
+                custom_attributes: None,
+            },
+        );
+
+        assert_eq!(
+            recovery_model_for_session(&log, "s_known"),
+            Some("grok-4.5".to_string()),
+            "a session with a known model must be reused instead of falling back to unknown"
+        );
+    }
+
+    #[test]
+    fn recovery_model_for_session_falls_back_when_model_is_unknown_or_missing() {
+        let mut log = AuthorshipLog::new();
+        log.metadata.sessions.insert(
+            "s_unknown".to_string(),
+            SessionRecord {
+                agent_id: AgentId {
+                    tool: "cursor".to_string(),
+                    id: "cursor-session".to_string(),
+                    model: "unknown".to_string(),
+                },
+                human_author: None,
+                custom_attributes: None,
+            },
+        );
+        log.metadata.sessions.insert(
+            "s_empty".to_string(),
+            SessionRecord {
+                agent_id: AgentId {
+                    tool: "cursor".to_string(),
+                    id: "cursor-session".to_string(),
+                    model: String::new(),
+                },
+                human_author: None,
+                custom_attributes: None,
+            },
+        );
+
+        assert_eq!(
+            recovery_model_for_session(&log, "s_unknown"),
+            None,
+            "a session recorded as unknown must not shadow the candidate's own model lookup"
+        );
+        assert_eq!(
+            recovery_model_for_session(&log, "s_empty"),
+            None,
+            "a session with an empty model must not shadow the candidate's own model lookup"
+        );
+        assert_eq!(
+            recovery_model_for_session(&log, "s_missing"),
+            None,
+            "a session that has not been recorded yet must fall back to the candidate's model"
         );
     }
 

--- a/src/authorship/attribution_recovery.rs
+++ b/src/authorship/attribution_recovery.rs
@@ -1188,6 +1188,14 @@ fn select_latest_commit_metadata_metric_session(
     target_repo_url: Option<&str>,
     metrics_db_unavailable: &mut bool,
 ) -> Result<Option<CommitMetadataSessionSelection>, GitAiError> {
+    // Only an exact repo_url match is safe here: this fallback has no time
+    // window, so an unscoped session (no repo_url) could belong to any
+    // commit on the machine. Without a target repo there is nothing to
+    // match against, and the metrics DB does not need to be consulted.
+    let Some(target_repo_url) = target_repo_url else {
+        return Ok(None);
+    };
+
     let db = match crate::metrics::db::MetricsDatabase::global() {
         Ok(db) => db,
         Err(_) => {
@@ -1204,31 +1212,19 @@ fn select_latest_commit_metadata_metric_session(
     };
 
     for detection in detections {
-        let candidates = match db.latest_session_event_candidates_for_tools(detection.kind.tools) {
-            Ok(candidates) => candidates,
+        let candidate = match db
+            .latest_session_event_candidate_for_repo(detection.kind.tools, target_repo_url)
+        {
+            Ok(candidate) => candidate,
             Err(error) => {
                 tracing::debug!(%error, "latest session-event candidate query failed");
                 *metrics_db_unavailable = true;
                 return Ok(None);
             }
         };
-        // Only an exact repo_url match is safe here: this fallback has no
-        // time window. Unscoped Cursor session events (no repo_url) would
-        // otherwise attach whatever Cursor session last ran on the machine.
-        if let Some(candidate) = candidates
-            .iter()
-            .filter(|candidate| {
-                commit_metadata_metric_repo_tier(candidate, target_repo_url)
-                    == Some(CommitMetadataMetricRepoTier::SameRepoUrl)
-            })
-            .max_by(|left, right| {
-                left.event_ts
-                    .cmp(&right.event_ts)
-                    .then_with(|| left.row_id.cmp(&right.row_id))
-            })
-        {
+        if let Some(candidate) = candidate {
             return Ok(Some(commit_metadata_selection_from_metric_candidate(
-                candidate,
+                &candidate,
                 "latest_matching_tool_session",
                 None,
             )));
@@ -2104,10 +2100,16 @@ mod tests {
         // temp dir so the open connection never points at a deleted file.
         std::mem::forget(dir);
 
+        // A target repo is required for the DB to be consulted at all: with
+        // no target repo an exact repo_url match can never succeed, so the
+        // busy-DB path below would never be reached otherwise.
+        let target_repo_url = Some("https://github.com/acme/repo");
+
         // Uncontended: the DB is consulted and the flag stays clear.
         let mut unavailable = false;
         let selection =
-            select_latest_commit_metadata_metric_session(&[], None, &mut unavailable).unwrap();
+            select_latest_commit_metadata_metric_session(&[], target_repo_url, &mut unavailable)
+                .unwrap();
         assert!(selection.is_none());
         assert!(!unavailable, "an uncontended DB must count as consulted");
 
@@ -2115,10 +2117,13 @@ mod tests {
         // caller mistake a busy DB for "no matching AI session" (which would
         // end in AI lines being attributed to the human author).
         let _held = db.lock().unwrap();
-        let checker = std::thread::spawn(|| {
+        let checker = std::thread::spawn(move || {
             let mut unavailable = false;
-            let selection =
-                select_latest_commit_metadata_metric_session(&[], None, &mut unavailable);
+            let selection = select_latest_commit_metadata_metric_session(
+                &[],
+                target_repo_url,
+                &mut unavailable,
+            );
             (selection, unavailable)
         });
         let (selection, unavailable) = checker.join().unwrap();

--- a/src/metrics/db.rs
+++ b/src/metrics/db.rs
@@ -1140,12 +1140,25 @@ impl MetricsDatabase {
         Ok(candidates)
     }
 
-    pub(crate) fn latest_session_event_candidates_for_tools(
+    /// Find the newest session-event row for any of `tools` whose repo_url
+    /// exactly matches `target_repo_url`.
+    ///
+    /// This deliberately does not `LIMIT` the underlying query before
+    /// checking `repo_url`: a busy machine can produce well over a hundred
+    /// more-recent session events for other or unscoped repositories, and
+    /// truncating first would make an older, genuinely matching same-repo
+    /// session invisible -- recovery would then mint a session that never
+    /// existed instead of finding the real one. Rows are still consumed in
+    /// `event_ts DESC, id DESC` order and the first repo_url match wins, so
+    /// the result stays deterministic; the scan simply stops as soon as a
+    /// match is found.
+    pub(crate) fn latest_session_event_candidate_for_repo(
         &self,
         tools: &[&str],
-    ) -> Result<Vec<SessionEventRecoveryCandidate>, GitAiError> {
+        target_repo_url: &str,
+    ) -> Result<Option<SessionEventRecoveryCandidate>, GitAiError> {
         if tools.is_empty() {
-            return Ok(Vec::new());
+            return Ok(None);
         }
 
         let placeholders = std::iter::repeat_n("?", tools.len())
@@ -1174,7 +1187,6 @@ impl MetricsDatabase {
               AND external_session_id IS NOT NULL
               AND external_session_id != ''
             ORDER BY event_ts DESC, id DESC
-            LIMIT 100
             "#
         );
 
@@ -1202,7 +1214,6 @@ impl MetricsDatabase {
             ))
         })?;
 
-        let mut candidates = Vec::new();
         for row in rows {
             let (
                 row_id,
@@ -1219,7 +1230,11 @@ impl MetricsDatabase {
             }
 
             let (repo_url, model) = recovery_attrs_from_event_json(&event_json);
-            candidates.push(SessionEventRecoveryCandidate {
+            if repo_url.as_deref() != Some(target_repo_url) {
+                continue;
+            }
+
+            return Ok(Some(SessionEventRecoveryCandidate {
                 row_id,
                 event_ts: event_ts as u32,
                 session_id,
@@ -1229,10 +1244,10 @@ impl MetricsDatabase {
                 external_session_id,
                 external_tool_use_id,
                 repo_url,
-            });
+            }));
         }
 
-        Ok(candidates)
+        Ok(None)
     }
 
     /// Backfill cached event metadata for one bounded batch of legacy rows.
@@ -2359,6 +2374,73 @@ mod tests {
             candidate.repo_url.as_deref(),
             Some("https://github.com/acme/repo")
         );
+    }
+
+    /// A busy machine can easily produce more than 100 newer session events
+    /// for the same tool from other (or unscoped) repositories. The latest-
+    /// session query must not truncate before checking repo_url, or a valid
+    /// older same-repo session becomes invisible and recovery mints a
+    /// session that never existed instead of finding the real one.
+    #[test]
+    fn test_latest_session_event_candidate_for_repo_finds_match_past_first_hundred() {
+        let (mut db, _temp_dir) = create_test_db();
+        let base_ts = seconds_ago(1_000);
+
+        let mut events = Vec::new();
+        for i in 0..150u32 {
+            events.push(session_event_json(
+                base_ts + 1_000 + i,
+                &format!("session-foreign-{i}"),
+                &format!("external-foreign-{i}"),
+                "cursor",
+                Some("https://github.com/other/repo"),
+            ));
+        }
+        events.push(session_event_json(
+            base_ts,
+            "session-same-repo",
+            "external-same-repo",
+            "cursor",
+            Some("https://github.com/acme/repo"),
+        ));
+        db.insert_events(&events).unwrap();
+
+        let candidate = db
+            .latest_session_event_candidate_for_repo(&["cursor"], "https://github.com/acme/repo")
+            .unwrap()
+            .expect("an older same-repo session must still be found");
+
+        assert_eq!(candidate.session_id, "session-same-repo");
+    }
+
+    #[test]
+    fn test_latest_session_event_candidate_for_repo_picks_newest_matching_row() {
+        let (mut db, _temp_dir) = create_test_db();
+        let base_ts = seconds_ago(60);
+        db.insert_events(&[
+            session_event_json(
+                base_ts,
+                "session-older",
+                "external-older",
+                "cursor",
+                Some("https://github.com/acme/repo"),
+            ),
+            session_event_json(
+                base_ts + 10,
+                "session-newer",
+                "external-newer",
+                "cursor",
+                Some("https://github.com/acme/repo"),
+            ),
+        ])
+        .unwrap();
+
+        let candidate = db
+            .latest_session_event_candidate_for_repo(&["cursor"], "https://github.com/acme/repo")
+            .unwrap()
+            .expect("a matching same-repo session must be found");
+
+        assert_eq!(candidate.session_id, "session-newer");
     }
 
     #[test]

--- a/src/metrics/db.rs
+++ b/src/metrics/db.rs
@@ -24,6 +24,8 @@ const SCHEMA_VERSION: usize = 5;
 const MAX_METRIC_UPLOAD_ATTEMPTS: u32 = 6;
 const METRIC_PROCESSING_LOCK_TIMEOUT_SECS: u64 = 10 * 60;
 pub(crate) const METADATA_BACKFILL_BATCH_SIZE: usize = 1000;
+/// Row cap for `latest_session_event_candidate_for_repo`'s scan (see there).
+const LATEST_SESSION_EVENT_SCAN_LIMIT: usize = 1000;
 const EVENT_METADATA_BACKFILL_COMPLETED_KEY: &str = "event_metadata_backfill_completed";
 const NS_PER_SECOND: u128 = 1_000_000_000;
 
@@ -1143,15 +1145,12 @@ impl MetricsDatabase {
     /// Find the newest session-event row for any of `tools` whose repo_url
     /// exactly matches `target_repo_url`.
     ///
-    /// This deliberately does not `LIMIT` the underlying query before
-    /// checking `repo_url`: a busy machine can produce well over a hundred
-    /// more-recent session events for other or unscoped repositories, and
-    /// truncating first would make an older, genuinely matching same-repo
-    /// session invisible -- recovery would then mint a session that never
-    /// existed instead of finding the real one. Rows are still consumed in
-    /// `event_ts DESC, id DESC` order and the first repo_url match wins, so
-    /// the result stays deterministic; the scan simply stops as soon as a
-    /// match is found.
+    /// Scanned newest-first under the metrics DB lock, capped at
+    /// `LATEST_SESSION_EVENT_SCAN_LIMIT` rows: unbounded would risk parsing
+    /// a year of retained history under the lock, but a small `LIMIT` (the
+    /// old `100`) can hide an older same-repo session behind newer
+    /// foreign/unscoped ones. This bound trades a documented, unlikely miss
+    /// for a predictable worst-case scan cost.
     pub(crate) fn latest_session_event_candidate_for_repo(
         &self,
         tools: &[&str],
@@ -1187,10 +1186,11 @@ impl MetricsDatabase {
               AND external_session_id IS NOT NULL
               AND external_session_id != ''
             ORDER BY event_ts DESC, id DESC
+            LIMIT ?
             "#
         );
 
-        let mut values = Vec::with_capacity(tools.len() + 1);
+        let mut values = Vec::with_capacity(tools.len() + 2);
         values.push(rusqlite::types::Value::Integer(
             MetricEventId::SessionEvent as i64,
         ));
@@ -1199,6 +1199,9 @@ impl MetricsDatabase {
                 .iter()
                 .map(|tool| rusqlite::types::Value::Text((*tool).to_string())),
         );
+        values.push(rusqlite::types::Value::Integer(
+            LATEST_SESSION_EVENT_SCAN_LIMIT as i64,
+        ));
 
         let mut stmt = self.conn.prepare(&sql)?;
         let rows = stmt.query_map(params_from_iter(values.iter()), |row| {
@@ -2411,6 +2414,41 @@ mod tests {
             .expect("an older same-repo session must still be found");
 
         assert_eq!(candidate.session_id, "session-same-repo");
+    }
+
+    /// A same-repo session past the scan bound is a documented, accepted miss.
+    #[test]
+    fn test_latest_session_event_candidate_for_repo_bounds_scan_past_the_limit() {
+        let (mut db, _temp_dir) = create_test_db();
+        let base_ts = seconds_ago(10_000);
+
+        let mut events = Vec::new();
+        for i in 0..(LATEST_SESSION_EVENT_SCAN_LIMIT as u32 + 1) {
+            events.push(session_event_json(
+                base_ts + 1_000 + i,
+                &format!("session-foreign-{i}"),
+                &format!("external-foreign-{i}"),
+                "cursor",
+                Some("https://github.com/other/repo"),
+            ));
+        }
+        events.push(session_event_json(
+            base_ts,
+            "session-same-repo",
+            "external-same-repo",
+            "cursor",
+            Some("https://github.com/acme/repo"),
+        ));
+        db.insert_events(&events).unwrap();
+
+        let candidate = db
+            .latest_session_event_candidate_for_repo(&["cursor"], "https://github.com/acme/repo")
+            .unwrap();
+
+        assert!(
+            candidate.is_none(),
+            "a same-repo session past the scan bound is an accepted, documented miss"
+        );
     }
 
     #[test]

--- a/src/metrics/db.rs
+++ b/src/metrics/db.rs
@@ -15,7 +15,7 @@ use std::path::PathBuf;
 use std::sync::{Mutex, OnceLock};
 
 /// Current schema version (must match MIGRATIONS.len())
-const SCHEMA_VERSION: usize = 5;
+const SCHEMA_VERSION: usize = 6;
 
 // This value is part of the metrics retry index schema. Changing it requires a
 // migration that rebuilds `metrics_retryable` with the same literal used by
@@ -24,8 +24,6 @@ const SCHEMA_VERSION: usize = 5;
 const MAX_METRIC_UPLOAD_ATTEMPTS: u32 = 6;
 const METRIC_PROCESSING_LOCK_TIMEOUT_SECS: u64 = 10 * 60;
 pub(crate) const METADATA_BACKFILL_BATCH_SIZE: usize = 1000;
-/// Row cap for `latest_session_event_candidate_for_repo`'s scan (see there).
-const LATEST_SESSION_EVENT_SCAN_LIMIT: usize = 1000;
 const EVENT_METADATA_BACKFILL_COMPLETED_KEY: &str = "event_metadata_backfill_completed";
 const NS_PER_SECOND: u128 = 1_000_000_000;
 
@@ -91,6 +89,14 @@ const MIGRATIONS: &[&str] = &[
             AND attempts < 6;
 
     DROP INDEX IF EXISTS metrics_pending_retry;
+    "#,
+    // Migration 5 -> 6: Cache repo_url so the latest-matching-session lookup
+    // can filter by exact repository through an index instead of scanning
+    // event_json row by row under the metrics DB lock.
+    r#"
+    CREATE INDEX IF NOT EXISTS metrics_repo_tool_kind_ts
+        ON metrics (repo_url, tool, event_kind, event_ts DESC, id DESC)
+        WHERE repo_url IS NOT NULL;
     "#,
 ];
 
@@ -162,6 +168,7 @@ struct MetricEventMetadata {
     external_event_id: Option<String>,
     external_parent_event_id: Option<String>,
     external_tool_use_id: Option<String>,
+    repo_url: Option<String>,
 }
 
 /// Database wrapper for metrics storage
@@ -374,6 +381,13 @@ impl MetricsDatabase {
         if from_version == 3 {
             self.add_event_metadata_columns()?;
         }
+        if from_version == 5 {
+            self.add_column_if_missing(
+                "metrics",
+                "repo_url",
+                "ALTER TABLE metrics ADD COLUMN repo_url TEXT DEFAULT NULL",
+            )?;
+        }
 
         let migration_sql = MIGRATIONS[from_version];
         let tx = self.conn.transaction()?;
@@ -531,9 +545,10 @@ impl MetricsDatabase {
                     external_parent_session_id,
                     external_event_id,
                     external_parent_event_id,
-                    external_tool_use_id
+                    external_tool_use_id,
+                    repo_url
                 )
-                VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
+                VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)
                 "#,
             )?;
 
@@ -569,6 +584,7 @@ impl MetricsDatabase {
                     metadata
                         .as_ref()
                         .and_then(|m| m.external_tool_use_id.as_deref()),
+                    metadata.as_ref().and_then(|m| m.repo_url.as_deref()),
                 ])?;
                 ids.push(tx.last_insert_rowid());
             }
@@ -1145,12 +1161,14 @@ impl MetricsDatabase {
     /// Find the newest session-event row for any of `tools` whose repo_url
     /// exactly matches `target_repo_url`.
     ///
-    /// Scanned newest-first under the metrics DB lock, capped at
-    /// `LATEST_SESSION_EVENT_SCAN_LIMIT` rows: unbounded would risk parsing
-    /// a year of retained history under the lock, but a small `LIMIT` (the
-    /// old `100`) can hide an older same-repo session behind newer
-    /// foreign/unscoped ones. This bound trades a documented, unlikely miss
-    /// for a predictable worst-case scan cost.
+    /// Filters on the cached, indexed `repo_url` column (`metrics_repo_tool_kind_ts`)
+    /// rather than parsing `event_json` per row: an app-level scan ordered by
+    /// recency and truncated with a `LIMIT` can always be defeated by enough
+    /// newer foreign/unscoped events, hiding a genuinely matching older
+    /// session. Filtering in SQL finds the exact match directly, however far
+    /// back it is, without holding the metrics DB lock any longer than an
+    /// indexed lookup takes. Legacy rows get `repo_url` populated by
+    /// `backfill_event_metadata`, same as the other cached columns here.
     pub(crate) fn latest_session_event_candidate_for_repo(
         &self,
         tools: &[&str],
@@ -1173,9 +1191,11 @@ impl MetricsDatabase {
                 trace_id,
                 tool,
                 external_session_id,
-                external_tool_use_id
+                external_tool_use_id,
+                repo_url
             FROM metrics
             WHERE event_kind = ?1
+              AND repo_url = ?2
               AND tool IN ({placeholders})
               AND event_ts IS NOT NULL
               AND session_id IS NOT NULL
@@ -1186,7 +1206,7 @@ impl MetricsDatabase {
               AND external_session_id IS NOT NULL
               AND external_session_id != ''
             ORDER BY event_ts DESC, id DESC
-            LIMIT ?
+            LIMIT 1
             "#
         );
 
@@ -1194,63 +1214,61 @@ impl MetricsDatabase {
         values.push(rusqlite::types::Value::Integer(
             MetricEventId::SessionEvent as i64,
         ));
+        values.push(rusqlite::types::Value::Text(target_repo_url.to_string()));
         values.extend(
             tools
                 .iter()
                 .map(|tool| rusqlite::types::Value::Text((*tool).to_string())),
         );
-        values.push(rusqlite::types::Value::Integer(
-            LATEST_SESSION_EVENT_SCAN_LIMIT as i64,
-        ));
 
         let mut stmt = self.conn.prepare(&sql)?;
-        let rows = stmt.query_map(params_from_iter(values.iter()), |row| {
-            Ok((
-                row.get::<_, i64>(0)?,
-                row.get::<_, String>(1)?,
-                row.get::<_, i64>(2)?,
-                row.get::<_, String>(3)?,
-                row.get::<_, Option<String>>(4)?,
-                row.get::<_, String>(5)?,
-                row.get::<_, String>(6)?,
-                row.get::<_, Option<String>>(7)?,
-            ))
-        })?;
+        let row = stmt
+            .query_map(params_from_iter(values.iter()), |row| {
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, i64>(2)?,
+                    row.get::<_, String>(3)?,
+                    row.get::<_, Option<String>>(4)?,
+                    row.get::<_, String>(5)?,
+                    row.get::<_, String>(6)?,
+                    row.get::<_, Option<String>>(7)?,
+                    row.get::<_, Option<String>>(8)?,
+                ))
+            })?
+            .next()
+            .transpose()?;
 
-        for row in rows {
-            let (
-                row_id,
-                event_json,
-                event_ts,
-                session_id,
-                trace_id,
-                tool,
-                external_session_id,
-                external_tool_use_id,
-            ) = row?;
-            if event_ts < 0 || event_ts > u32::MAX as i64 {
-                continue;
-            }
-
-            let (repo_url, model) = recovery_attrs_from_event_json(&event_json);
-            if repo_url.as_deref() != Some(target_repo_url) {
-                continue;
-            }
-
-            return Ok(Some(SessionEventRecoveryCandidate {
-                row_id,
-                event_ts: event_ts as u32,
-                session_id,
-                trace_id,
-                tool,
-                model,
-                external_session_id,
-                external_tool_use_id,
-                repo_url,
-            }));
+        let Some((
+            row_id,
+            event_json,
+            event_ts,
+            session_id,
+            trace_id,
+            tool,
+            external_session_id,
+            external_tool_use_id,
+            repo_url,
+        )) = row
+        else {
+            return Ok(None);
+        };
+        if event_ts < 0 || event_ts > u32::MAX as i64 {
+            return Ok(None);
         }
 
-        Ok(None)
+        let (_, model) = recovery_attrs_from_event_json(&event_json);
+        Ok(Some(SessionEventRecoveryCandidate {
+            row_id,
+            event_ts: event_ts as u32,
+            session_id,
+            trace_id,
+            tool,
+            model,
+            external_session_id,
+            external_tool_use_id,
+            repo_url,
+        }))
     }
 
     /// Backfill cached event metadata for one bounded batch of legacy rows.
@@ -1365,8 +1383,9 @@ impl MetricsDatabase {
                     external_parent_session_id = ?8,
                     external_event_id = ?9,
                     external_parent_event_id = ?10,
-                    external_tool_use_id = ?11
-                WHERE id = ?12
+                    external_tool_use_id = ?11,
+                    repo_url = ?12
+                WHERE id = ?13
                 "#,
             )?;
 
@@ -1387,6 +1406,7 @@ impl MetricsDatabase {
                     metadata.external_event_id.as_deref(),
                     metadata.external_parent_event_id.as_deref(),
                     metadata.external_tool_use_id.as_deref(),
+                    metadata.repo_url.as_deref(),
                     id,
                 ])?;
                 summary.updated += 1;
@@ -1549,6 +1569,7 @@ fn extract_metric_event_metadata(event_json: &str) -> Option<MetricEventMetadata
         external_event_id: event_specific_external_event_id(event_kind, values),
         external_parent_event_id: event_specific_external_parent_event_id(event_kind, values),
         external_tool_use_id: event_specific_external_tool_use_id(event_kind, values),
+        repo_url: sparse_object_string(attrs, attr_pos::REPO_URL),
     })
 }
 
@@ -1698,6 +1719,7 @@ mod tests {
         external_event_id: Option<String>,
         external_parent_event_id: Option<String>,
         external_tool_use_id: Option<String>,
+        repo_url: Option<String>,
     }
 
     fn metric_identifier_rows(db: &MetricsDatabase) -> Vec<MetricIdentifierRow> {
@@ -1706,7 +1728,8 @@ mod tests {
             .prepare(
                 "SELECT trace_id, session_id, parent_session_id, tool, \
                         external_session_id, external_parent_session_id, \
-                        external_event_id, external_parent_event_id, external_tool_use_id \
+                        external_event_id, external_parent_event_id, external_tool_use_id, \
+                        repo_url \
                  FROM metrics ORDER BY id ASC",
             )
             .unwrap();
@@ -1722,6 +1745,7 @@ mod tests {
                     external_event_id: row.get(6)?,
                     external_parent_event_id: row.get(7)?,
                     external_tool_use_id: row.get(8)?,
+                    repo_url: row.get(9)?,
                 })
             })
             .unwrap();
@@ -1735,6 +1759,7 @@ mod tests {
                 "e":{event_kind},
                 "v":{{}},
                 "a":{{
+                    "1":"https://github.com/acme/repo",
                     "20":"codex",
                     "23":"external-session-1",
                     "24":"session-1",
@@ -1770,7 +1795,7 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
-        assert_eq!(version, "5");
+        assert_eq!(version, "6");
 
         for column in [
             "delivered_ts",
@@ -1790,6 +1815,7 @@ mod tests {
             "external_event_id",
             "external_parent_event_id",
             "external_tool_use_id",
+            "repo_url",
         ] {
             let column_count: i64 = db
                 .conn
@@ -1866,7 +1892,7 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
-        assert_eq!(version, "5");
+        assert_eq!(version, "6");
     }
 
     #[test]
@@ -1905,7 +1931,7 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
-        assert_eq!(version, "5");
+        assert_eq!(version, "6");
         assert_eq!(db.count().unwrap(), 1);
         assert_eq!(db.count_retryable().unwrap(), 1);
     }
@@ -1948,7 +1974,7 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
-        assert_eq!(version, "5");
+        assert_eq!(version, "6");
 
         for column in [
             "delivered_ts",
@@ -1968,6 +1994,7 @@ mod tests {
             "external_event_id",
             "external_parent_event_id",
             "external_tool_use_id",
+            "repo_url",
         ] {
             assert!(db.column_exists("metrics", column).unwrap());
         }
@@ -2017,13 +2044,15 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
-        assert_eq!(version, "5");
+        assert_eq!(version, "6");
         assert!(db.column_exists("metrics", "event_ts").unwrap());
         assert!(db.column_exists("metrics", "event_kind").unwrap());
+        assert!(db.column_exists("metrics", "repo_url").unwrap());
         for index in [
             "metrics_event_ts_kind",
             "metrics_session_kind_ts",
             "metrics_parent_session_kind_ts",
+            "metrics_repo_tool_kind_ts",
         ] {
             assert_metric_index_exists(&db, index);
         }
@@ -2040,6 +2069,7 @@ mod tests {
                 external_event_id: None,
                 external_parent_event_id: None,
                 external_tool_use_id: None,
+                repo_url: None,
             }]
         );
     }
@@ -2076,7 +2106,7 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
-        assert_eq!(version, "5");
+        assert_eq!(version, "6");
         assert_metric_index_exists(&db, "metrics_retryable");
         assert_metric_index_missing(&db, "metrics_pending_retry");
         assert_eq!(db.count().unwrap(), 1);
@@ -2132,6 +2162,7 @@ mod tests {
                 external_event_id: None,
                 external_parent_event_id: None,
                 external_tool_use_id: None,
+                repo_url: Some("https://github.com/acme/repo".to_string()),
             }]
         );
     }
@@ -2214,6 +2245,7 @@ mod tests {
                     external_event_id: Some("legacy-event".to_string()),
                     external_parent_event_id: Some("legacy-parent".to_string()),
                     external_tool_use_id: Some("legacy-tool".to_string()),
+                    repo_url: None,
                 },
                 MetricIdentifierRow {
                     trace_id: Some("trace-from-attrs".to_string()),
@@ -2225,6 +2257,7 @@ mod tests {
                     external_event_id: Some("otel-event".to_string()),
                     external_parent_event_id: Some("otel-parent".to_string()),
                     external_tool_use_id: Some("otel-tool".to_string()),
+                    repo_url: None,
                 },
                 MetricIdentifierRow {
                     trace_id: None,
@@ -2236,6 +2269,7 @@ mod tests {
                     external_event_id: None,
                     external_parent_event_id: None,
                     external_tool_use_id: Some("checkpoint-tool-use".to_string()),
+                    repo_url: None,
                 },
             ]
         );
@@ -2416,14 +2450,16 @@ mod tests {
         assert_eq!(candidate.session_id, "session-same-repo");
     }
 
-    /// A same-repo session past the scan bound is a documented, accepted miss.
+    /// Filtering happens on the indexed `repo_url` column, not an
+    /// app-level scan with a `LIMIT`, so no number of newer foreign events
+    /// can hide an older same-repo session.
     #[test]
-    fn test_latest_session_event_candidate_for_repo_bounds_scan_past_the_limit() {
+    fn test_latest_session_event_candidate_for_repo_finds_match_past_a_thousand() {
         let (mut db, _temp_dir) = create_test_db();
         let base_ts = seconds_ago(10_000);
 
         let mut events = Vec::new();
-        for i in 0..(LATEST_SESSION_EVENT_SCAN_LIMIT as u32 + 1) {
+        for i in 0..1_500u32 {
             events.push(session_event_json(
                 base_ts + 1_000 + i,
                 &format!("session-foreign-{i}"),
@@ -2443,12 +2479,10 @@ mod tests {
 
         let candidate = db
             .latest_session_event_candidate_for_repo(&["cursor"], "https://github.com/acme/repo")
-            .unwrap();
+            .unwrap()
+            .expect("an older same-repo session must still be found");
 
-        assert!(
-            candidate.is_none(),
-            "a same-repo session past the scan bound is an accepted, documented miss"
-        );
+        assert_eq!(candidate.session_id, "session-same-repo");
     }
 
     #[test]
@@ -2510,6 +2544,7 @@ mod tests {
                     external_event_id: None,
                     external_parent_event_id: None,
                     external_tool_use_id: None,
+                    repo_url: None,
                 },
                 MetricIdentifierRow {
                     trace_id: None,
@@ -2521,6 +2556,7 @@ mod tests {
                     external_event_id: None,
                     external_parent_event_id: None,
                     external_tool_use_id: None,
+                    repo_url: None,
                 },
                 MetricIdentifierRow {
                     trace_id: None,
@@ -2532,6 +2568,7 @@ mod tests {
                     external_event_id: None,
                     external_parent_event_id: None,
                     external_tool_use_id: None,
+                    repo_url: None,
                 },
             ]
         );
@@ -2581,6 +2618,7 @@ mod tests {
                     external_event_id: None,
                     external_parent_event_id: None,
                     external_tool_use_id: None,
+                    repo_url: Some("https://github.com/acme/repo".to_string()),
                 },
                 MetricIdentifierRow {
                     trace_id: None,
@@ -2592,6 +2630,7 @@ mod tests {
                     external_event_id: Some("legacy-event".to_string()),
                     external_parent_event_id: Some("legacy-parent".to_string()),
                     external_tool_use_id: Some("legacy-tool".to_string()),
+                    repo_url: Some("https://github.com/acme/project".to_string()),
                 },
                 MetricIdentifierRow {
                     trace_id: None,
@@ -2603,6 +2642,7 @@ mod tests {
                     external_event_id: None,
                     external_parent_event_id: None,
                     external_tool_use_id: None,
+                    repo_url: None,
                 },
             ]
         );

--- a/src/streams/agents/cursor.rs
+++ b/src/streams/agents/cursor.rs
@@ -68,17 +68,29 @@ impl CursorAgent {
     fn infer_cwd_from_transcript(stream_path: &Path) -> Option<PathBuf> {
         let file = fs::File::open(stream_path).ok()?;
         let reader = BufReader::new(file);
+        let mut found: Option<PathBuf> = None;
+        // Check up to 40 lines for tool-use file paths.
         for line in reader.lines().take(40).map_while(Result::ok) {
             let Ok(json) = serde_json::from_str::<serde_json::Value>(&line) else {
                 continue;
             };
             for path in cursor_event_file_paths(&json) {
-                if let Some(root) = worktree_root_for_path(&path) {
-                    return Some(root);
+                let Some(root) = worktree_root_for_path(&path) else {
+                    continue;
+                };
+                match &found {
+                    Some(existing) if *existing != root => {
+                        // Tool paths resolve to more than one worktree
+                        // root: every event in the stream shares one
+                        // cached cwd, so fail closed rather than guessing
+                        // which repository the whole session belongs to.
+                        return None;
+                    }
+                    _ => found = Some(root),
                 }
             }
         }
-        None
+        found
     }
 }
 
@@ -433,13 +445,7 @@ mod tests {
         use std::io::Write;
         use tempfile::NamedTempFile;
 
-        let repo = tempfile::tempdir().unwrap();
-        fs::create_dir_all(repo.path().join(".git")).unwrap();
-        fs::write(
-            repo.path().join(".git").join("HEAD"),
-            "ref: refs/heads/main",
-        )
-        .unwrap();
+        let repo = fake_git_repo();
         fs::create_dir_all(repo.path().join("src")).unwrap();
         let file_path = repo.path().join("src").join("main.rs");
         fs::write(&file_path, "fn main() {}\n").unwrap();
@@ -480,5 +486,57 @@ mod tests {
 
         let agent = CursorAgent::new();
         assert_eq!(agent.infer_cwd(transcript.path()), None);
+    }
+
+    fn fake_git_repo() -> tempfile::TempDir {
+        let repo = tempfile::tempdir().unwrap();
+        fs::create_dir_all(repo.path().join(".git")).unwrap();
+        fs::write(
+            repo.path().join(".git").join("HEAD"),
+            "ref: refs/heads/main",
+        )
+        .unwrap();
+        repo
+    }
+
+    /// A single Cursor conversation can read or edit more than one
+    /// repository (e.g. a monorepo checkout plus a sibling dependency
+    /// checked out elsewhere). Every event in the stream shares one cached
+    /// repo_work_dir, so guessing the first repository seen would silently
+    /// mislabel every later event that actually belongs to a different one.
+    #[test]
+    fn test_infer_cwd_none_when_tool_paths_span_multiple_repos() {
+        use std::io::Write;
+        use tempfile::NamedTempFile;
+
+        let repo_a = fake_git_repo();
+        let file_a = repo_a.path().join("a.rs");
+        fs::write(&file_a, "fn a() {}\n").unwrap();
+
+        let repo_b = fake_git_repo();
+        let file_b = repo_b.path().join("b.rs");
+        fs::write(&file_b, "fn b() {}\n").unwrap();
+
+        let mut transcript = NamedTempFile::new().unwrap();
+        writeln!(
+            transcript,
+            r#"{{"role":"assistant","message":{{"content":[{{"type":"tool_use","name":"Read","input":{{"path":{}}}}}]}}}}"#,
+            serde_json::to_string(&file_a.to_string_lossy()).unwrap()
+        )
+        .unwrap();
+        writeln!(
+            transcript,
+            r#"{{"role":"assistant","message":{{"content":[{{"type":"tool_use","name":"Read","input":{{"path":{}}}}}]}}}}"#,
+            serde_json::to_string(&file_b.to_string_lossy()).unwrap()
+        )
+        .unwrap();
+        transcript.flush().unwrap();
+
+        let agent = CursorAgent::new();
+        assert_eq!(
+            agent.infer_cwd(transcript.path()),
+            None,
+            "tool paths spanning multiple repos must fail closed instead of guessing one"
+        );
     }
 }

--- a/src/streams/agents/cursor.rs
+++ b/src/streams/agents/cursor.rs
@@ -1,11 +1,13 @@
 //! Cursor agent implementation with sweep discovery.
 
 use crate::authorship::authorship_log_serialization::generate_session_id;
+use crate::git::repo_state::worktree_root_for_path;
 use crate::streams::agent::{Agent, PathResolverKind, StreamDescriptor};
 use crate::streams::sweep::{DiscoveredSession, StreamFormat, SweepStrategy};
 use crate::streams::types::{StreamBatch, StreamError};
 use crate::streams::watermark::{ByteOffsetWatermark, WatermarkStrategy};
 use std::fs;
+use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -62,6 +64,47 @@ impl CursorAgent {
             }
         }
     }
+
+    fn infer_cwd_from_transcript(stream_path: &Path) -> Option<PathBuf> {
+        let file = fs::File::open(stream_path).ok()?;
+        let reader = BufReader::new(file);
+        for line in reader.lines().take(40).map_while(Result::ok) {
+            let Ok(json) = serde_json::from_str::<serde_json::Value>(&line) else {
+                continue;
+            };
+            for path in cursor_event_file_paths(&json) {
+                if let Some(root) = worktree_root_for_path(&path) {
+                    return Some(root);
+                }
+            }
+        }
+        None
+    }
+}
+
+fn cursor_event_file_paths(event: &serde_json::Value) -> Vec<PathBuf> {
+    let Some(content) = event
+        .get("message")
+        .and_then(|message| message.get("content"))
+        .and_then(|content| content.as_array())
+    else {
+        return Vec::new();
+    };
+
+    let mut paths = Vec::new();
+    for item in content {
+        let Some(input) = item.get("input") else {
+            continue;
+        };
+        for key in ["path", "file_path", "target_directory"] {
+            if let Some(path) = input.get(key).and_then(|value| value.as_str())
+                && !path.is_empty()
+            {
+                paths.push(PathBuf::from(path));
+            }
+        }
+    }
+    paths
 }
 
 impl Default for CursorAgent {
@@ -217,6 +260,10 @@ impl Agent for CursorAgent {
         crate::streams::agent::file_time_fallback(file_meta, is_first_event)
     }
 
+    fn infer_cwd(&self, stream_path: &Path) -> Option<PathBuf> {
+        Self::infer_cwd_from_transcript(stream_path)
+    }
+
     fn streams(&self) -> Vec<StreamDescriptor> {
         let format = StreamFormat::CursorJsonl;
         vec![StreamDescriptor {
@@ -234,6 +281,7 @@ impl Agent for CursorAgent {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::streams::agent::Agent;
 
     #[test]
     fn test_sweep_strategy() {
@@ -378,5 +426,59 @@ mod tests {
         assert_eq!(result.events.len(), 2);
         assert_eq!(result.events[0]["role"].as_str(), Some("user"));
         assert_eq!(result.events[1]["role"].as_str(), Some("assistant"));
+    }
+
+    #[test]
+    fn test_infer_cwd_from_transcript_tool_path() {
+        use std::io::Write;
+        use tempfile::NamedTempFile;
+
+        let repo = tempfile::tempdir().unwrap();
+        fs::create_dir_all(repo.path().join(".git")).unwrap();
+        fs::write(
+            repo.path().join(".git").join("HEAD"),
+            "ref: refs/heads/main",
+        )
+        .unwrap();
+        fs::create_dir_all(repo.path().join("src")).unwrap();
+        let file_path = repo.path().join("src").join("main.rs");
+        fs::write(&file_path, "fn main() {}\n").unwrap();
+
+        let mut transcript = NamedTempFile::new().unwrap();
+        writeln!(
+            transcript,
+            r#"{{"role":"user","message":{{"content":[{{"type":"text","text":"edit main"}}]}}}}"#
+        )
+        .unwrap();
+        writeln!(
+            transcript,
+            r#"{{"role":"assistant","message":{{"content":[{{"type":"tool_use","name":"Read","input":{{"path":{}}}}}]}}}}"#,
+            serde_json::to_string(&file_path.to_string_lossy()).unwrap()
+        )
+        .unwrap();
+        transcript.flush().unwrap();
+
+        let agent = CursorAgent::new();
+        assert_eq!(
+            agent.infer_cwd(transcript.path()).as_deref(),
+            Some(repo.path())
+        );
+    }
+
+    #[test]
+    fn test_infer_cwd_none_without_repo_paths() {
+        use std::io::Write;
+        use tempfile::NamedTempFile;
+
+        let mut transcript = NamedTempFile::new().unwrap();
+        writeln!(
+            transcript,
+            r#"{{"role":"user","message":{{"content":[{{"type":"text","text":"hello"}}]}}}}"#
+        )
+        .unwrap();
+        transcript.flush().unwrap();
+
+        let agent = CursorAgent::new();
+        assert_eq!(agent.infer_cwd(transcript.path()), None);
     }
 }

--- a/src/streams/agents/cursor.rs
+++ b/src/streams/agents/cursor.rs
@@ -11,6 +11,9 @@ use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+/// Line cap for `infer_cwd_from_transcript`'s multi-repo scan (see there).
+const CURSOR_INFER_CWD_LINE_LIMIT: usize = 1000;
+
 /// Cursor agent that discovers conversations from Cursor storage.
 pub struct CursorAgent {
     batch_size: usize,
@@ -69,8 +72,13 @@ impl CursorAgent {
         let file = fs::File::open(stream_path).ok()?;
         let reader = BufReader::new(file);
         let mut found: Option<PathBuf> = None;
-        // Check up to 40 lines for tool-use file paths.
-        for line in reader.lines().take(40).map_while(Result::ok) {
+        // Scan far enough to catch a repo switch anywhere in a typical
+        // session, not just in the first few lines.
+        for line in reader
+            .lines()
+            .take(CURSOR_INFER_CWD_LINE_LIMIT)
+            .map_while(Result::ok)
+        {
             let Ok(json) = serde_json::from_str::<serde_json::Value>(&line) else {
                 continue;
             };
@@ -79,13 +87,9 @@ impl CursorAgent {
                     continue;
                 };
                 match &found {
-                    Some(existing) if *existing != root => {
-                        // Tool paths resolve to more than one worktree
-                        // root: every event in the stream shares one
-                        // cached cwd, so fail closed rather than guessing
-                        // which repository the whole session belongs to.
-                        return None;
-                    }
+                    // Multiple worktree roots: fail closed instead of
+                    // guessing which repo the whole session belongs to.
+                    Some(existing) if *existing != root => return None,
                     _ => found = Some(root),
                 }
             }
@@ -537,6 +541,44 @@ mod tests {
             agent.infer_cwd(transcript.path()),
             None,
             "tool paths spanning multiple repos must fail closed instead of guessing one"
+        );
+    }
+
+    /// A repo switch well past a short prefix must still be caught.
+    #[test]
+    fn test_infer_cwd_none_when_repo_switch_happens_after_short_prefix() {
+        use std::io::Write;
+        use tempfile::NamedTempFile;
+
+        let repo_a = fake_git_repo();
+        let file_a = repo_a.path().join("a.rs");
+        fs::write(&file_a, "fn a() {}\n").unwrap();
+
+        let repo_b = fake_git_repo();
+        let file_b = repo_b.path().join("b.rs");
+        fs::write(&file_b, "fn b() {}\n").unwrap();
+
+        let mut transcript = NamedTempFile::new().unwrap();
+        let line_a = format!(
+            r#"{{"role":"assistant","message":{{"content":[{{"type":"tool_use","name":"Read","input":{{"path":{}}}}}]}}}}"#,
+            serde_json::to_string(&file_a.to_string_lossy()).unwrap()
+        );
+        for _ in 0..60 {
+            writeln!(transcript, "{line_a}").unwrap();
+        }
+        writeln!(
+            transcript,
+            r#"{{"role":"assistant","message":{{"content":[{{"type":"tool_use","name":"Read","input":{{"path":{}}}}}]}}}}"#,
+            serde_json::to_string(&file_b.to_string_lossy()).unwrap()
+        )
+        .unwrap();
+        transcript.flush().unwrap();
+
+        let agent = CursorAgent::new();
+        assert_eq!(
+            agent.infer_cwd(transcript.path()),
+            None,
+            "a repo switch past a short prefix must still be caught, not silently missed"
         );
     }
 }

--- a/tests/integration/session_event_attribution.rs
+++ b/tests/integration/session_event_attribution.rs
@@ -788,7 +788,7 @@ fn test_commit_metadata_recovery_uses_nearest_matching_tool_session_event() {
 }
 
 #[test]
-fn test_commit_metadata_recovery_falls_back_to_most_recent_matching_tool_session() {
+fn test_commit_metadata_recovery_does_not_attach_unscoped_latest_tool_session() {
     let (_metrics_db_dir, metrics_db_path) = isolated_metrics_db_path();
     let repo =
         TestRepo::new_with_daemon_env(&[("GIT_AI_TEST_METRICS_DB_PATH", metrics_db_path.as_str())]);
@@ -829,12 +829,26 @@ fn test_commit_metadata_recovery_falls_back_to_most_recent_matching_tool_session
             .metadata
             .sessions
             .contains_key(&older_session_id),
-        "latest fallback should not select an older Claude session"
+        "unscoped session events must not be attached via latest-tool fallback"
+    );
+    assert!(
+        !commit
+            .authorship_log
+            .metadata
+            .sessions
+            .contains_key(&latest_session_id),
+        "unscoped session events must not be attached via latest-tool fallback"
+    );
+    let claude_sessions = session_ids_for_tool(&commit.authorship_log, "claude");
+    assert_eq!(
+        claude_sessions.len(),
+        1,
+        "Co-authored-by without a repo-linked session should synthesize one session"
     );
     assert_session_attests_lines(
         &commit.authorship_log,
         "metadata-latest.txt",
-        &latest_session_id,
+        &claude_sessions[0],
         &[1],
     );
 }
@@ -894,6 +908,122 @@ fn test_commit_metadata_recovery_latest_matching_tool_prefers_current_repo_url()
         &commit.authorship_log,
         "metadata-latest-repo-url.txt",
         &same_repo_session_id,
+        &[1],
+    );
+}
+
+#[test]
+fn test_commit_metadata_recovery_latest_ignores_newer_unscoped_session() {
+    let (_metrics_db_dir, metrics_db_path) = isolated_metrics_db_path();
+    let repo =
+        TestRepo::new_with_daemon_env(&[("GIT_AI_TEST_METRICS_DB_PATH", metrics_db_path.as_str())]);
+    repo.git(&[
+        "remote",
+        "add",
+        "origin",
+        "https://github.com/acme/metadata-unscoped.git",
+    ])
+    .expect("remote add should succeed");
+    repo.git(&["commit", "--allow-empty", "-m", "initial"])
+        .expect("initial empty commit should succeed");
+
+    let file_path = repo.path().join("metadata-latest-unscoped.txt");
+    fs::write(&file_path, "cursor recovered ignoring unscoped session\n").unwrap();
+    let file_ts = file_mtime_secs(&file_path);
+    let unscoped_session_id = insert_session_event_for_tool(
+        &metrics_db_path,
+        file_ts.saturating_sub(100),
+        "cursor",
+        "cursor-unscoped-session",
+        "cursor-unscoped-tool",
+        None,
+    );
+    let same_repo_session_id = insert_session_event_for_tool(
+        &metrics_db_path,
+        file_ts.saturating_sub(200),
+        "cursor",
+        "cursor-same-repo-unscoped",
+        "cursor-same-repo-unscoped-tool",
+        Some("https://github.com/acme/metadata-unscoped"),
+    );
+
+    let commit = repo
+        .stage_all_and_commit(
+            "Recover from Cursor trailer\n\nCo-authored-by: Cursor <cursoragent@cursor.com>",
+        )
+        .expect("commit should succeed");
+
+    let mut file = repo.filename("metadata-latest-unscoped.txt");
+    file.assert_committed_lines(lines!["cursor recovered ignoring unscoped session".ai()]);
+    assert!(
+        !commit
+            .authorship_log
+            .metadata
+            .sessions
+            .contains_key(&unscoped_session_id),
+        "latest fallback must not attach a more recent session event that has no repo_url"
+    );
+    assert_session_attests_lines(
+        &commit.authorship_log,
+        "metadata-latest-unscoped.txt",
+        &same_repo_session_id,
+        &[1],
+    );
+}
+
+#[test]
+fn test_commit_metadata_recovery_does_not_use_unscoped_session_from_another_project() {
+    let (_metrics_db_dir, metrics_db_path) = isolated_metrics_db_path();
+    let repo =
+        TestRepo::new_with_daemon_env(&[("GIT_AI_TEST_METRICS_DB_PATH", metrics_db_path.as_str())]);
+    repo.git(&[
+        "remote",
+        "add",
+        "origin",
+        "https://github.com/acme/product-front.git",
+    ])
+    .expect("remote add should succeed");
+    repo.git(&["commit", "--allow-empty", "-m", "initial"])
+        .expect("initial empty commit should succeed");
+
+    let file_path = repo.path().join("product-name.txt");
+    fs::write(&file_path, "one recovered line\n").unwrap();
+    let file_ts = file_mtime_secs(&file_path);
+    let other_project_session_id = insert_session_event_for_tool(
+        &metrics_db_path,
+        file_ts.saturating_sub(42_000),
+        "cursor",
+        "cursor-other-project-session",
+        "cursor-other-project-tool",
+        None,
+    );
+
+    let commit = repo
+        .stage_all_and_commit(
+            "feat(product-name): add field\n\nCo-authored-by: Cursor <cursoragent@cursor.com>",
+        )
+        .expect("commit should succeed");
+
+    let mut file = repo.filename("product-name.txt");
+    file.assert_committed_lines(lines!["one recovered line".ai()]);
+    assert!(
+        !commit
+            .authorship_log
+            .metadata
+            .sessions
+            .contains_key(&other_project_session_id),
+        "Co-authored-by must not attach an unscoped Cursor session from another project"
+    );
+    let cursor_sessions = session_ids_for_tool(&commit.authorship_log, "cursor");
+    assert_eq!(
+        cursor_sessions.len(),
+        1,
+        "unscoped foreign sessions should fall back to a synthesized Cursor session"
+    );
+    assert_session_attests_lines(
+        &commit.authorship_log,
+        "product-name.txt",
+        &cursor_sessions[0],
         &[1],
     );
 }

--- a/tests/integration/session_event_repo_url.rs
+++ b/tests/integration/session_event_repo_url.rs
@@ -641,20 +641,54 @@ fn test_repo_work_dir_priority_infer_fallback() {
     );
 }
 
-// === Test Group 7: Agents without cwd inference ===
+// === Test Group 7: Cursor cwd inference from tool paths ===
 
 #[test]
-fn test_cursor_infer_cwd_returns_none() {
+fn test_cursor_infer_cwd_returns_none_without_tool_paths() {
     use git_ai::streams::agents::CursorAgent;
 
     let temp_dir = TempDir::new().unwrap();
     let transcript = temp_dir.path().join("session.jsonl");
-    fs::write(&transcript, r#"{"type":"user","message":{"content":"hi"}}"#).unwrap();
+    fs::write(
+        &transcript,
+        r#"{"role":"user","message":{"content":[{"type":"text","text":"hi"}]}}"#,
+    )
+    .unwrap();
     let agent = CursorAgent::new();
     assert_eq!(
         agent.infer_cwd(&transcript),
         None,
-        "CursorAgent must return None for infer_cwd (no cwd in format)"
+        "CursorAgent must return None when the transcript has no file-path tool inputs"
+    );
+}
+
+#[test]
+fn test_cursor_infer_cwd_from_tool_path() {
+    use git_ai::streams::agents::CursorAgent;
+
+    let repo = TestRepo::new();
+    let file_path = repo.path().join("src.rs");
+    fs::write(&file_path, "fn main() {}\n").unwrap();
+
+    let temp_dir = TempDir::new().unwrap();
+    let transcript = temp_dir.path().join("session.jsonl");
+    let event = json!({
+        "role": "assistant",
+        "message": {
+            "content": [{
+                "type": "tool_use",
+                "name": "Read",
+                "input": {"path": file_path.to_string_lossy()}
+            }]
+        }
+    });
+    fs::write(&transcript, format!("{event}\n")).unwrap();
+
+    let agent = CursorAgent::new();
+    assert_eq!(
+        agent.infer_cwd(&transcript),
+        Some(repo.path().to_path_buf()),
+        "CursorAgent should infer the git workdir from tool-use file paths"
     );
 }
 


### PR DESCRIPTION
## Problem

Two related mis-attribution bugs found via real repo data:

1. **Cross-repo mis-attribution (real bug)**: a commit with a `Co-authored-by: Cursor` trailer and no session event within the 3s window fell back to `select_latest_commit_metadata_metric_session`, which had no time window and treated candidates with a missing `repo_url` as usable. On a multi-repo machine this attached whatever Cursor session last ran anywhere on the machine — in the observed case, a session from reviewing an unrelated PR in a different repo the night before got attached to an IMS frontend commit.
2. **Model backfill (real bug, correct session)**: a small (`+2` lines) session-event-recovered hunk had the *correct* session attached, but the recovered checkpoint metric recorded `model: "unknown"` because Cursor's `session_event` rows never carry model info, and recovery only looked at that one event instead of reusing the model already on record for that same session from other checkpointed lines in the same commit.

Root cause: Cursor doesn't push a working directory, so its `session_event` rows are frequently missing `repo_url`, making the unscoped cross-repo fallback path close to default behavior on multi-repo machines.

## Fix

1. `select_latest_commit_metadata_metric_session` now only accepts an **exact `repo_url` match**. If no same-repo session exists, it falls through to the existing synthesized-session fallback instead of borrowing a cross-repo/unscoped session. (The time-windowed `select_nearest_...` path is untouched — its 3s window already makes an unscoped candidate low-risk.)
2. `recovery_model_for_session` backfills the recovered checkpoint metric's `model` from the session's already-known model (if any) before falling back to the session-event candidate's own (usually absent) model.
3. `CursorAgent::infer_cwd` now infers the git worktree root from transcript tool-use file paths (`path`/`file_path`/`target_directory`), so future Cursor `session_event` rows are more likely to carry `repo_url` and avoid the unscoped fallback path entirely.

Only affects attribution recovery for **future** commits; already-written notes are not rewritten.

## Tests

- Unit: `recovery_model_for_session_reuses_known_model`, `recovery_model_for_session_falls_back_when_model_is_unknown_or_missing` (attribution_recovery.rs)
- Unit: `test_infer_cwd_from_transcript_tool_path`, `test_infer_cwd_none_without_repo_paths` (cursor.rs)
- Integration: `test_commit_metadata_recovery_does_not_attach_unscoped_latest_tool_session`, `test_commit_metadata_recovery_latest_ignores_newer_unscoped_session`, `test_commit_metadata_recovery_does_not_use_unscoped_session_from_another_project`, `test_cursor_infer_cwd_from_tool_path` (covers same-machine stale unscoped session, same-machine newer unscoped session, and cross-project unscoped session)

## Verification

- `cargo fmt` / `cargo clippy --all-targets -- -D warnings`: clean
- `cargo test --lib` (attribution_recovery + cursor agent): 102 passed
- `cargo test --test integration session_event`: 50 passed
- Broader regression (`attribution`/`recovery`/`cursor` filters): 565 passed, 0 failed

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/2298" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->