### PR TITLE
fix(daemon): bound the family causal fence with a grace window

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ openssl = { version = "0.10", features = ["vendored"] }
 [target.'cfg(windows)'.dependencies]
 named_pipe = "0.4.1"
 winreg = "0.55"
-windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_System_Environment", "Win32_UI_WindowsAndMessaging"] }
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_System_Environment", "Win32_System_Threading", "Win32_UI_WindowsAndMessaging"] }
 
 [features]
 test-support = ["dep:tempfile"]

--- a/docs/daemon-trace2-ingestion-spec.md
+++ b/docs/daemon-trace2-ingestion-spec.md
@@ -67,8 +67,44 @@ Separation of concerns:
   mutating command is not a sequencer entry: it is an open trace root that
   fences later entries of its family until it finishes, and a root the reader
   has already seen finishing keeps that fence until the ingest worker
-  processes its final frames.
+  processes its final frames. See "Causal fence" for how long a root can hold.
 - **Side effects** run only after enrichment, on exact data.
+
+### Causal fence
+
+Trace2 frames of one root arrive in order (one connection, sequential writes),
+but across roots there is no order: independent reader threads feed a serial
+ingest worker. The hazard this creates is a git process that has changed refs
+while its final frame has not reached the sequencer. An open, mutating (or not
+yet classified) root that started at or before a completed entry holds that
+entry — and `sync.family`, the shutdown drain, and `await` — as follows,
+decided from data first and heuristics last:
+
+1. **Finishing** (`atexit` already read by the reader, or its socket closed):
+   holds until the worker processes its queued frame. The worker clears the
+   root even when that frame fails to normalize or ingest; as a safety net,
+   the hard cap releases a finishing root too (`reason=finishing_root_cap`).
+2. **Written**: the reader captured the root's worktree `HEAD` reflog length
+   when it started; if that reflog has grown, or was modified after the root's
+   start on git's clock, the root has changed refs and holds until it
+   finishes (a post-write hook, say), bounded by 600 × grace. The modification
+   time covers a length the reader recorded late, after the root had already
+   written, and cannot be set by a committer date.
+3. **Unwritten**: neither signal fired, so the root has changed nothing and
+   fences nothing. Nobody waits for an editor or a pre-commit hook, not even a
+   grace.
+4. **No reflog to consult** (the root's worktree is unknown, or the repository
+   has no `HEAD` reflog): time and liveness decide. The root holds for the
+   causal grace (`FAMILY_CAUSAL_GRACE`, 1 s; `GIT_AI_DAEMON_CAUSAL_GRACE_MS`)
+   measured from when the waiting work became ready; past it, a root whose pid
+   (encoded in its sid, `-P<hex>`) is alive is released
+   (`reason=causal_grace_expired`) and one whose process is gone or unknown
+   holds until the hard cap (`reason=causal_fence_hard_cap`).
+
+Unattributed roots (no `def_repo` yet) fail closed and fence every family.
+Roots that started after the waiting work cannot precede it and never fence
+it. Heuristic releases are `WARN`-logged once per root with the root, its
+command, family, age and wait, and counted for the health snapshot.
 
 ### NormalizedCommand
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -10150,6 +10150,34 @@ mod stream_worker_tests;
 
 #[cfg(test)]
 mod tests {
+    impl ActorDaemonCoordinator {
+        // Test-only views of the fence's candidate roots; production paths go
+        // through `evaluate_fence`.
+        fn has_open_trace_roots_that_may_mutate_refs(&self) -> bool {
+            let Ok(ingress) = self.trace_ingress_state.lock() else {
+                return false;
+            };
+            ingress
+                .root_open_connections
+                .keys()
+                .any(|root| Self::open_root_may_mutate_family(&ingress, root, None))
+        }
+
+        /// As [`Self::has_open_trace_roots_that_may_mutate_refs`], but scoped to
+        /// one family: roots already attributed to a DIFFERENT family (via their
+        /// `def_repo` worktree) cannot mutate this family's refs and are ignored.
+        /// Roots with no family attribution yet fail closed and block everyone.
+        fn has_open_trace_roots_that_may_mutate_family(&self, family: &str) -> bool {
+            let Ok(ingress) = self.trace_ingress_state.lock() else {
+                return false;
+            };
+            ingress
+                .root_open_connections
+                .keys()
+                .any(|root| Self::open_root_may_mutate_family(&ingress, root, Some(family)))
+        }
+    }
+
     use super::*;
     use serial_test::serial;
     use std::ffi::OsString;
@@ -11016,18 +11044,28 @@ mod tests {
             .expect("def_repo should ingest");
         assert!(
             coord
-                .family_entry_blocked_by_prior_open_trace_root(&family, now_unix_nanos(), None)
-                .unwrap(),
+                .family_entry_blocked_by_prior_open_trace_root(
+                    &family,
+                    now_unix_nanos(),
+                    None,
+                    Duration::ZERO,
+                    "test",
+                )
+                .unwrap()
+                .is_some(),
             "an open root whose command is still unknown fails closed and fences its family"
         );
         assert!(
-            !coord
+            coord
                 .family_entry_blocked_by_prior_open_trace_root(
                     "/some/other/family/.git",
                     now_unix_nanos(),
-                    None
+                    None,
+                    Duration::ZERO,
+                    "test",
                 )
-                .unwrap(),
+                .unwrap()
+                .is_none(),
             "a root attributed to one family must not fence other families"
         );
 
@@ -11045,8 +11083,15 @@ mod tests {
 
         assert!(
             coord
-                .family_entry_blocked_by_prior_open_trace_root(&family, now_unix_nanos(), None)
-                .unwrap(),
+                .family_entry_blocked_by_prior_open_trace_root(
+                    &family,
+                    now_unix_nanos(),
+                    None,
+                    Duration::ZERO,
+                    "test",
+                )
+                .unwrap()
+                .is_some(),
             "a running mutating root fences its family once argv and repo metadata are both known, even when they arrive on different events"
         );
         assert!(
@@ -11504,6 +11549,416 @@ mod tests {
             "an abandoned root must not leave a sequencer entry behind"
         );
         coord.request_shutdown();
+    }
+
+    #[test]
+    fn trace_sid_pid_parses_real_trace2_sid() {
+        assert_eq!(
+            trace_sid_pid("20260903T230057.647295Z-H68dbce90-P001cc228"),
+            Some(0x001c_c228)
+        );
+        assert_eq!(
+            trace_sid_pid(
+                "20260903T230057.647295Z-H68dbce90-P001cc228/20260903T230058.100000Z-H68dbce90-P001cc2f0"
+            ),
+            Some(0x001c_c228),
+            "child sids resolve to the root process"
+        );
+        assert_eq!(
+            trace_sid_pid("20260411T120000.000000-Punfinished-root"),
+            None
+        );
+        assert_eq!(trace_sid_pid("no-pid-here"), None);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn process_alive_distinguishes_live_reaped_and_foreign_processes() {
+        assert!(process_alive(std::process::id()), "this process is alive");
+        assert!(
+            process_alive(1),
+            "a process we may not signal (EPERM) is still alive"
+        );
+        let mut child = std::process::Command::new("true")
+            .spawn()
+            .expect("spawn a short-lived process");
+        child.wait().expect("reap the short-lived process");
+        assert!(!process_alive(child.id()), "a reaped process is gone");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn process_alive_distinguishes_live_and_reaped_processes() {
+        assert!(process_alive(std::process::id()), "this process is alive");
+        let mut child = std::process::Command::new("cmd")
+            .args(["/C", "exit", "0"])
+            .spawn()
+            .expect("spawn a short-lived process");
+        child.wait().expect("reap the short-lived process");
+        assert!(!process_alive(child.id()), "a reaped process is gone");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn process_alive_treats_zombies_as_gone() {
+        let mut child = std::process::Command::new("true")
+            .spawn()
+            .expect("spawn a short-lived process");
+        let started = std::time::Instant::now();
+        while !process_is_zombie(child.id()) {
+            assert!(
+                started.elapsed() < Duration::from_secs(5),
+                "child never exited"
+            );
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        assert!(
+            !process_alive(child.id()),
+            "an exited but unreaped process has finished writing: it is gone"
+        );
+        child.wait().unwrap();
+    }
+
+    /// A root sid whose pid is this test process: alive for as long as the
+    /// test runs, standing in for a git command blocked in an editor or hook.
+    fn alive_root_sid(tag: &str) -> String {
+        format!("20260411T120000.000000-H{tag}-P{:x}", std::process::id())
+    }
+
+    /// Opens a mutating `git commit` root on the reader side only (no ingest
+    /// worker needed). Without a worktree it is unattributed and fences
+    /// every family.
+    fn open_unattributed_commit_root(coord: &ActorDaemonCoordinator, sid: &str) {
+        coord.trace_root_connection_opened(sid).unwrap();
+        let mut start = serde_json::json!({
+            "event": "start",
+            "sid": sid,
+            "argv": ["git", "commit", "-m", "blocked"],
+            "time_ns": 1u64,
+        });
+        assert!(coord.prepare_trace_payload_for_ingest(&mut start));
+    }
+
+    /// The reader consumes the root's `atexit` frame: the process is done and
+    /// its final frame is queued for the worker.
+    fn read_root_atexit(coord: &ActorDaemonCoordinator, sid: &str) {
+        let mut atexit = serde_json::json!({
+            "event": "atexit",
+            "sid": sid,
+            "code": 0,
+            "time_ns": 2u64,
+        });
+        assert!(coord.prepare_trace_payload_for_ingest(&mut atexit));
+    }
+
+    /// Opens a mutating root running `argv` attributed to `repo`, so the
+    /// reader records its family and its reflog start offsets.
+    fn open_attributed_root(coord: &ActorDaemonCoordinator, sid: &str, repo: &Path, argv: &[&str]) {
+        coord.trace_root_connection_opened(sid).unwrap();
+        let mut start = serde_json::json!({
+            "event": "start",
+            "sid": sid,
+            "argv": argv,
+            "worktree": repo,
+            "time_ns": 1u64,
+        });
+        assert!(coord.prepare_trace_payload_for_ingest(&mut start));
+    }
+
+    fn open_attributed_commit_root(coord: &ActorDaemonCoordinator, sid: &str, repo: &Path) {
+        open_attributed_root(coord, sid, repo, &["git", "commit", "-m", "running"]);
+    }
+
+    /// A ref write in `repo` that bypasses trace2, standing in for the write
+    /// a still-running root performs.
+    fn commit_untraced(repo: &Path) {
+        let output = std::process::Command::new("git")
+            .arg("-C")
+            .arg(repo)
+            .args([
+                "-c",
+                "user.email=t@example.com",
+                "-c",
+                "user.name=t",
+                "commit",
+                "--allow-empty",
+                "-m",
+                "write",
+            ])
+            .env("GIT_TRACE2_EVENT", "0")
+            .output()
+            .expect("git commit should run");
+        assert!(
+            output.status.success(),
+            "git commit failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn append_ready_rebase(coord: &ActorDaemonCoordinator, family: &str) {
+        coord
+            .append_family_sequencer_entry(
+                family,
+                2,
+                FamilySequencerEntry::ReadyCommand(Box::new(test_rebase_command(&[], Vec::new()))),
+            )
+            .unwrap();
+    }
+
+    fn is_fenced(disposition: FamilyFrontDisposition) -> bool {
+        matches!(disposition, FamilyFrontDisposition::Fenced { .. })
+    }
+
+    #[tokio::test]
+    async fn family_fence_releases_after_grace_when_root_process_is_alive() {
+        let grace = Duration::from_millis(20);
+        let coord = ActorDaemonCoordinator::new_with_causal_grace(grace);
+        let sid = alive_root_sid("alive");
+        open_unattributed_commit_root(&coord, &sid);
+        append_ready_rebase(&coord, "family-a");
+        assert!(
+            is_fenced(coord.family_front_entry_disposition("family-a")),
+            "a completed entry waits for an older open root within the causal grace"
+        );
+
+        tokio::time::sleep(grace * 3).await;
+        assert_eq!(
+            coord.family_front_entry_disposition("family-a"),
+            FamilyFrontDisposition::Ready,
+            "with no reflog to consult, a root whose process is alive past the grace is judged still running, not in flight"
+        );
+        assert_eq!(coord.causal_grace_expirations.load(Ordering::Relaxed), 1);
+
+        // Later work waits its own grace, but the heuristic release is
+        // reported once per root.
+        append_ready_rebase(&coord, "family-b");
+        assert!(is_fenced(coord.family_front_entry_disposition("family-b")));
+        tokio::time::sleep(grace * 3).await;
+        assert_eq!(
+            coord.family_front_entry_disposition("family-b"),
+            FamilyFrontDisposition::Ready
+        );
+        assert_eq!(
+            coord.causal_grace_expirations.load(Ordering::Relaxed),
+            1,
+            "a release is counted once per root"
+        );
+
+        // A root that closes before the grace expires releases without a count.
+        let coord = ActorDaemonCoordinator::new_with_causal_grace(grace);
+        let sid = alive_root_sid("closed");
+        open_unattributed_commit_root(&coord, &sid);
+        append_ready_rebase(&coord, "family-a");
+        assert!(is_fenced(coord.family_front_entry_disposition("family-a")));
+        coord.clear_trace_root_tracking(&sid).unwrap();
+        assert_eq!(
+            coord.family_front_entry_disposition("family-a"),
+            FamilyFrontDisposition::Ready
+        );
+        assert_eq!(coord.causal_grace_expirations.load(Ordering::Relaxed), 0);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn family_fence_holds_past_grace_when_root_process_is_dead() {
+        let grace = Duration::from_millis(20);
+        let hard_cap = grace * FAMILY_CAUSAL_FENCE_HARD_CAP_MULTIPLIER;
+        let coord = ActorDaemonCoordinator::new_with_causal_grace(grace);
+        let mut child = std::process::Command::new("true")
+            .spawn()
+            .expect("spawn a short-lived process");
+        child.wait().expect("reap the short-lived process");
+        let sid = format!("20260411T120000.000000-Hdead-P{:x}", child.id());
+        open_unattributed_commit_root(&coord, &sid);
+        append_ready_rebase(&coord, "family-a");
+
+        tokio::time::sleep(grace * 4).await;
+        assert!(
+            is_fenced(coord.family_front_entry_disposition("family-a")),
+            "a root whose process is gone may still have frames in flight: keep holding past the grace"
+        );
+        assert_eq!(coord.causal_grace_expirations.load(Ordering::Relaxed), 0);
+
+        tokio::time::sleep(hard_cap).await;
+        assert_eq!(
+            coord.family_front_entry_disposition("family-a"),
+            FamilyFrontDisposition::Ready,
+            "the hard cap bounds the wait for a root that never finishes"
+        );
+        assert_eq!(
+            coord.causal_fence_hard_cap_releases.load(Ordering::Relaxed),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn finishing_root_holds_fence_until_cleared() {
+        let grace = Duration::from_millis(20);
+        let coord = ActorDaemonCoordinator::new_with_causal_grace(grace);
+        let sid = alive_root_sid("exiting");
+        open_unattributed_commit_root(&coord, &sid);
+        read_root_atexit(&coord, &sid);
+        append_ready_rebase(&coord, "family-a");
+        tokio::time::sleep(grace * 3).await;
+        assert!(
+            is_fenced(coord.family_front_entry_disposition("family-a")),
+            "a finishing root holds the fence until the worker processes its frames, regardless of grace or liveness"
+        );
+        coord.clear_trace_root_tracking(&sid).unwrap();
+        assert_eq!(
+            coord.family_front_entry_disposition("family-a"),
+            FamilyFrontDisposition::Ready
+        );
+        assert_eq!(coord.causal_grace_expirations.load(Ordering::Relaxed), 0);
+
+        // A finishing root is never released by time: its final frame is
+        // queued and the worker clears it, even if that frame fails to ingest.
+        let coord = ActorDaemonCoordinator::new_with_causal_grace(grace);
+        let sid = alive_root_sid("stuck");
+        open_unattributed_commit_root(&coord, &sid);
+        read_root_atexit(&coord, &sid);
+        append_ready_rebase(&coord, "family-a");
+        tokio::time::sleep(grace * FAMILY_CAUSAL_FENCE_HARD_CAP_MULTIPLIER + grace).await;
+        assert!(is_fenced(coord.family_front_entry_disposition("family-a")));
+        assert_eq!(
+            coord.causal_fence_hard_cap_releases.load(Ordering::Relaxed),
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn root_with_a_reflog_fences_only_once_it_has_written() {
+        let grace = Duration::from_millis(20);
+        let coord = ActorDaemonCoordinator::new_with_causal_grace(grace);
+        let temp = tempfile::tempdir().unwrap();
+        let (repo, family) = init_test_family(&coord, &temp);
+        commit_untraced(&repo); // so the worktree HEAD reflog exists
+        let sid = alive_root_sid("attributed");
+        open_attributed_commit_root(&coord, &sid, &repo);
+
+        append_ready_rebase(&coord, &family);
+        assert_eq!(
+            coord.family_front_entry_disposition(&family),
+            FamilyFrontDisposition::Ready,
+            "an open root whose worktree HEAD reflog has not grown has changed nothing: no wait at all"
+        );
+
+        // The root writes refs (say, then runs a post-commit hook).
+        commit_untraced(&repo);
+        append_ready_rebase(&coord, &family);
+        assert!(
+            is_fenced(coord.family_front_entry_disposition(&family)),
+            "once its worktree HEAD reflog has grown, the root holds the fence"
+        );
+        tokio::time::sleep(grace * 3).await;
+        assert!(
+            is_fenced(coord.family_front_entry_disposition(&family)),
+            "...for as long as it runs, even though its process is alive"
+        );
+        read_root_atexit(&coord, &sid);
+        assert!(is_fenced(coord.family_front_entry_disposition(&family)));
+        coord.clear_trace_root_tracking(&sid).unwrap();
+        assert_eq!(
+            coord.family_front_entry_disposition(&family),
+            FamilyFrontDisposition::Ready
+        );
+        assert_eq!(coord.causal_grace_expirations.load(Ordering::Relaxed), 0);
+        assert_eq!(
+            coord.causal_fence_hard_cap_releases.load(Ordering::Relaxed),
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn root_writing_refs_other_than_head_falls_back_to_grace_and_liveness() {
+        let grace = Duration::from_millis(20);
+        let coord = ActorDaemonCoordinator::new_with_causal_grace(grace);
+        let temp = tempfile::tempdir().unwrap();
+        let (repo, family) = init_test_family(&coord, &temp);
+        commit_untraced(&repo);
+        let sid = alive_root_sid("branch");
+        open_attributed_root(
+            &coord,
+            &sid,
+            &repo,
+            &["git", "branch", "-f", "other", "HEAD"],
+        );
+        append_ready_rebase(&coord, &family);
+
+        assert!(
+            is_fenced(coord.family_front_entry_disposition(&family)),
+            "the HEAD reflog cannot reveal a branch update: hold for the grace"
+        );
+        tokio::time::sleep(grace * 3).await;
+        assert_eq!(
+            coord.family_front_entry_disposition(&family),
+            FamilyFrontDisposition::Ready,
+            "past the grace an alive process is judged still running"
+        );
+        assert_eq!(coord.causal_grace_expirations.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test]
+    async fn checkpoint_fence_waits_for_open_mutating_trace_root_until_causal_grace_expires() {
+        let grace = Duration::from_millis(50);
+        let coord = ActorDaemonCoordinator::new_with_causal_grace(grace);
+        let sid = alive_root_sid("sync");
+        open_unattributed_commit_root(&coord, &sid);
+
+        assert!(
+            tokio::time::timeout(
+                Duration::from_millis(20),
+                coord.wait_for_trace_ingest_processed_through()
+            )
+            .await
+            .is_err(),
+            "the fence holds within the causal grace"
+        );
+        tokio::time::timeout(
+            Duration::from_secs(2),
+            coord.wait_for_trace_ingest_processed_through(),
+        )
+        .await
+        .expect("the fence releases once the grace expires and the root's process is alive");
+        tokio::time::timeout(
+            Duration::from_secs(2),
+            coord.wait_for_trace_ingest_processed_through_family("/any/family/.git"),
+        )
+        .await
+        .expect("the family-scoped fence sees the same sticky release");
+        assert!(
+            coord.has_open_trace_roots_that_may_mutate_refs(),
+            "releasing the fence does not forget the root: it is still open"
+        );
+    }
+
+    #[tokio::test]
+    async fn await_pending_work_ignores_idle_open_roots_but_counts_finishing_ones() {
+        let grace = Duration::from_millis(20);
+        let coord = ActorDaemonCoordinator::new_with_causal_grace(grace);
+        let sid = alive_root_sid("idle");
+        open_unattributed_commit_root(&coord, &sid);
+        assert!(
+            coord.has_pending_daemon_work(),
+            "a fresh open root without a reflog to consult is pending within the grace"
+        );
+        tokio::time::sleep(grace * 3).await;
+        assert!(
+            !coord.has_pending_daemon_work(),
+            "an open root judged still running (a human at an editor) is not daemon work"
+        );
+
+        let coord = ActorDaemonCoordinator::new_with_causal_grace(grace);
+        let sid = alive_root_sid("finishing");
+        open_unattributed_commit_root(&coord, &sid);
+        read_root_atexit(&coord, &sid);
+        assert!(
+            tokio::time::timeout(grace * 3, coord.wait_for_trace_ingest_processed_through())
+                .await
+                .is_err(),
+            "a finishing root's frames are queued: waits hold and await keeps it pending"
+        );
+        assert!(coord.has_pending_daemon_work());
     }
 
     #[tokio::test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -48,7 +48,7 @@ use std::os::windows::io::{AsRawHandle, FromRawHandle, IntoRawHandle};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
 use tokio::sync::{Mutex as AsyncMutex, Notify, Semaphore, mpsc};
 use tokio::time::Duration;
 
@@ -114,6 +114,20 @@ const COMMAND_SIDE_EFFECT_CONCURRENCY: usize = 2;
 /// waiting. Healthy admission takes milliseconds; a wait this long means
 /// trace ingestion is stalled and must be visible in the logs (#2252).
 const CHECKPOINT_ADMISSION_DELAY_LOG_INTERVAL: Duration = Duration::from_secs(5);
+/// How long a completed sequencer entry (or a sync/await request) waits for an
+/// older, still-open mutating trace root of its family before that root's
+/// process is examined: long enough for a git process that just changed refs
+/// to get its `exit`/`atexit` frames to the reader. Overridable via
+/// `GIT_AI_DAEMON_CAUSAL_GRACE_MS`.
+const FAMILY_CAUSAL_GRACE: Duration = Duration::from_secs(1);
+/// Multiple of the grace after which a fence is released although the root is
+/// finishing (its final frames never got processed) or its process is gone or
+/// unknown (frames lost, or a socket fd leaked to a hook's background child).
+const FAMILY_CAUSAL_FENCE_HARD_CAP_MULTIPLIER: u32 = 30;
+/// Multiple of the grace for which a root that has already changed refs (its
+/// worktree HEAD reflog grew since it started) may hold the fence while it is
+/// still running, e.g. through a post-write hook.
+const FAMILY_WRITTEN_ROOT_FENCE_CAP_MULTIPLIER: u32 = 600;
 // Trace2 frames are written synchronously by Git to the daemon's Unix socket.
 // With small kernel socket buffers (macOS defaults to ~8 KiB), a bursty trace2
 // stream can fill the buffer and block the raw `git` process in `write()` until
@@ -491,6 +505,23 @@ fn is_trace_payload(payload: &Value) -> bool {
 
 fn trace_root_sid(sid: &str) -> &str {
     sid.split('/').next().unwrap_or(sid)
+}
+
+/// Git encodes its pid in the trace2 session id
+/// (`<timestamp>-H<host hash>-P<hex pid>`); child sids append `/<child sid>`.
+fn trace_sid_pid(sid: &str) -> Option<u32> {
+    let root = trace_root_sid(sid);
+    let pid_hex = &root[root.rfind("-P")? + 2..];
+    u32::from_str_radix(pid_hex, 16).ok()
+}
+
+/// Sleeps until `deadline`, or forever when there is no timer to wait for
+/// (for `select!` arms that only sometimes have a deadline).
+pub(crate) async fn sleep_until_or_pending(deadline: Option<tokio::time::Instant>) {
+    match deadline {
+        Some(deadline) => tokio::time::sleep_until(deadline).await,
+        None => std::future::pending().await,
+    }
 }
 
 fn is_terminal_root_trace_event(event: &str, sid: &str, root: &str) -> bool {
@@ -2561,7 +2592,7 @@ fn prune_stale_daemon_logs(log_dir: &Path) {
             Some(s) => s,
             None => continue,
         };
-        let _pid: u32 = match stem.parse() {
+        let pid: u32 = match stem.parse() {
             Ok(p) => p,
             Err(_) => continue,
         };
@@ -2574,20 +2605,64 @@ fn prune_stale_daemon_logs(log_dir: &Path) {
         if !dominated {
             continue;
         }
-        #[cfg(unix)]
-        {
-            if process_alive(_pid) {
-                continue;
-            }
+        if process_alive(pid) {
+            continue;
         }
         let _ = fs::remove_file(&path);
     }
 }
 
+/// Whether `pid` is a running process. Exited-but-unreaped (zombie) processes
+/// count as gone: they have finished writing. Processes we may not signal
+/// (another user's) count as alive.
 #[cfg(unix)]
 fn process_alive(pid: u32) -> bool {
     // kill(pid, 0) checks existence without sending a signal.
-    unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
+    let exists = unsafe { libc::kill(pid as libc::pid_t, 0) } == 0
+        || std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM);
+    exists && !process_is_zombie(pid)
+}
+
+#[cfg(target_os = "linux")]
+fn process_is_zombie(pid: u32) -> bool {
+    // `/proc/<pid>/stat`: "<pid> (<comm>) <state> ..."; comm may contain
+    // spaces and parentheses, so read the state after the last ')'.
+    std::fs::read_to_string(format!("/proc/{pid}/stat"))
+        .ok()
+        .and_then(|stat| {
+            let after_comm = &stat[stat.rfind(')')? + 1..];
+            after_comm
+                .split_whitespace()
+                .next()
+                .map(|state| state == "Z")
+        })
+        .unwrap_or(false)
+}
+
+#[cfg(all(unix, not(target_os = "linux")))]
+fn process_is_zombie(_pid: u32) -> bool {
+    false
+}
+
+#[cfg(windows)]
+fn process_alive(pid: u32) -> bool {
+    use windows_sys::Win32::Foundation::{
+        CloseHandle, ERROR_ACCESS_DENIED, GetLastError, STILL_ACTIVE,
+    };
+    use windows_sys::Win32::System::Threading::{
+        GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
+    };
+
+    unsafe {
+        let handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid);
+        if handle.is_null() {
+            return GetLastError() == ERROR_ACCESS_DENIED;
+        }
+        let mut exit_code = 0u32;
+        let queried = GetExitCodeProcess(handle, &mut exit_code) != 0;
+        CloseHandle(handle);
+        queried && exit_code == STILL_ACTIVE as u32
+    }
 }
 
 fn read_json_line<R: BufRead>(reader: &mut R) -> Result<Option<String>, GitAiError> {
@@ -2659,10 +2734,120 @@ struct FamilySequencerOrder {
     ordinal: u64,
 }
 
+/// A sequenced entry plus the daemon-side moment it became ready. The causal
+/// fence measures its wait from `enqueued_at`, never from git's own
+/// timestamps in the order key.
+#[derive(Debug)]
+struct FamilySequencerSlot {
+    enqueued_at: Instant,
+    entry: FamilySequencerEntry,
+}
+
 #[derive(Debug, Default)]
 struct FamilySequencerState {
     next_ordinal: u64,
-    entries: BTreeMap<FamilySequencerOrder, FamilySequencerEntry>,
+    entries: BTreeMap<FamilySequencerOrder, FamilySequencerSlot>,
+}
+
+/// One open root's standing against the causal fence for some waiting work
+/// (see `classify_root_fence`).
+enum RootFence {
+    /// Still holds; its time bound next changes the answer after this long.
+    Held(Duration),
+    /// Held past its bound, or judged not causally prior by the fallback
+    /// heuristics: release it, and say so once.
+    Release(&'static str),
+    /// Fences nothing: it has not changed refs.
+    Open,
+}
+
+/// What the causal fence needs to know about one open root. Gathered under
+/// the ingress lock (cheap map reads and clones); the filesystem and process
+/// observations run after the lock is dropped, so a slow worktree or a
+/// liveness syscall never stalls trace ingestion.
+#[derive(Clone)]
+struct RootFenceProbe {
+    root_sid: String,
+    waited: Duration,
+    /// Its atexit is queued (or its socket closed): the worker will clear it.
+    finishing: bool,
+    /// Worktree HEAD reflog start offsets and worktree, for commands that move
+    /// HEAD; `None` when that reflog cannot reveal the root's writes.
+    head_reflog: Option<(HashMap<String, u64>, Option<PathBuf>)>,
+    /// The root's start on git's clock, which a reflog modified later reveals
+    /// as written even when its length was recorded late.
+    started_at_ns: Option<u128>,
+    pid: Option<u32>,
+    wrote_refs: Option<bool>,
+    alive: Option<bool>,
+}
+
+impl RootFenceProbe {
+    /// Performs the observations the classification needs: the reflog stat
+    /// when there is one to consult, else a liveness probe once the grace has
+    /// passed. Runs without any daemon lock held.
+    fn observe(&mut self, grace: Duration) {
+        if self.finishing {
+            return;
+        }
+        self.observe_reflog();
+        if self.wrote_refs.is_none() && self.waited >= grace {
+            self.alive = self.pid.map(process_alive);
+        }
+    }
+
+    /// Whether the root has written its worktree HEAD reflog since it started.
+    fn observe_reflog(&mut self) {
+        self.wrote_refs = self.head_reflog.as_ref().and_then(|(offsets, worktree)| {
+            crate::daemon::ref_cursor::worktree_head_reflog_grew_since(
+                offsets,
+                worktree.as_deref(),
+                self.started_at_ns,
+            )
+        });
+    }
+}
+
+/// A fence release to log once the ingress lock is dropped.
+struct FenceRelease {
+    reason: &'static str,
+    context: &'static str,
+    root_sid: String,
+    root_primary: Option<String>,
+    root_family: Option<String>,
+    root_age_ms: Option<u64>,
+    waited_ms: u64,
+}
+
+impl FenceRelease {
+    fn log(&self) {
+        tracing::warn!(
+            component = "daemon",
+            phase = "checkpoint_processing",
+            reason = self.reason,
+            context = self.context,
+            root_sid = %self.root_sid,
+            root_primary = self.root_primary.as_deref().unwrap_or("unknown"),
+            root_family = self.root_family.as_deref().unwrap_or("unattributed"),
+            root_age_ms = self.root_age_ms,
+            waited_ms = self.waited_ms,
+            "proceeding past an open mutating trace root"
+        );
+    }
+}
+
+/// What a drain would do with a family's sequencer front right now.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FamilyFrontDisposition {
+    /// Nothing to pop, or checkpoint admission is in progress: the event that
+    /// appends or admits an entry schedules its own drain.
+    Idle,
+    Ready,
+    /// Fenced behind an older open root; look again after `retry_in` or when
+    /// a root clears or is released (`trace_root_fence_notify`).
+    Fenced {
+        retry_in: Duration,
+    },
 }
 
 type CommitFileTimestampSnapshotHandle =
@@ -2760,6 +2945,8 @@ struct TraceIngressState {
     /// which clears the root (and lifts its fence) when it reaches it. Socket
     /// EOF must not clear such a root first, and needs no close marker for it.
     root_finishing: HashSet<String>,
+    /// Roots whose fence release has been logged and counted already.
+    root_fence_release_logged: HashSet<String>,
 }
 
 #[doc(hidden)]
@@ -2781,6 +2968,17 @@ pub struct ActorDaemonCoordinator {
     /// Outer key: family. Inner key: absolute file path string. Value: registration timestamp (nanos).
     pending_ai_edits_by_family: Mutex<HashMap<String, HashMap<String, u128>>>,
     family_sequencers_by_family: Mutex<HashMap<String, FamilySequencerState>>,
+    /// See [`FAMILY_CAUSAL_GRACE`].
+    causal_grace: Duration,
+    /// Fences released because the root's process was alive past the grace
+    /// and had written nothing.
+    causal_grace_expirations: AtomicU64,
+    /// Fences released at a time bound (hard cap, written-root cap).
+    causal_fence_hard_cap_releases: AtomicU64,
+    /// Fired when a root clears or is released: fenced drains and waits
+    /// re-evaluate. Distinct from the per-frame ingest progress notify so a
+    /// fenced family does not wake on every trace frame the daemon sees.
+    trace_root_fence_notify: Notify,
     commit_file_timestamp_snapshots_by_root:
         Mutex<HashMap<String, CommitFileTimestampSnapshotHandles>>,
     recent_replay_prerequisites_by_family:
@@ -2913,6 +3111,10 @@ impl ActorDaemonCoordinator {
             inflight_effects_by_family: Mutex::new(HashMap::new()),
             pending_ai_edits_by_family: Mutex::new(HashMap::new()),
             family_sequencers_by_family: Mutex::new(HashMap::new()),
+            causal_grace: family_causal_grace(),
+            causal_grace_expirations: AtomicU64::new(0),
+            causal_fence_hard_cap_releases: AtomicU64::new(0),
+            trace_root_fence_notify: Notify::new(),
             commit_file_timestamp_snapshots_by_root: Mutex::new(HashMap::new()),
             recent_replay_prerequisites_by_family: Mutex::new(HashMap::new()),
             side_effect_errors_by_family: Mutex::new(HashMap::new()),
@@ -3335,6 +3537,13 @@ impl ActorDaemonCoordinator {
         }
     }
 
+    #[cfg(test)]
+    fn new_with_causal_grace(causal_grace: Duration) -> Self {
+        let mut coordinator = Self::new();
+        coordinator.causal_grace = causal_grace;
+        coordinator
+    }
+
     /// Attribution work an automatic restart would abandon mid-flight:
     /// accepted checkpoints, queued trace payloads, sequencer entries, and
     /// executing side-effect passes. Still-running commands live in trace
@@ -3519,18 +3728,29 @@ impl ActorDaemonCoordinator {
             ordinal: state.next_ordinal,
         };
         state.next_ordinal = state.next_ordinal.saturating_add(1);
-        state.entries.insert(order, entry);
+        state.entries.insert(
+            order,
+            FamilySequencerSlot {
+                enqueued_at: Instant::now(),
+                entry,
+            },
+        );
         Ok(())
     }
 
-    async fn drain_ready_family_sequencer_entries(&self, family: &str) -> Result<(), GitAiError> {
+    /// Drains the family's ready entries; when an older open root still holds
+    /// the front, returns how long until that fence's time bound is next due.
+    async fn drain_ready_family_sequencer_entries(
+        &self,
+        family: &str,
+    ) -> Result<Option<Duration>, GitAiError> {
         let exec_lock = self.side_effect_exec_lock(family)?;
         let _guard = exec_lock.lock().await;
         self.drain_ready_family_sequencer_entries_locked(family)
             .await
     }
 
-    async fn drain_all_ready_family_sequencers(&self) -> Result<(), GitAiError> {
+    async fn drain_all_ready_family_sequencers(self: &Arc<Self>) -> Result<(), GitAiError> {
         let families = {
             let map = self.family_sequencers_by_family.lock().map_err(|_| {
                 GitAiError::Generic("family sequencer map lock poisoned".to_string())
@@ -3540,17 +3760,25 @@ impl ActorDaemonCoordinator {
                 .map(|(family, _)| family.clone())
                 .collect::<Vec<_>>()
         };
-        let first_error = stream::iter(families)
-            .map(|family| async move { self.drain_ready_family_sequencer_entries(&family).await })
-            .buffer_unordered(CHECKPOINT_FAMILY_DRAIN_CONCURRENCY)
-            .fold(None, |first_error, result| async move {
-                first_error.or_else(|| result.err())
+        let outcomes = stream::iter(families)
+            .map(|family| async move {
+                let outcome = self.drain_ready_family_sequencer_entries(&family).await;
+                (family, outcome)
             })
+            .buffer_unordered(CHECKPOINT_FAMILY_DRAIN_CONCURRENCY)
+            .collect::<Vec<_>>()
             .await;
-        if let Some(error) = first_error {
-            return Err(error);
+        let mut first_error = None;
+        for (family, outcome) in outcomes {
+            match outcome {
+                // A fence lifts on a timer as much as on a root clearing; the
+                // coalesced per-family drain task owns that wait.
+                Ok(Some(_)) => self.schedule_family_drain(family),
+                Ok(None) => {}
+                Err(error) => first_error = first_error.or(Some(error)),
+            }
         }
-        Ok(())
+        first_error.map_or(Ok(()), Err)
     }
 
     /// Schedules drains for sequencer entries unblocked by a cleared trace
@@ -3586,96 +3814,369 @@ impl ActorDaemonCoordinator {
         let coordinator = Arc::clone(self);
         tokio::spawn(async move {
             loop {
-                if let Err(error) = coordinator
+                // Enroll before draining so a root clearing or releasing
+                // between the pass and the wait below cannot be lost.
+                let fence_changed = coordinator.trace_root_fence_notify.notified();
+                tokio::pin!(fence_changed);
+                fence_changed.as_mut().enable();
+                let fenced = match coordinator
                     .drain_ready_family_sequencer_entries(&family)
                     .await
                 {
-                    tracing::error!(
-                        component = "daemon",
-                        phase = "checkpoint_processing",
-                        reason = "family_drain_failed",
-                        %family,
-                        %error,
-                        "failed draining family sequencer"
-                    );
-                    if let Ok(mut scheduled) = coordinator.scheduled_family_drains.lock() {
-                        scheduled.remove(&family);
+                    Ok(Some(retry_in)) => Some(retry_in),
+                    Ok(None) => {
+                        // Deregister atomically with the front check: an entry
+                        // appended after the pass but before deregistration
+                        // must either be seen here (loop again) or by the
+                        // fresh task its own schedule call spawns after we
+                        // release the marker.
+                        let Ok(mut scheduled) = coordinator.scheduled_family_drains.lock() else {
+                            return;
+                        };
+                        match coordinator.family_front_entry_disposition(&family) {
+                            FamilyFrontDisposition::Idle => {
+                                scheduled.remove(&family);
+                                return;
+                            }
+                            FamilyFrontDisposition::Ready => continue,
+                            FamilyFrontDisposition::Fenced { retry_in } => Some(retry_in),
+                        }
                     }
-                    return;
-                }
-                // Deregister atomically with the emptiness check: an entry
-                // appended after the pass but before deregistration must
-                // either be seen here (loop again) or by the fresh task its
-                // own schedule call spawns after we release the marker.
-                let Ok(mut scheduled) = coordinator.scheduled_family_drains.lock() else {
-                    return;
+                    Err(error) => {
+                        tracing::error!(
+                            component = "daemon",
+                            phase = "checkpoint_processing",
+                            reason = "family_drain_failed",
+                            %family,
+                            %error,
+                            "failed draining family sequencer"
+                        );
+                        if let Ok(mut scheduled) = coordinator.scheduled_family_drains.lock() {
+                            scheduled.remove(&family);
+                        }
+                        return;
+                    }
                 };
-                if !coordinator.family_has_actionable_front_entry(&family) {
-                    scheduled.remove(&family);
-                    return;
+                // Keep the marker: this task owns the family's re-drain. The
+                // fence lifts when its root clears or is released (notified)
+                // or when its time bound expires (timer).
+                let deadline = fenced.map(|retry_in| tokio::time::Instant::now() + retry_in);
+                tokio::select! {
+                    _ = &mut fence_changed => {}
+                    _ = sleep_until_or_pending(deadline) => {}
+                    _ = coordinator.wait_for_shutdown() => {
+                        if let Ok(mut scheduled) = coordinator.scheduled_family_drains.lock() {
+                            scheduled.remove(&family);
+                        }
+                        return;
+                    }
                 }
             }
         });
     }
 
-    /// Whether the family's sequencer front would be popped by a drain right
-    /// now — mirrors the gates of `drain_ready_family_sequencer_entries_locked`
-    /// (unadmitted checkpoints, prior-open-root fencing).
-    /// Gated-but-present entries return false: the event that lifts their
-    /// gate (admission completion, root clear) schedules its own drain.
-    fn family_has_actionable_front_entry(&self, family: &str) -> bool {
+    /// What a drain would do with the family's sequencer front right now —
+    /// mirrors the gates of `drain_ready_family_sequencer_entries_locked`
+    /// (unadmitted checkpoints, prior-open-root fencing). Entries gated on
+    /// admission are `Idle`: admission completion schedules its own drain.
+    fn family_front_entry_disposition(&self, family: &str) -> FamilyFrontDisposition {
         if self.unadmitted_checkpoints.load(Ordering::Acquire) > 0 {
-            return false;
+            return FamilyFrontDisposition::Idle;
         }
         let Ok(map) = self.family_sequencers_by_family.lock() else {
-            return false;
+            return FamilyFrontDisposition::Idle;
         };
         let Some(state) = map.get(family) else {
-            return false;
+            return FamilyFrontDisposition::Idle;
         };
-        let Some((order, entry)) = state.entries.first_key_value() else {
-            return false;
+        let Some((order, slot)) = state.entries.first_key_value() else {
+            return FamilyFrontDisposition::Idle;
         };
-        let entry_root_sid = match entry {
-            FamilySequencerEntry::ReadyCommand(command) => Some(command.root_sid.as_str()),
-            FamilySequencerEntry::AppliedSideEffects { applied, .. } => {
-                Some(applied.command.root_sid.as_str())
-            }
-            _ => None,
-        };
-        !self
-            .family_entry_blocked_by_prior_open_trace_root(
-                family,
-                order.started_at_ns,
-                entry_root_sid,
-            )
-            .unwrap_or(true)
+        let (entry_root_sid, entry_kind) = Self::sequencer_entry_identity(&slot.entry);
+        match self.family_entry_blocked_by_prior_open_trace_root(
+            family,
+            order.started_at_ns,
+            entry_root_sid,
+            slot.enqueued_at.elapsed(),
+            entry_kind,
+        ) {
+            Ok(None) => FamilyFrontDisposition::Ready,
+            Ok(Some(retry_in)) => FamilyFrontDisposition::Fenced { retry_in },
+            Err(_) => FamilyFrontDisposition::Idle,
+        }
     }
 
-    /// Whether a sequencer entry must wait for an older mutating trace root
-    /// that is still open: a running command may still change refs, and a
-    /// finished one may have changed them with its final frames not yet
-    /// processed. Roots that started after the entry cannot precede it.
-    /// Unattributed roots (no family yet) fail closed and fence every family.
+    /// The trace root an entry came from (so it never fences itself) and a
+    /// label for logs.
+    fn sequencer_entry_identity(entry: &FamilySequencerEntry) -> (Option<&str>, &'static str) {
+        match entry {
+            FamilySequencerEntry::ReadyCommand(command) => {
+                (Some(command.root_sid.as_str()), "command")
+            }
+            FamilySequencerEntry::AppliedSideEffects { applied, .. } => (
+                Some(applied.command.root_sid.as_str()),
+                "applied_side_effects",
+            ),
+            FamilySequencerEntry::Checkpoint { .. } => (None, "checkpoint"),
+        }
+    }
+
+    /// Whether an open trace root could still change refs that matter to
+    /// `family` (`None`: any family): open, not definitely read-only,
+    /// mutating or not yet classified, and attributed to `family` or to no
+    /// family yet (unattributed roots fail closed and count for everyone).
+    fn open_root_may_mutate_family(
+        ingress: &TraceIngressState,
+        root_sid: &str,
+        family: Option<&str>,
+    ) -> bool {
+        ingress
+            .root_open_connections
+            .get(root_sid)
+            .is_some_and(|count| *count > 0)
+            && !ingress.root_definitely_read_only.contains(root_sid)
+            && ingress.root_mutating.get(root_sid).copied().unwrap_or(true)
+            && family.is_none_or(|family| {
+                ingress
+                    .root_families
+                    .get(root_sid)
+                    .is_none_or(|root_family| root_family == family)
+            })
+    }
+
+    /// Gathers what the fence needs about open root `root_sid` for work that
+    /// has waited `waited`; see [`RootFenceProbe::observe`] for the rest.
+    fn root_fence_probe(
+        ingress: &TraceIngressState,
+        root_sid: &str,
+        waited: Duration,
+    ) -> RootFenceProbe {
+        let moves_head = ingress
+            .root_argv
+            .get(root_sid)
+            .and_then(|argv| trace_argv_primary_command(argv))
+            .is_some_and(|primary| {
+                crate::git::command_classification::moves_head_command(&primary)
+            });
+        RootFenceProbe {
+            root_sid: root_sid.to_string(),
+            waited,
+            finishing: ingress.root_finishing.contains(root_sid)
+                || ingress.root_close_markers_enqueued.contains(root_sid),
+            head_reflog: moves_head
+                .then(|| ingress.root_reflog_start_offsets.get(root_sid).cloned())
+                .flatten()
+                .map(|offsets| (offsets, ingress.root_worktrees.get(root_sid).cloned())),
+            started_at_ns: ingress.root_started_at_ns.get(root_sid).copied(),
+            pid: trace_sid_pid(root_sid),
+            wrote_refs: None,
+            alive: None,
+        }
+    }
+
+    /// Whether an observed open root holds the causal fence. Decides from
+    /// data first and heuristics last, and applies no bookkeeping itself, so
+    /// status probes can ask too (releases are recorded by `evaluate_fence`).
+    ///
+    /// The fence exists for one hazard: a git process that has changed refs
+    /// while its final frame has not reached the sequencer. So:
+    /// - a *finishing* root (atexit read, or socket closed) holds until the
+    ///   worker processes its queued frame, which always clears it; should
+    ///   that somehow not happen, the hard cap releases it with a warning;
+    /// - a HEAD-moving root whose worktree HEAD reflog has grown or been
+    ///   modified since it started has changed refs and holds until it
+    ///   finishes (a post-write hook, say), bounded by the written-root cap;
+    /// - a HEAD-moving root whose worktree HEAD reflog is untouched has
+    ///   changed nothing: it fences nothing, and nobody waits for an editor or
+    ///   a pre-commit hook;
+    /// - any other root (no reflog to consult, or a command whose ref writes
+    ///   that reflog cannot reveal) falls back to time and liveness: it holds
+    ///   for the causal grace, then is released if its process is alive and
+    ///   held until the hard cap if it is gone.
+    fn classify_root_fence(&self, probe: &RootFenceProbe) -> RootFence {
+        let grace = self.causal_grace;
+        let hard_cap = grace * FAMILY_CAUSAL_FENCE_HARD_CAP_MULTIPLIER;
+        let hold_until = |bound: Duration, release: &'static str| {
+            if probe.waited < bound {
+                RootFence::Held(bound - probe.waited)
+            } else {
+                RootFence::Release(release)
+            }
+        };
+        if probe.finishing {
+            return hold_until(hard_cap, "finishing_root_cap");
+        }
+        match probe.wrote_refs {
+            Some(true) => {
+                return hold_until(
+                    grace * FAMILY_WRITTEN_ROOT_FENCE_CAP_MULTIPLIER,
+                    "written_root_cap",
+                );
+            }
+            Some(false) => return RootFence::Open,
+            None => {}
+        }
+        if probe.waited < grace {
+            return hold_until(grace, "causal_grace_expired");
+        }
+        match probe.alive {
+            Some(true) => RootFence::Release("causal_grace_expired"),
+            _ => hold_until(hard_cap, "causal_fence_hard_cap"),
+        }
+    }
+
+    /// Evaluates every open root accepted by `candidate` against the causal
+    /// fence for work that has waited `waited_for(root)`: gathers probes under
+    /// the ingress lock, observes them with the lock dropped, then applies
+    /// (and logs, once per root) any heuristic release. Returns the
+    /// earliest-expiring hold, if any root still holds.
+    fn evaluate_fence(
+        &self,
+        candidate: impl Fn(&TraceIngressState, &str) -> bool,
+        waited_for: impl Fn(&TraceIngressState, &str) -> Duration,
+        context: &'static str,
+    ) -> Result<Option<Duration>, GitAiError> {
+        let lock_ingress = || {
+            self.trace_ingress_state
+                .lock()
+                .map_err(|_| GitAiError::Generic("trace ingress state lock poisoned".to_string()))
+        };
+        let mut probes = {
+            let ingress = lock_ingress()?;
+            ingress
+                .root_open_connections
+                .keys()
+                .filter(|root_sid| candidate(&ingress, root_sid))
+                .map(|root_sid| {
+                    Self::root_fence_probe(&ingress, root_sid, waited_for(&ingress, root_sid))
+                })
+                .collect::<Vec<_>>()
+        };
+        if probes.is_empty() {
+            return Ok(None);
+        }
+        for probe in &mut probes {
+            probe.observe(self.causal_grace);
+        }
+
+        let mut ingress = lock_ingress()?;
+        let mut held: Option<Duration> = None;
+        let mut releases = Vec::new();
+        for probe in probes {
+            // Cleared while we were observing: it fences nothing any more.
+            if !Self::open_root_may_mutate_family(&ingress, &probe.root_sid, None) {
+                continue;
+            }
+            match self.classify_root_fence(&probe) {
+                RootFence::Held(retry_in) => {
+                    if held.is_none_or(|earliest| retry_in < earliest) {
+                        held = Some(retry_in);
+                    }
+                }
+                RootFence::Release(reason) => {
+                    if ingress
+                        .root_fence_release_logged
+                        .insert(probe.root_sid.clone())
+                    {
+                        releases.push(self.fence_release(
+                            &ingress,
+                            probe.root_sid,
+                            reason,
+                            probe.waited,
+                            context,
+                        ));
+                    }
+                }
+                RootFence::Open => {}
+            }
+        }
+        drop(ingress);
+        if !releases.is_empty() {
+            for release in &releases {
+                release.log();
+            }
+            self.trace_root_fence_notify.notify_waiters();
+        }
+        Ok(held)
+    }
+
+    fn fence_release(
+        &self,
+        ingress: &TraceIngressState,
+        root_sid: String,
+        reason: &'static str,
+        waited: Duration,
+        context: &'static str,
+    ) -> FenceRelease {
+        let counter = if reason == "causal_grace_expired" {
+            &self.causal_grace_expirations
+        } else {
+            &self.causal_fence_hard_cap_releases
+        };
+        counter.fetch_add(1, Ordering::Relaxed);
+        FenceRelease {
+            reason,
+            context,
+            root_primary: ingress
+                .root_argv
+                .get(&root_sid)
+                .and_then(|argv| trace_argv_primary_command(argv)),
+            root_family: ingress.root_families.get(&root_sid).cloned(),
+            root_age_ms: ingress
+                .root_started_at_ns
+                .get(&root_sid)
+                .map(|started| (now_unix_nanos().saturating_sub(*started) / 1_000_000) as u64),
+            waited_ms: waited.as_millis() as u64,
+            root_sid,
+        }
+    }
+
+    /// Open mutating roots that hold the causal fence right now: `await`
+    /// treats them as pending work. Roots without a reflog to consult are
+    /// judged on how long the daemon has heard nothing from them.
+    fn has_open_mutating_roots_holding_fence(&self) -> bool {
+        let now = now_unix_nanos();
+        self.evaluate_fence(
+            |ingress, root_sid| Self::open_root_may_mutate_family(ingress, root_sid, None),
+            |ingress, root_sid| {
+                ingress
+                    .root_last_activity_ns
+                    .get(root_sid)
+                    .map(|last| Duration::from_nanos(now.saturating_sub(u128::from(*last)) as u64))
+                    .unwrap_or(Duration::ZERO)
+            },
+            "await",
+        )
+        .ok()
+        .flatten()
+        .is_some()
+    }
+
+    /// Whether a sequencer entry positioned at `started_at_ns`, ready for
+    /// `waited`, must still wait for an older mutating trace root that is open
+    /// (see `classify_root_fence` for how long a root can hold). Roots that
+    /// started after the entry cannot precede it. Unattributed roots (no
+    /// family yet) fail closed and fence every family.
     fn family_entry_blocked_by_prior_open_trace_root(
         &self,
         family: &str,
         started_at_ns: u128,
         entry_root_sid: Option<&str>,
-    ) -> Result<bool, GitAiError> {
-        let ingress = self
-            .trace_ingress_state
-            .lock()
-            .map_err(|_| GitAiError::Generic("trace ingress state lock poisoned".to_string()))?;
-
-        Ok(ingress.root_open_connections.keys().any(|root_sid| {
-            entry_root_sid != Some(root_sid.as_str())
-                && Self::open_root_may_mutate_family(&ingress, root_sid, Some(family))
-                && ingress
-                    .root_started_at_ns
-                    .get(root_sid)
-                    .is_none_or(|root_started| *root_started <= started_at_ns)
-        }))
+        waited: Duration,
+        entry_kind: &'static str,
+    ) -> Result<Option<Duration>, GitAiError> {
+        self.evaluate_fence(
+            |ingress, root_sid| {
+                entry_root_sid != Some(root_sid)
+                    && Self::open_root_may_mutate_family(ingress, root_sid, Some(family))
+                    && ingress
+                        .root_started_at_ns
+                        .get(root_sid)
+                        .is_none_or(|root_started| *root_started <= started_at_ns)
+            },
+            |_, _| waited,
+            entry_kind,
+        )
     }
 
     fn record_side_effect_error(
@@ -3838,30 +4339,8 @@ impl ActorDaemonCoordinator {
         ingress.root_open_connections.remove(root_sid);
         ingress.root_close_markers_enqueued.remove(root_sid);
         ingress.root_finishing.remove(root_sid);
+        ingress.root_fence_release_logged.remove(root_sid);
         fenced
-    }
-
-    /// Whether an open trace root could still change refs that matter to
-    /// `family` (`None`: any family): open, not definitely read-only,
-    /// mutating or not yet classified, and attributed to `family` or to no
-    /// family yet (unattributed roots fail closed and count for everyone).
-    fn open_root_may_mutate_family(
-        ingress: &TraceIngressState,
-        root_sid: &str,
-        family: Option<&str>,
-    ) -> bool {
-        ingress
-            .root_open_connections
-            .get(root_sid)
-            .is_some_and(|count| *count > 0)
-            && !ingress.root_definitely_read_only.contains(root_sid)
-            && ingress.root_mutating.get(root_sid).copied().unwrap_or(true)
-            && family.is_none_or(|family| {
-                ingress
-                    .root_families
-                    .get(root_sid)
-                    .is_none_or(|root_family| root_family == family)
-            })
     }
 
     fn record_trace_connection_close(&self, roots: &[String]) -> Result<Vec<String>, GitAiError> {
@@ -3992,31 +4471,10 @@ impl ActorDaemonCoordinator {
         })?;
         queued.remove(root_sid);
         self.trace_ingest_progress_notify.notify_waiters();
+        if cleared.is_some() {
+            self.trace_root_fence_notify.notify_waiters();
+        }
         Ok(cleared)
-    }
-
-    fn has_open_trace_roots_that_may_mutate_refs(&self) -> bool {
-        let Ok(ingress) = self.trace_ingress_state.lock() else {
-            return false;
-        };
-        ingress
-            .root_open_connections
-            .keys()
-            .any(|root| Self::open_root_may_mutate_family(&ingress, root, None))
-    }
-
-    /// As [`Self::has_open_trace_roots_that_may_mutate_refs`], but scoped to
-    /// one family: roots already attributed to a DIFFERENT family (via their
-    /// `def_repo` worktree) cannot mutate this family's refs and are ignored.
-    /// Roots with no family attribution yet fail closed and block everyone.
-    fn has_open_trace_roots_that_may_mutate_family(&self, family: &str) -> bool {
-        let Ok(ingress) = self.trace_ingress_state.lock() else {
-            return false;
-        };
-        ingress
-            .root_open_connections
-            .keys()
-            .any(|root| Self::open_root_may_mutate_family(&ingress, root, Some(family)))
     }
 
     fn next_trace_ingest_seq(&self) -> u64 {
@@ -4436,10 +4894,13 @@ impl ActorDaemonCoordinator {
             state.next_ordinal = state.next_ordinal.saturating_add(1);
             state.entries.insert(
                 order,
-                FamilySequencerEntry::Checkpoint {
-                    request: Box::new(prepared.request),
-                    receipt_seq: prepared.receipt_seq,
-                    reservation: prepared.reservation,
+                FamilySequencerSlot {
+                    enqueued_at: Instant::now(),
+                    entry: FamilySequencerEntry::Checkpoint {
+                        request: Box::new(prepared.request),
+                        receipt_seq: prepared.receipt_seq,
+                        reservation: prepared.reservation,
+                    },
                 },
             );
             self.unadmitted_checkpoints
@@ -4571,13 +5032,11 @@ impl ActorDaemonCoordinator {
 
     fn checkpoint_admission_delay_log_interval() -> Duration {
         #[cfg(feature = "test-support")]
-        if let Ok(raw) = std::env::var("GIT_AI_TEST_CHECKPOINT_ADMISSION_DELAY_LOG_INTERVAL_MS")
-            && let Ok(interval_ms) = raw.parse::<u64>()
-            && interval_ms > 0
-        {
-            return Duration::from_millis(interval_ms);
-        }
-
+        return env_duration_ms(
+            "GIT_AI_TEST_CHECKPOINT_ADMISSION_DELAY_LOG_INTERVAL_MS",
+            CHECKPOINT_ADMISSION_DELAY_LOG_INTERVAL,
+        );
+        #[cfg(not(feature = "test-support"))]
         CHECKPOINT_ADMISSION_DELAY_LOG_INTERVAL
     }
 
@@ -4622,19 +5081,38 @@ impl ActorDaemonCoordinator {
     }
 
     /// Waits until all trace payloads enqueued up to now have been processed
-    /// by the ingest worker, and any identified trace root that may mutate refs
-    /// has closed. This is a causal drain fence: it guarantees that trace2 data
+    /// by the ingest worker, and no identified trace root that may mutate refs
+    /// still holds the causal fence (see `classify_root_fence`): it has
+    /// closed, or it has been open past the grace with its process provably
+    /// still running and nothing written. This guarantees that trace2 data
     /// already visible to the daemon for prior mutating git operations has
-    /// reached the family sequencer before returning.
+    /// reached the family sequencer.
     ///
     /// Accepted sockets with no complete trace2 root are not causal evidence for
     /// any repository family. They are tracked for connection cleanup, but must
     /// not globally block checkpoint/sync control requests.
-    ///
-    /// Used by checkpoint entry to ensure ordering: a checkpoint must not be
-    /// processed until all causally-prior git operations have been ingested
-    /// through their root `atexit`/connection-close boundary.
     async fn wait_for_trace_ingest_processed_through(&self) {
+        self.wait_for_trace_ingest_processed_through_scope(None, "global")
+            .await
+    }
+
+    /// As [`Self::wait_for_trace_ingest_processed_through`], but scoped to one
+    /// family: open mutating roots already attributed to a different family do
+    /// not hold this fence, so a long-running git command in one repository
+    /// does not delay `sync.family` for every other repository. Unattributed
+    /// roots still fail closed and count until their `def_repo` arrives.
+    async fn wait_for_trace_ingest_processed_through_family(&self, family: &str) {
+        self.wait_for_trace_ingest_processed_through_scope(Some(family), "sync")
+            .await
+    }
+
+    async fn wait_for_trace_ingest_processed_through_scope(
+        &self,
+        family: Option<&str>,
+        context: &'static str,
+    ) {
+        let started = Instant::now();
+        let started_ns = now_unix_nanos();
         loop {
             // Read the current high-water mark. Any payload enqueued before this
             // point has a seq <= this value. We need to wait until the ingest
@@ -4642,42 +5120,30 @@ impl ActorDaemonCoordinator {
             let target = self.next_trace_ingest_seq.load(Ordering::Acquire) as u64;
             self.wait_for_trace_ingest_seq(target).await;
 
-            if !self.has_open_trace_roots_that_may_mutate_refs() {
+            // Enroll before checking (see wait_for_trace_ingest_seq): a root
+            // clearing or releasing must not race the evaluation.
+            let fence_changed = self.trace_root_fence_notify.notified();
+            tokio::pin!(fence_changed);
+            fence_changed.as_mut().enable();
+            // Roots that started after this wait began cannot precede the
+            // work it certifies, and must not be judged on this wait's clock.
+            let hold = self.evaluate_fence(
+                |ingress, root_sid| {
+                    Self::open_root_may_mutate_family(ingress, root_sid, family)
+                        && ingress
+                            .root_started_at_ns
+                            .get(root_sid)
+                            .is_none_or(|root_started| *root_started <= started_ns)
+                },
+                |_, _| started.elapsed(),
+                context,
+            );
+            let Ok(Some(retry_in)) = hold else {
                 return;
-            }
-
-            let progress = self.trace_ingest_progress_notify.notified();
-            if !self.has_open_trace_roots_that_may_mutate_refs() {
-                return;
-            }
+            };
             tokio::select! {
-                _ = progress => {}
-                _ = self.wait_for_shutdown() => return,
-            }
-        }
-    }
-
-    /// As [`Self::wait_for_trace_ingest_processed_through`], but scoped to one
-    /// family: open mutating roots already attributed to a different family do
-    /// not hold this fence, so a long-running git command in one repository no
-    /// longer delays `sync.family` for every other repository. Unattributed
-    /// roots still fail closed and block until their `def_repo` arrives.
-    async fn wait_for_trace_ingest_processed_through_family(&self, family: &str) {
-        loop {
-            let target = self.next_trace_ingest_seq.load(Ordering::Acquire) as u64;
-            self.wait_for_trace_ingest_seq(target).await;
-
-            // Enroll before checking (see wait_for_trace_ingest_seq): the
-            // notify_waiters fired by the root's close/def_repo must not race
-            // the condition load.
-            let progress = self.trace_ingest_progress_notify.notified();
-            tokio::pin!(progress);
-            progress.as_mut().enable();
-            if !self.has_open_trace_roots_that_may_mutate_family(family) {
-                return;
-            }
-            tokio::select! {
-                _ = &mut progress => {}
+                _ = &mut fence_changed => {}
+                _ = tokio::time::sleep(retry_in) => {}
                 _ = self.wait_for_shutdown() => return,
             }
         }
@@ -4894,44 +5360,43 @@ impl ActorDaemonCoordinator {
     async fn drain_ready_family_sequencer_entries_locked(
         &self,
         family: &str,
-    ) -> Result<(), GitAiError> {
+    ) -> Result<Option<Duration>, GitAiError> {
         // Register the in-flight pass BEFORE popping entries: completion
         // fences must never observe an empty sequencer with no registered
         // pass while popped entries are about to execute (#2252).
         let _family_effect = self.begin_family_effect_guarded(family);
         let mut ready: Vec<(u64, FamilySequencerEntry)> = Vec::new();
+        let mut fenced = None;
         {
             let mut map = self.family_sequencers_by_family.lock().map_err(|_| {
                 GitAiError::Generic("family sequencer map lock poisoned".to_string())
             })?;
             if self.unadmitted_checkpoints.load(Ordering::Acquire) > 0 {
-                return Ok(());
+                return Ok(None);
             }
             let Some(state) = map.get_mut(family) else {
-                return Ok(());
+                return Ok(None);
             };
             while let Some(first_entry) = state.entries.first_entry() {
-                let entry_root_sid = match first_entry.get() {
-                    FamilySequencerEntry::ReadyCommand(command) => Some(command.root_sid.as_str()),
-                    FamilySequencerEntry::AppliedSideEffects { applied, .. } => {
-                        Some(applied.command.root_sid.as_str())
-                    }
-                    _ => None,
-                };
-                if self.family_entry_blocked_by_prior_open_trace_root(
+                let slot = first_entry.get();
+                let (entry_root_sid, entry_kind) = Self::sequencer_entry_identity(&slot.entry);
+                fenced = self.family_entry_blocked_by_prior_open_trace_root(
                     family,
                     first_entry.key().started_at_ns,
                     entry_root_sid,
-                )? {
+                    slot.enqueued_at.elapsed(),
+                    entry_kind,
+                )?;
+                if fenced.is_some() {
                     break;
                 }
-                let (order, entry) = first_entry.remove_entry();
-                ready.push((order.ordinal, entry));
+                let (order, slot) = first_entry.remove_entry();
+                ready.push((order.ordinal, slot.entry));
             }
         }
 
         if ready.is_empty() {
-            return Ok(());
+            return Ok(fenced);
         }
 
         for (order, ready_entry) in ready {
@@ -5363,7 +5828,7 @@ impl ActorDaemonCoordinator {
             }
         }
 
-        Ok(())
+        Ok(fenced)
     }
 
     fn worktree_state_key(worktree: &Path) -> String {
@@ -7064,7 +7529,10 @@ impl ActorDaemonCoordinator {
         }
     }
 
-    async fn sync_family(&self, repo_working_dir: String) -> Result<FamilyStatus, GitAiError> {
+    async fn sync_family(
+        self: &Arc<Self>,
+        repo_working_dir: String,
+    ) -> Result<FamilyStatus, GitAiError> {
         let checkpoint_target = self.next_checkpoint_receipt_seq.load(Ordering::Acquire) as u64;
         self.wait_for_checkpoint_admission_through(checkpoint_target)
             .await;
@@ -7098,7 +7566,7 @@ impl ActorDaemonCoordinator {
         self.status_for_family(repo_working_dir).await
     }
 
-    async fn drain_accepted_checkpoints(&self) -> Result<(), GitAiError> {
+    async fn drain_accepted_checkpoints(self: &Arc<Self>) -> Result<(), GitAiError> {
         loop {
             let checkpoint_target = self.next_checkpoint_receipt_seq.load(Ordering::Acquire) as u64;
             self.wait_for_checkpoint_admission_through(checkpoint_target)
@@ -7123,7 +7591,7 @@ impl ActorDaemonCoordinator {
     /// Progress is logged every few seconds. Returns an `AwaitResult` describing
     /// whether the daemon was idle before the timeout and how much telemetry
     /// (if any) is still pending.
-    async fn await_completion(&self, timeout_secs: u64) -> AwaitResult {
+    async fn await_completion(self: &Arc<Self>, timeout_secs: u64) -> AwaitResult {
         use tokio::time::{Duration, Instant, timeout};
 
         let start = Instant::now();
@@ -7284,7 +7752,7 @@ impl ActorDaemonCoordinator {
         {
             return true;
         }
-        if self.has_open_trace_roots_that_may_mutate_refs() {
+        if self.has_open_mutating_roots_holding_fence() {
             return true;
         }
         if let Ok(map) = self.inflight_effects_by_family.lock()
@@ -7316,7 +7784,7 @@ impl ActorDaemonCoordinator {
         Ok(())
     }
 
-    async fn handle_control_request(&self, request: ControlRequest) -> ControlResponse {
+    async fn handle_control_request(self: &Arc<Self>, request: ControlRequest) -> ControlResponse {
         let result = match request {
             ControlRequest::Ping => Ok(ControlResponse::ok(None, None)),
             ControlRequest::CheckpointRun { .. } => Err(GitAiError::Generic(
@@ -8798,6 +9266,21 @@ fn daemon_max_uptime_ns() -> u128 {
 
 const DAEMON_SOCKET_HEALTH_CHECK_SECS: u64 = 30;
 
+/// A positive millisecond duration override from the environment, else
+/// `default`.
+fn env_duration_ms(var: &str, default: Duration) -> Duration {
+    std::env::var(var)
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .filter(|ms| *ms > 0)
+        .map(Duration::from_millis)
+        .unwrap_or(default)
+}
+
+fn family_causal_grace() -> Duration {
+    env_duration_ms("GIT_AI_DAEMON_CAUSAL_GRACE_MS", FAMILY_CAUSAL_GRACE)
+}
+
 fn daemon_socket_health_check_interval() -> u64 {
     std::env::var("GIT_AI_DAEMON_SOCKET_HEALTH_CHECK_SECS")
         .ok()
@@ -9183,11 +9666,10 @@ fn report_ingest_losses(coordinator: &Arc<ActorDaemonCoordinator>) {
 const TRACE_DRAIN_PROBE_DEADLINE: Duration = Duration::from_secs(5);
 
 fn daemon_trace_drain_probe_deadline() -> Duration {
-    std::env::var("GIT_AI_DAEMON_TRACE_DRAIN_PROBE_DEADLINE_MS")
-        .ok()
-        .and_then(|v| v.parse::<u64>().ok())
-        .map(Duration::from_millis)
-        .unwrap_or(TRACE_DRAIN_PROBE_DEADLINE)
+    env_duration_ms(
+        "GIT_AI_DAEMON_TRACE_DRAIN_PROBE_DEADLINE_MS",
+        TRACE_DRAIN_PROBE_DEADLINE,
+    )
 }
 
 /// End-to-end trace drain health probe: connect to the trace socket, write
@@ -11654,13 +12136,25 @@ mod tests {
     /// Opens a mutating root running `argv` attributed to `repo`, so the
     /// reader records its family and its reflog start offsets.
     fn open_attributed_root(coord: &ActorDaemonCoordinator, sid: &str, repo: &Path, argv: &[&str]) {
+        open_attributed_root_started_at(coord, sid, repo, argv, now_unix_nanos());
+    }
+
+    /// Like `open_attributed_root`, with the root's `start` frame stamped at
+    /// `started_at_ns` on git's clock.
+    fn open_attributed_root_started_at(
+        coord: &ActorDaemonCoordinator,
+        sid: &str,
+        repo: &Path,
+        argv: &[&str],
+        started_at_ns: u128,
+    ) {
         coord.trace_root_connection_opened(sid).unwrap();
         let mut start = serde_json::json!({
             "event": "start",
             "sid": sid,
             "argv": argv,
             "worktree": repo,
-            "time_ns": 1u64,
+            "time_ns": started_at_ns as u64,
         });
         assert!(coord.prepare_trace_payload_for_ingest(&mut start));
     }
@@ -11695,11 +12189,13 @@ mod tests {
         );
     }
 
+    /// Appends a completed rebase keyed at the current clock, so it follows
+    /// every root opened earlier in the test.
     fn append_ready_rebase(coord: &ActorDaemonCoordinator, family: &str) {
         coord
             .append_family_sequencer_entry(
                 family,
-                2,
+                now_unix_nanos(),
                 FamilySequencerEntry::ReadyCommand(Box::new(test_rebase_command(&[], Vec::new()))),
             )
             .unwrap();
@@ -11811,18 +12307,24 @@ mod tests {
         );
         assert_eq!(coord.causal_grace_expirations.load(Ordering::Relaxed), 0);
 
-        // A finishing root is never released by time: its final frame is
-        // queued and the worker clears it, even if that frame fails to ingest.
+        // A finishing root's final frame is queued and the worker clears it,
+        // even if that frame fails to ingest; only the hard cap, a safety net
+        // against a root the worker somehow never clears, releases it by time.
         let coord = ActorDaemonCoordinator::new_with_causal_grace(grace);
         let sid = alive_root_sid("stuck");
         open_unattributed_commit_root(&coord, &sid);
         read_root_atexit(&coord, &sid);
         append_ready_rebase(&coord, "family-a");
-        tokio::time::sleep(grace * FAMILY_CAUSAL_FENCE_HARD_CAP_MULTIPLIER + grace).await;
+        tokio::time::sleep(grace * (FAMILY_CAUSAL_FENCE_HARD_CAP_MULTIPLIER / 2)).await;
         assert!(is_fenced(coord.family_front_entry_disposition("family-a")));
+        tokio::time::sleep(grace * (FAMILY_CAUSAL_FENCE_HARD_CAP_MULTIPLIER / 2) + grace).await;
+        assert_eq!(
+            coord.family_front_entry_disposition("family-a"),
+            FamilyFrontDisposition::Ready
+        );
         assert_eq!(
             coord.causal_fence_hard_cap_releases.load(Ordering::Relaxed),
-            0
+            1
         );
     }
 
@@ -11867,6 +12369,36 @@ mod tests {
             coord.causal_fence_hard_cap_releases.load(Ordering::Relaxed),
             0
         );
+    }
+
+    #[tokio::test]
+    async fn root_that_wrote_before_its_reflog_length_was_recorded_counts_as_written() {
+        let grace = Duration::from_millis(20);
+        let coord = ActorDaemonCoordinator::new_with_causal_grace(grace);
+        let temp = tempfile::tempdir().unwrap();
+        let (repo, family) = init_test_family(&coord, &temp);
+        commit_untraced(&repo);
+        // The root started, wrote, and only then did the reader get to record
+        // its reflog length: the length shows no growth, but the reflog was
+        // modified after the root's start.
+        let started_at_ns = now_unix_nanos();
+        std::thread::sleep(Duration::from_millis(20));
+        commit_untraced(&repo);
+        let sid = alive_root_sid("late-capture");
+        open_attributed_root_started_at(
+            &coord,
+            &sid,
+            &repo,
+            &["git", "commit", "-m", "already written"],
+            started_at_ns,
+        );
+        append_ready_rebase(&coord, &family);
+        tokio::time::sleep(grace * 3).await;
+        assert!(
+            is_fenced(coord.family_front_entry_disposition(&family)),
+            "a late-recorded reflog length must not hide a write that already happened"
+        );
+        assert_eq!(coord.causal_grace_expirations.load(Ordering::Relaxed), 0);
     }
 
     #[tokio::test]

--- a/src/daemon/ref_cursor.rs
+++ b/src/daemon/ref_cursor.rs
@@ -2343,6 +2343,44 @@ pub(crate) fn capture_reflog_start_offsets_for_worktree(worktree: &Path) -> Hash
     offsets
 }
 
+/// Whether a command that started at `started_at_ns` has written the worktree
+/// `HEAD` reflog since: the reflog is longer than the length recorded in
+/// `start_offsets` when the command started, or it was modified after the
+/// command started. The modification time covers a recorded length that was
+/// itself taken late, after the first write; unlike a reflog entry's committer
+/// date it cannot be set by the user. A repository that had no `HEAD` reflog
+/// then but has one now has been written too. `None` when nothing can be said:
+/// the worktree is unknown, the repository keeps no reflogs, or the file
+/// cannot be read.
+pub(crate) fn worktree_head_reflog_grew_since(
+    start_offsets: &HashMap<String, u64>,
+    worktree: Option<&Path>,
+    started_at_ns: Option<u128>,
+) -> Option<bool> {
+    let Some((key, start_len)) = start_offsets
+        .iter()
+        .find(|(key, _)| key.starts_with("worktree:"))
+    else {
+        let logs = git_dir_for_worktree(worktree?)?.join("logs");
+        if !logs.is_dir() {
+            return None;
+        }
+        return Some(logs.join("HEAD").is_file());
+    };
+    let (_, path) = reflog_reference_and_path_for_key(Path::new(""), key)?;
+    let metadata = fs::metadata(&path).ok()?;
+    if metadata.len() > *start_len {
+        return Some(true);
+    }
+    let modified_ns = metadata
+        .modified()
+        .ok()?
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()?
+        .as_nanos();
+    Some(modified_ns > started_at_ns?)
+}
+
 pub(crate) fn refs_at_reflog_start_offsets(
     family: &FamilyKey,
     offsets: &HashMap<String, u64>,

--- a/src/daemon/stream_worker.rs
+++ b/src/daemon/stream_worker.rs
@@ -380,13 +380,9 @@ impl StreamWorker {
             } else {
                 self.next_delayed_task_at()
             };
-            let retry_sleep = async {
-                if let Some(at) = next_retry_at {
-                    tokio::time::sleep_until(tokio::time::Instant::from_std(at)).await;
-                } else {
-                    std::future::pending::<()>().await;
-                }
-            };
+            let retry_sleep = crate::daemon::sleep_until_or_pending(
+                next_retry_at.map(tokio::time::Instant::from_std),
+            );
 
             tokio::select! {
                 _ = self.shutdown_notify.notified() => {

--- a/src/git/command_classification.rs
+++ b/src/git/command_classification.rs
@@ -129,6 +129,24 @@ pub fn participates_in_family_sequencer_command(command: &str) -> bool {
     )
 }
 
+/// Commands whose ref writes move `HEAD`, and so append to the worktree's
+/// `HEAD` reflog. Other mutating commands write refs that reflog cannot reveal.
+pub fn moves_head_command(command: &str) -> bool {
+    matches!(
+        command,
+        "am" | "checkout"
+            | "cherry-pick"
+            | "commit"
+            | "merge"
+            | "pull"
+            | "rebase"
+            | "reset"
+            | "revert"
+            | "stash"
+            | "switch"
+    )
+}
+
 /// Returns true when a full Git invocation must be ordered inside an existing
 /// repo family.
 pub fn git_invocation_participates_in_family_sequencer(

--- a/tests/commit_tree_update_ref.rs
+++ b/tests/commit_tree_update_ref.rs
@@ -11,7 +11,12 @@ use git_ai::git::find_repository_in_path;
 use git_ai::git::notes_api::read_note;
 use git_ai::git::repository::Repository as GitAiRepository;
 use repos::test_file::ExpectedLineExt;
-use repos::test_repo::{TestRepo, new_daemon_test_sync_session_id, real_git_executable};
+#[cfg(not(windows))]
+use repos::test_repo::configure_raw_traced_git_env_for;
+use repos::test_repo::{
+    TestRepo, configure_raw_traced_git_env, live_pid_trace_sid, new_daemon_test_sync_session_id,
+    real_git_executable,
+};
 use serde_json::{Value, json};
 use std::fs;
 use std::io::Write;
@@ -95,23 +100,7 @@ fn ai_attested_lines_for_file(
 fn raw_traced_git(repo: &TestRepo, args: &[&str]) -> String {
     let mut command = Command::new(real_git_executable());
     command.arg("-C").arg(repo.path()).args(args);
-    command.env("HOME", repo.test_home_path());
-    command.env(
-        "GIT_CONFIG_GLOBAL",
-        repo.test_home_path().join(".gitconfig"),
-    );
-    command.env("XDG_CONFIG_HOME", repo.test_home_path().join(".config"));
-    command.env("GIT_CONFIG_NOSYSTEM", "1");
-    command.env(
-        "GIT_TRACE2_EVENT",
-        git_ai::daemon::DaemonConfig::trace2_event_target_for_path(
-            &repo.daemon_trace_socket_path(),
-        ),
-    );
-    command.env(
-        "GIT_TRACE2_EVENT_NESTING",
-        std::env::var("GIT_AI_TEST_TRACE2_NESTING").unwrap_or_else(|_| "0".to_string()),
-    );
+    configure_raw_traced_git_env(&mut command, repo);
 
     let output = command
         .output()
@@ -137,23 +126,7 @@ fn raw_traced_git(repo: &TestRepo, args: &[&str]) -> String {
 fn raw_traced_git_stdin(repo: &TestRepo, args: &[&str], stdin: &str) -> String {
     let mut command = Command::new(real_git_executable());
     command.arg("-C").arg(repo.path()).args(args);
-    command.env("HOME", repo.test_home_path());
-    command.env(
-        "GIT_CONFIG_GLOBAL",
-        repo.test_home_path().join(".gitconfig"),
-    );
-    command.env("XDG_CONFIG_HOME", repo.test_home_path().join(".config"));
-    command.env("GIT_CONFIG_NOSYSTEM", "1");
-    command.env(
-        "GIT_TRACE2_EVENT",
-        git_ai::daemon::DaemonConfig::trace2_event_target_for_path(
-            &repo.daemon_trace_socket_path(),
-        ),
-    );
-    command.env(
-        "GIT_TRACE2_EVENT_NESTING",
-        std::env::var("GIT_AI_TEST_TRACE2_NESTING").unwrap_or_else(|_| "0".to_string()),
-    );
+    configure_raw_traced_git_env(&mut command, repo);
     command.stdin(Stdio::piped());
     command.stdout(Stdio::piped());
     command.stderr(Stdio::piped());
@@ -191,23 +164,7 @@ fn raw_traced_git_with_session(repo: &TestRepo, args: &[&str], session: &str) ->
         .arg("-c")
         .arg(&session_arg)
         .args(args);
-    command.env("HOME", repo.test_home_path());
-    command.env(
-        "GIT_CONFIG_GLOBAL",
-        repo.test_home_path().join(".gitconfig"),
-    );
-    command.env("XDG_CONFIG_HOME", repo.test_home_path().join(".config"));
-    command.env("GIT_CONFIG_NOSYSTEM", "1");
-    command.env(
-        "GIT_TRACE2_EVENT",
-        git_ai::daemon::DaemonConfig::trace2_event_target_for_path(
-            &repo.daemon_trace_socket_path(),
-        ),
-    );
-    command.env(
-        "GIT_TRACE2_EVENT_NESTING",
-        std::env::var("GIT_AI_TEST_TRACE2_NESTING").unwrap_or_else(|_| "0".to_string()),
-    );
+    configure_raw_traced_git_env(&mut command, repo);
 
     let output = command
         .output()
@@ -228,17 +185,10 @@ fn raw_traced_git_with_session(repo: &TestRepo, args: &[&str], session: &str) ->
 fn raw_traced_git_in_dir(dir: &Path, test_home: &Path, trace_socket: &Path, args: &[&str]) {
     let mut command = Command::new(real_git_executable());
     command.arg("-C").arg(dir).args(args);
-    command.env("HOME", test_home);
-    command.env("GIT_CONFIG_GLOBAL", test_home.join(".gitconfig"));
-    command.env("XDG_CONFIG_HOME", test_home.join(".config"));
-    command.env("GIT_CONFIG_NOSYSTEM", "1");
-    command.env(
-        "GIT_TRACE2_EVENT",
-        git_ai::daemon::DaemonConfig::trace2_event_target_for_path(trace_socket),
-    );
-    command.env(
-        "GIT_TRACE2_EVENT_NESTING",
-        std::env::var("GIT_AI_TEST_TRACE2_NESTING").unwrap_or_else(|_| "0".to_string()),
+    configure_raw_traced_git_env_for(
+        &mut command,
+        test_home,
+        &git_ai::daemon::DaemonConfig::trace2_event_target_for_path(trace_socket),
     );
 
     let output = command
@@ -276,18 +226,8 @@ fn raw_git_trace_to_file_output(repo: &TestRepo, args: &[&str], trace_path: &Pat
     let _ = fs::remove_file(trace_path);
     let mut command = Command::new(real_git_executable());
     command.arg("-C").arg(repo.path()).args(args);
-    command.env("HOME", repo.test_home_path());
-    command.env(
-        "GIT_CONFIG_GLOBAL",
-        repo.test_home_path().join(".gitconfig"),
-    );
-    command.env("XDG_CONFIG_HOME", repo.test_home_path().join(".config"));
-    command.env("GIT_CONFIG_NOSYSTEM", "1");
+    configure_raw_traced_git_env(&mut command, repo);
     command.env("GIT_TRACE2_EVENT", trace_path);
-    command.env(
-        "GIT_TRACE2_EVENT_NESTING",
-        std::env::var("GIT_AI_TEST_TRACE2_NESTING").unwrap_or_else(|_| "0".to_string()),
-    );
 
     command
         .output()
@@ -332,32 +272,6 @@ fn replay_trace_payloads_to_daemon(repo: &TestRepo, payloads: &[Value]) {
         stream.write_all(b"\n").expect("write trace newline");
     }
     stream.flush().expect("flush trace payloads");
-}
-
-fn open_unfinished_mutating_trace_root(
-    repo: &TestRepo,
-    sid: &str,
-) -> git_ai::daemon::DaemonClientStream {
-    let mut stream = open_local_socket_stream_with_timeout(
-        &repo.daemon_trace_socket_path(),
-        Duration::from_secs(2),
-    )
-    .expect("connect unfinished trace root to daemon");
-    let line = serde_json::to_string(&json!({
-        "event": "start",
-        "sid": sid,
-        "argv": ["git", "commit", "-m", "unfinished earlier command"],
-        "time_ns": 1u64,
-    }))
-    .expect("serialize unfinished trace start");
-    stream
-        .write_all(line.as_bytes())
-        .expect("write unfinished trace start");
-    stream
-        .write_all(b"\n")
-        .expect("write unfinished trace newline");
-    stream.flush().expect("flush unfinished trace start");
-    stream
 }
 
 fn daemon_completed_session(repo: &TestRepo, session: &str) -> bool {
@@ -2049,7 +1963,7 @@ fn test_delayed_current_branch_update_ref_trace_preserves_new_commit_attribution
 }
 
 #[test]
-fn test_update_ref_side_effect_waits_for_prior_open_trace_root_without_family() {
+fn test_update_ref_side_effect_waits_for_prior_open_trace_root_until_causal_grace() {
     let repo = TestRepo::new();
     setup_initial_commit(&repo);
 
@@ -2082,8 +1996,9 @@ fn test_update_ref_side_effect_waits_for_prior_open_trace_root_without_family() 
     .trim()
     .to_string();
 
+    // This test process stands in for the still-running git: its pid is alive.
     let unfinished_trace =
-        open_unfinished_mutating_trace_root(&repo, "20260411T120000.000000-Punfinished-root");
+        repo.open_mutating_commit_trace_root(&live_pid_trace_sid("unfinished"), false);
     std::thread::sleep(Duration::from_millis(100));
 
     let session = new_daemon_test_sync_session_id();
@@ -2094,10 +2009,23 @@ fn test_update_ref_side_effect_waits_for_prior_open_trace_root_without_family() 
     );
 
     let start = std::time::Instant::now();
-    while start.elapsed() < Duration::from_millis(500) {
+    while start.elapsed() < Duration::from_millis(200) {
         assert!(
             !daemon_completed_session(&repo, &session),
             "update-ref side effect completed while an earlier mutating trace root was still open without family metadata"
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    }
+
+    // Past the causal grace the daemon checks the root's process: it is alive
+    // and has not written anything, so the command is still running and
+    // nothing causally prior is in flight. The fence releases without waiting
+    // for the trace to close.
+    let released = std::time::Instant::now();
+    while !daemon_completed_session(&repo, &session) {
+        assert!(
+            released.elapsed() < Duration::from_secs(5),
+            "update-ref side effect stayed fenced behind a live open trace root past the causal grace"
         );
         std::thread::sleep(Duration::from_millis(10));
     }
@@ -2146,4 +2074,252 @@ fn test_update_ref_stdin_head_with_new_content_preserves_attribution() {
     repo.wait_for_daemon_total_completion_count(baseline, baseline + 1);
 
     assert_note_has_ai_for_file(&repo, &commit_sha, "stdin.txt");
+}
+
+#[cfg(not(windows))]
+fn checkpoint_completion_count(repo: &TestRepo) -> usize {
+    repo.daemon_completion_entries()
+        .iter()
+        .filter(|entry| entry.kind == "checkpoint")
+        .count()
+}
+
+#[cfg(not(windows))]
+fn completion_seq_for_session(repo: &TestRepo, session: &str) -> u64 {
+    let entries = repo.daemon_completion_entries();
+    entries
+        .iter()
+        .find(|entry| entry.test_sync_session.as_deref() == Some(session))
+        .unwrap_or_else(|| panic!("no completion entry for session {session}: {entries:?}"))
+        .seq
+}
+
+/// A commit held open in its pre-commit hook must not hold up, nor be
+/// sequenced ahead of, a commit of the same family that started later but
+/// finished first: the blocked commit has not changed the repository yet. Here
+/// the blocked commit runs in the main worktree while a linked worktree of the
+/// same family commits underneath it.
+#[test]
+#[cfg(not(windows))]
+fn test_commit_blocked_in_pre_commit_hook_is_sequenced_after_later_completed_commit() {
+    let repo =
+        TestRepo::new_worktree_with_daemon_scope(repos::test_repo::DaemonTestScope::Dedicated);
+    let main_path = repo
+        .base_repo_path()
+        .expect("linked worktree has a base repo")
+        .to_path_buf();
+
+    // Main worktree: an AI edit is staged and its commit blocks in pre-commit.
+    fs::write(main_path.join("blocked.txt"), "blocked ai\n").unwrap();
+    repo.git_ai_from_working_dir(&main_path, &["checkpoint", "mock_ai", "blocked.txt"])
+        .unwrap();
+    raw_traced_git_in_dir(
+        &main_path,
+        repo.test_home_path(),
+        &repo.daemon_trace_socket_path(),
+        &["add", "blocked.txt"],
+    );
+    let blocked_session = new_daemon_test_sync_session_id();
+    let mut blocked = repos::test_repo::BlockedTracedGit::spawn_commit_blocked_in(
+        &repo,
+        &main_path,
+        "pre-commit",
+        &blocked_session,
+        "blocked commit",
+    );
+
+    // Linked worktree: a later AI edit commits and finishes while the first
+    // commit is still blocked.
+    fs::write(repo.path().join("later.txt"), "later ai\n").unwrap();
+    repo.git_ai_without_pre_sync_for_test(&["checkpoint", "mock_ai", "later.txt"])
+        .unwrap();
+    raw_traced_git(&repo, &["add", "later.txt"]);
+    let later_session = new_daemon_test_sync_session_id();
+    raw_traced_git_with_session(&repo, &["commit", "-m", "later commit"], &later_session);
+
+    // The later commit is processed while the blocked one is still running.
+    let started = std::time::Instant::now();
+    while !daemon_completed_session(&repo, &later_session) {
+        assert!(
+            blocked.is_running(),
+            "the hook-blocked commit must still be running"
+        );
+        assert!(
+            started.elapsed() < Duration::from_secs(10),
+            "the later commit stayed fenced behind the hook-blocked commit"
+        );
+        std::thread::sleep(Duration::from_millis(25));
+    }
+
+    blocked.release();
+    repo.sync_daemon_external_completion_sessions(&[
+        blocked_session.clone(),
+        later_session.clone(),
+    ]);
+    assert!(
+        completion_seq_for_session(&repo, &later_session)
+            < completion_seq_for_session(&repo, &blocked_session),
+        "the commit that finished first must be sequenced first"
+    );
+
+    let mut later_file = repo.filename("later.txt");
+    later_file.assert_committed_lines(lines!["later ai".ai()]);
+    let main_head = raw_untraced_git(
+        &repo,
+        &["-C", main_path.to_str().unwrap(), "rev-parse", "HEAD"],
+    )
+    .trim()
+    .to_string();
+    let note = repo
+        .read_authorship_note(&main_head)
+        .expect("the blocked commit has an authorship note");
+    let log = AuthorshipLog::deserialize_from_string(&note).expect("parse authorship note");
+    assert_eq!(
+        ai_attested_lines_for_file(&log, "blocked.txt"),
+        std::collections::BTreeSet::from([1]),
+        "the blocked commit's AI line is attributed exactly"
+    );
+}
+
+/// A checkpoint that arrives while a `git commit` of the same family is
+/// blocked in its pre-commit hook must not wait for that commit: the commit
+/// has written nothing yet (its worktree HEAD reflog has not grown), so it
+/// fences nothing and the checkpoint is processed at once. The commit's own
+/// attribution is intact once it completes.
+#[test]
+#[cfg(not(windows))]
+fn test_checkpoint_completes_while_commit_blocked_in_pre_commit_hook() {
+    let repo = TestRepo::new_dedicated_daemon();
+    setup_initial_commit(&repo);
+
+    fs::write(repo.path().join("blocked.txt"), "blocked ai\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "blocked.txt"])
+        .unwrap();
+    raw_traced_git(&repo, &["add", "blocked.txt"]);
+    let blocked_session = new_daemon_test_sync_session_id();
+    let mut blocked = repos::test_repo::BlockedTracedGit::spawn_commit_blocked_in(
+        &repo,
+        repo.path(),
+        "pre-commit",
+        &blocked_session,
+        "blocked commit",
+    );
+
+    let baseline = checkpoint_completion_count(&repo);
+    fs::write(repo.path().join("later.txt"), "later ai\n").unwrap();
+    repo.git_ai_without_pre_sync_for_test(&["checkpoint", "mock_ai", "later.txt"])
+        .unwrap();
+
+    let started = std::time::Instant::now();
+    while checkpoint_completion_count(&repo) == baseline {
+        assert!(
+            blocked.is_running(),
+            "the hook-blocked commit must still be running"
+        );
+        assert!(
+            started.elapsed() < Duration::from_secs(10),
+            "checkpoint stayed fenced behind the hook-blocked commit; daemon log:\n{}",
+            repo.daemon_stderr_contents()
+        );
+        std::thread::sleep(Duration::from_millis(25));
+    }
+    assert!(
+        blocked.is_running(),
+        "the checkpoint must complete without waiting for the blocked commit"
+    );
+    assert!(
+        started.elapsed() < Duration::from_secs(2),
+        "a root that has written nothing must not delay the checkpoint; took {:?}",
+        started.elapsed()
+    );
+
+    blocked.release();
+    repo.sync_daemon_external_completion_sessions(&[blocked_session]);
+    let mut blocked_file = repo.filename("blocked.txt");
+    blocked_file.assert_committed_lines(lines!["blocked ai".ai()]);
+
+    raw_traced_git(&repo, &["add", "later.txt"]);
+    let later_session = new_daemon_test_sync_session_id();
+    raw_traced_git_with_session(&repo, &["commit", "-m", "later commit"], &later_session);
+    repo.sync_daemon_external_completion_sessions(&[later_session]);
+    let mut later_file = repo.filename("later.txt");
+    later_file.assert_committed_lines(lines!["later ai".ai()]);
+}
+
+/// A commit blocked in its post-commit hook has already moved HEAD. A
+/// checkpoint arriving during that hook observed the new HEAD and must be
+/// processed after the commit, however long the hook runs: the daemon sees the
+/// root's worktree HEAD reflog has grown and keeps the fence even though the
+/// process is alive.
+#[test]
+#[cfg(not(windows))]
+fn test_checkpoint_during_post_commit_hook_waits_for_the_commit() {
+    let repo = TestRepo::new_dedicated_daemon();
+    setup_initial_commit(&repo);
+
+    fs::write(repo.path().join("committed.txt"), "committed ai\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_ai", "committed.txt"])
+        .unwrap();
+    raw_traced_git(&repo, &["add", "committed.txt"]);
+    let commit_session = new_daemon_test_sync_session_id();
+    let mut blocked = repos::test_repo::BlockedTracedGit::spawn_commit_blocked_in(
+        &repo,
+        repo.path(),
+        "post-commit",
+        &commit_session,
+        "committed during hook",
+    );
+
+    let baseline = checkpoint_completion_count(&repo);
+    fs::write(repo.path().join("typed.txt"), "typed ai\n").unwrap();
+    repo.git_ai_without_pre_sync_for_test(&["checkpoint", "mock_ai", "typed.txt"])
+        .unwrap();
+
+    // The checkpoint stays held behind the commit for as long as its hook runs.
+    let held = std::time::Instant::now();
+    while held.elapsed() < Duration::from_millis(800) {
+        assert!(
+            blocked.is_running(),
+            "the hook-blocked commit must still be running"
+        );
+        assert_eq!(
+            checkpoint_completion_count(&repo),
+            baseline,
+            "a checkpoint taken after HEAD moved must wait for the commit that moved it; daemon log:\n{}",
+            repo.daemon_stderr_contents()
+        );
+        std::thread::sleep(Duration::from_millis(50));
+    }
+
+    blocked.release();
+    repo.sync_daemon_external_completion_sessions(std::slice::from_ref(&commit_session));
+    let started = std::time::Instant::now();
+    while checkpoint_completion_count(&repo) == baseline {
+        assert!(
+            started.elapsed() < Duration::from_secs(10),
+            "the checkpoint must be processed once the commit finishes"
+        );
+        std::thread::sleep(Duration::from_millis(25));
+    }
+    let entries = repo.daemon_completion_entries();
+    let commit_seq = completion_seq_for_session(&repo, &commit_session);
+    let checkpoint_seq = entries
+        .iter()
+        .filter(|entry| entry.kind == "checkpoint")
+        .map(|entry| entry.seq)
+        .max()
+        .expect("checkpoint completion entry");
+    assert!(
+        commit_seq < checkpoint_seq,
+        "the commit must be sequenced before the checkpoint that observed it (commit={commit_seq}, checkpoint={checkpoint_seq})"
+    );
+
+    let mut committed_file = repo.filename("committed.txt");
+    committed_file.assert_committed_lines(lines!["committed ai".ai()]);
+    raw_traced_git(&repo, &["add", "typed.txt"]);
+    let typed_session = new_daemon_test_sync_session_id();
+    raw_traced_git_with_session(&repo, &["commit", "-m", "typed commit"], &typed_session);
+    repo.sync_daemon_external_completion_sessions(&[typed_session]);
+    let mut typed_file = repo.filename("typed.txt");
+    typed_file.assert_committed_lines(lines!["typed ai".ai()]);
 }

--- a/tests/commit_tree_update_ref.rs
+++ b/tests/commit_tree_update_ref.rs
@@ -2249,8 +2249,8 @@ fn test_checkpoint_completes_while_commit_blocked_in_pre_commit_hook() {
 /// A commit blocked in its post-commit hook has already moved HEAD. A
 /// checkpoint arriving during that hook observed the new HEAD and must be
 /// processed after the commit, however long the hook runs: the daemon sees the
-/// root's worktree HEAD reflog has grown and keeps the fence even though the
-/// process is alive.
+/// root's worktree HEAD reflog was written since the root started and keeps
+/// the fence even though the process is alive.
 #[test]
 #[cfg(not(windows))]
 fn test_checkpoint_during_post_commit_hook_waits_for_the_commit() {

--- a/tests/daemon_mode.rs
+++ b/tests/daemon_mode.rs
@@ -24,9 +24,12 @@ use git_ai::metrics::{
     EventAttributes, MetricEvent, PosEncoded, SessionEventValues, TokenUsageValues,
 };
 use repos::test_file::ExpectedLineExt;
+#[cfg(not(windows))]
+use repos::test_repo::live_pid_trace_sid;
 use repos::test_repo::{
     DAEMON_SPAWN_LOADER_RETRY_ATTEMPTS, DaemonTestCompletionLogEntry, DaemonTestScope, TestRepo,
-    get_binary_path, is_windows_loader_init_failure, real_git_executable,
+    configure_raw_traced_git_env_for, get_binary_path, is_windows_loader_init_failure,
+    real_git_executable, trace_atexit_frame, write_trace_frames,
 };
 use serde_json::Value;
 use serde_json::json;
@@ -136,39 +139,7 @@ fn send_trace_frames(trace_socket_path: &Path, payloads: &[Value]) {
     let mut stream =
         open_local_socket_stream_with_timeout(trace_socket_path, DAEMON_TEST_PROBE_TIMEOUT)
             .expect("failed to connect to trace socket");
-    for payload in payloads {
-        let raw = serde_json::to_string(payload).expect("failed to serialize trace payload");
-        stream
-            .write_all(raw.as_bytes())
-            .expect("failed to write trace payload");
-        stream
-            .write_all(b"\n")
-            .expect("failed to write trace newline");
-    }
-    stream.flush().expect("failed to flush trace payloads");
-}
-
-fn trace_atexit_frame(sid: &str, code: i32, time_ns: u64) -> Value {
-    json!({
-        "event": "atexit",
-        "sid": sid,
-        "code": code,
-        "time_ns": time_ns,
-    })
-}
-
-#[cfg(not(windows))]
-fn write_trace_frames_to_stream(stream: &mut impl Write, payloads: &[Value]) {
-    for payload in payloads {
-        let raw = serde_json::to_string(payload).expect("failed to serialize trace payload");
-        stream
-            .write_all(raw.as_bytes())
-            .expect("failed to write trace payload");
-        stream
-            .write_all(b"\n")
-            .expect("failed to write trace newline");
-    }
-    stream.flush().expect("failed to flush trace payloads");
+    write_trace_frames(&mut stream, payloads);
 }
 
 /// Waits until the repo's dedicated daemon logs that a delayed side-effect
@@ -727,15 +698,14 @@ impl WorkdirRaceHarness {
     fn run_traced_git(&self, workdir: &Path, args: &[&str]) {
         let mut command = Command::new(real_git_executable());
         command.args(args).current_dir(workdir);
-        configure_test_home_env(&mut command, &self.test_home);
+        configure_raw_traced_git_env_for(
+            &mut command,
+            &self.test_home,
+            &DaemonConfig::trace2_event_target_for_path(&self.trace_socket_path),
+        );
         let output = command
             .env("GIT_AI_TEST_DB_PATH", &self.test_db_path)
             .env("GITAI_TEST_DB_PATH", &self.test_db_path)
-            .env(
-                "GIT_TRACE2_EVENT",
-                DaemonConfig::trace2_event_target_for_path(&self.trace_socket_path),
-            )
-            .env("GIT_TRACE2_EVENT_NESTING", "0")
             .output()
             .expect("failed to execute traced git command");
         assert!(
@@ -2882,38 +2852,87 @@ fn daemon_stalled_unidentified_trace_connection_does_not_block_sync_control_requ
 
 #[test]
 #[cfg(not(windows))]
+fn daemon_sync_family_returns_promptly_with_open_unwritten_mutating_root() {
+    let repo = TestRepo::new_dedicated_daemon();
+    // An attributed `git commit` that is still running (its worktree HEAD
+    // reflog has not grown) fences nothing: nobody waits for an editor.
+    let sid = live_pid_trace_sid("sync");
+    let mut open_trace = repo.open_mutating_commit_trace_root(&sid, true);
+    thread::sleep(Duration::from_millis(150));
+
+    let started = std::time::Instant::now();
+    let response = send_control_request_with_timeout(
+        &daemon_control_socket_path(&repo),
+        &ControlRequest::SyncFamily {
+            repo_working_dir: repo_workdir_string(&repo),
+        },
+        Duration::from_secs(5),
+    )
+    .expect("sync.family must return while an interactive git command stays open");
+    assert!(response.ok, "sync.family failed: {response:?}");
+    assert!(
+        started.elapsed() < Duration::from_secs(3),
+        "sync.family must not wait for a root that has written nothing"
+    );
+
+    write_trace_frames(&mut open_trace, &[trace_atexit_frame(&sid, 0, 1_002)]);
+}
+
+#[test]
+#[cfg(not(windows))]
+fn daemon_await_completes_with_idle_open_mutating_root() {
+    let repo = TestRepo::new_with_daemon_env(&[("GIT_AI_DAEMON_CAUSAL_GRACE_MS", "300")]);
+    let sid = live_pid_trace_sid("await");
+    let mut open_trace = repo.open_mutating_commit_trace_root(&sid, true);
+    thread::sleep(Duration::from_millis(150));
+
+    let started = std::time::Instant::now();
+    let response = send_control_request_with_timeout(
+        &daemon_control_socket_path(&repo),
+        &ControlRequest::Await { timeout_secs: 5 },
+        Duration::from_secs(15),
+    )
+    .expect("await must answer while an interactive git command stays open");
+    assert!(response.ok, "await failed: {response:?}");
+    let data = response.data.expect("await response data");
+    assert_eq!(
+        data["timed_out"],
+        json!(false),
+        "await must not run to its deadline behind a human at an editor: {data}"
+    );
+    assert!(
+        started.elapsed() < Duration::from_secs(4),
+        "await should return well before its 5s deadline"
+    );
+
+    write_trace_frames(&mut open_trace, &[trace_atexit_frame(&sid, 0, 1_002)]);
+}
+
+#[test]
+#[cfg(not(windows))]
 fn daemon_sync_family_ignores_open_mutating_root_from_other_family() {
     let first_repo = TestRepo::new_dedicated_daemon();
     let second_repo = TestRepo::new_with_daemon_scope(DaemonTestScope::NoDaemon);
-    let trace_socket = daemon_trace_socket_path(&first_repo);
     let control_socket = daemon_control_socket_path(&first_repo);
-    let first_worktree = repo_workdir_string(&first_repo);
     let second_worktree = repo_workdir_string(&second_repo);
-    let first_git_dir = first_repo.path().join(".git").to_string_lossy().to_string();
     let sid = "cross-family-open-mutating-root";
 
-    let mut open_trace =
-        open_local_socket_stream_with_timeout(&trace_socket, DAEMON_TEST_PROBE_TIMEOUT)
-            .expect("failed to connect to trace socket");
-    write_trace_frames_to_stream(
-        &mut open_trace,
-        &[
-            json!({
-                "event": "start",
-                "sid": sid,
-                "argv": ["git", "commit", "-m", "long-running commit"],
-                "time_ns": 1_000u64,
-            }),
-            json!({
-                "event": "def_repo",
-                "sid": sid,
-                "worktree": first_worktree,
-                "repo": first_git_dir,
-                "time_ns": 1_001u64,
-            }),
-        ],
-    );
+    let mut open_trace = first_repo.open_mutating_commit_trace_root(sid, true);
     thread::sleep(Duration::from_millis(150));
+
+    // The root has written refs (a real commit in its worktree, as its
+    // process would); from here on its own family must wait for it.
+    first_repo
+        .git_og_with_env(
+            &[
+                "commit",
+                "--allow-empty",
+                "-m",
+                "written under the open root",
+            ],
+            &[("GIT_TRACE2_EVENT", "0")],
+        )
+        .expect("untraced commit");
 
     let own_control_socket = control_socket.clone();
     let own_worktree = repo_workdir_string(&first_repo);
@@ -2932,7 +2951,7 @@ fn daemon_sync_family_ignores_open_mutating_root_from_other_family() {
         own_sync_rx
             .recv_timeout(Duration::from_millis(250))
             .is_err(),
-        "sync.family must still wait for an open mutating root in its own family"
+        "sync.family must still wait for an open mutating root in its own family once it has written"
     );
 
     let unrelated_sync = send_control_request_with_timeout(
@@ -2948,7 +2967,7 @@ fn daemon_sync_family_ignores_open_mutating_root_from_other_family() {
         "unrelated sync.family request failed: {unrelated_sync:?}"
     );
 
-    write_trace_frames_to_stream(&mut open_trace, &[trace_atexit_frame(sid, 0, 1_002)]);
+    write_trace_frames(&mut open_trace, &[trace_atexit_frame(sid, 0, 1_002)]);
     let own_sync_response = own_sync_rx
         .recv_timeout(Duration::from_secs(1))
         .expect("own-family sync should complete after the trace root closes")
@@ -3081,7 +3100,7 @@ fn daemon_trace_read_error_does_not_leave_root_open_forever() {
     let mut stream =
         open_local_socket_stream_with_timeout(&trace_socket, DAEMON_TEST_PROBE_TIMEOUT)
             .expect("failed to connect to trace socket");
-    write_trace_frames_to_stream(
+    write_trace_frames(
         &mut stream,
         &[
             json!({
@@ -3140,7 +3159,7 @@ fn daemon_trace_family_resolution_io_does_not_block_other_readers() {
     let mut slow_repo_stream =
         open_local_socket_stream_with_timeout(&trace_socket, DAEMON_TEST_PROBE_TIMEOUT)
             .expect("failed to connect slow-repo trace socket");
-    write_trace_frames_to_stream(
+    write_trace_frames(
         &mut slow_repo_stream,
         &[
             json!({
@@ -3685,7 +3704,7 @@ fn daemon_trace_ingest_backpressure_shuts_down_without_blocking_listener() {
     let mut stream =
         open_local_socket_stream_with_timeout(&trace_socket, DAEMON_TEST_PROBE_TIMEOUT)
             .expect("failed to connect trace socket");
-    write_trace_frames_to_stream(
+    write_trace_frames(
         &mut stream,
         &[
             json!({
@@ -8107,7 +8126,7 @@ fn trace_queue_full_drop_logs_the_dropped_root() {
     let mut stream =
         open_local_socket_stream_with_timeout(&trace_socket, DAEMON_TEST_PROBE_TIMEOUT)
             .expect("failed to connect trace socket");
-    write_trace_frames_to_stream(
+    write_trace_frames(
         &mut stream,
         &[
             json!({

--- a/tests/integration/repos/test_repo.rs
+++ b/tests/integration/repos/test_repo.rs
@@ -4,8 +4,8 @@ use git_ai::authorship::authorship_log_serialization::AuthorshipLog;
 use git_ai::authorship::stats::CommitStats;
 use git_ai::config::ConfigPatch;
 use git_ai::daemon::{
-    ControlRequest, DaemonConfig, local_socket_connects_with_timeout, send_control_request,
-    send_control_request_with_timeout,
+    ControlRequest, DaemonClientStream, DaemonConfig, local_socket_connects_with_timeout,
+    open_local_socket_stream_with_timeout, send_control_request, send_control_request_with_timeout,
 };
 use git_ai::feature_flags::FeatureFlags;
 use git_ai::git::cli_parser::{ParsedGitInvocation, extract_clone_target_directory};
@@ -1801,7 +1801,7 @@ impl TestRepo {
             .and_then(|patch| serde_json::to_string(patch).ok())
     }
 
-    fn trace2_nesting_value() -> String {
+    pub(crate) fn trace2_nesting_value() -> String {
         std::env::var("GIT_AI_TEST_TRACE2_NESTING").unwrap_or_else(|_| "0".to_string())
     }
 
@@ -2486,6 +2486,45 @@ impl TestRepo {
 
     pub fn path(&self) -> &PathBuf {
         &self.path
+    }
+
+    /// The main repository path when this `TestRepo` is a linked worktree
+    /// created via `new_worktree*`; `None` for standalone repositories.
+    pub fn base_repo_path(&self) -> Option<&Path> {
+        self._base_repo_path.as_deref()
+    }
+
+    /// Holds a synthetic mutating `git commit` root open on the daemon's trace
+    /// socket: a `start` frame, plus a `def_repo` attributing it to this repo
+    /// when `attribute_to_repo`. Dropping the stream closes the root without
+    /// an `atexit`; write `trace_atexit_frame` to finish it normally.
+    pub(crate) fn open_mutating_commit_trace_root(
+        &self,
+        sid: &str,
+        attribute_to_repo: bool,
+    ) -> DaemonClientStream {
+        let mut stream = open_local_socket_stream_with_timeout(
+            &self.daemon_trace_socket_path(),
+            Duration::from_secs(2),
+        )
+        .expect("connect trace root to daemon");
+        let mut frames = vec![serde_json::json!({
+            "event": "start",
+            "sid": sid,
+            "argv": ["git", "commit", "-m", "still running"],
+            "time_ns": 1_000u64,
+        })];
+        if attribute_to_repo {
+            frames.push(serde_json::json!({
+                "event": "def_repo",
+                "sid": sid,
+                "worktree": self.path().to_string_lossy(),
+                "repo": self.path().join(".git").to_string_lossy(),
+                "time_ns": 1_001u64,
+            }));
+        }
+        write_trace_frames(&mut stream, &frames);
+        stream
     }
 
     pub fn canonical_path(&self) -> PathBuf {
@@ -3593,6 +3632,156 @@ pub(crate) fn real_git_executable() -> &'static str {
     // Ensure HOME is isolated before Config::get() caches HOME-derived paths.
     ensure_isolated_process_home();
     git_ai::config::Config::get().git_cmd()
+}
+
+/// Points a raw (non-proxied) git command at an isolated test HOME and at a
+/// trace2 event target, exactly like production trace2 wiring.
+pub(crate) fn configure_raw_traced_git_env_for(
+    command: &mut Command,
+    test_home: &Path,
+    trace2_event_target: &str,
+) {
+    configure_test_home_env(command, test_home);
+    command.env("GIT_TRACE2_EVENT", trace2_event_target);
+    command.env("GIT_TRACE2_EVENT_NESTING", TestRepo::trace2_nesting_value());
+}
+
+/// As [`configure_raw_traced_git_env_for`], targeting the repo's per-test
+/// daemon trace socket.
+pub(crate) fn configure_raw_traced_git_env(command: &mut Command, repo: &TestRepo) {
+    configure_raw_traced_git_env_for(
+        command,
+        repo.test_home_path(),
+        &DaemonConfig::trace2_event_target_for_path(&repo.daemon_trace_socket_path()),
+    );
+}
+
+/// Writes newline-delimited trace2 frames to an open daemon trace stream.
+pub(crate) fn write_trace_frames(stream: &mut impl Write, frames: &[serde_json::Value]) {
+    for frame in frames {
+        let raw = serde_json::to_string(frame).expect("serialize trace frame");
+        stream.write_all(raw.as_bytes()).expect("write trace frame");
+        stream.write_all(b"\n").expect("write trace frame newline");
+    }
+    stream.flush().expect("flush trace frames");
+}
+
+pub(crate) fn trace_atexit_frame(sid: &str, code: i32, time_ns: u64) -> serde_json::Value {
+    serde_json::json!({
+        "event": "atexit",
+        "sid": sid,
+        "code": code,
+        "time_ns": time_ns,
+    })
+}
+
+/// A trace2 root sid whose pid is this test process: alive for as long as the
+/// test runs, standing in for a git command blocked in an editor or a hook.
+pub(crate) fn live_pid_trace_sid(tag: &str) -> String {
+    format!("20260411T120000.000000-H{tag}-P{:x}", std::process::id())
+}
+
+/// A real, trace2-wired `git commit` whose named hook blocks until released.
+/// Lets tests hold a mutating Git root open (the way an editor or a slow hook
+/// does) while other daemon work arrives for the same family. Blocking in
+/// `pre-commit` holds the root before it writes refs; `post-commit` after.
+#[cfg(not(windows))]
+pub(crate) struct BlockedTracedGit {
+    child: Child,
+    release_path: PathBuf,
+}
+
+#[cfg(not(windows))]
+impl BlockedTracedGit {
+    /// Spawns `git commit -m <message>` in `working_dir`, tagged with
+    /// `git-ai.testSyncSession=<session>` so its completion can be synced
+    /// later. Returns once the `hook` is blocking; the child is released and
+    /// reaped on drop, including when a later assertion panics.
+    pub(crate) fn spawn_commit_blocked_in(
+        repo: &TestRepo,
+        working_dir: &Path,
+        hook: &str,
+        session: &str,
+        message: &str,
+    ) -> Self {
+        use std::os::unix::fs::PermissionsExt;
+
+        let hooks_dir = repo
+            .test_home_path()
+            .join(format!("blocked-hooks-{session}"));
+        fs::create_dir_all(&hooks_dir).expect("create blocked hooks dir");
+        let started_path = hooks_dir.join("started");
+        let release_path = hooks_dir.join("release");
+        let hook_path = hooks_dir.join(hook);
+        fs::write(
+            &hook_path,
+            format!(
+                "#!/bin/sh\ntouch '{}'\nwhile [ ! -e '{}' ]; do sleep 0.05; done\n",
+                started_path.display(),
+                release_path.display()
+            ),
+        )
+        .expect("write blocking hook");
+        fs::set_permissions(&hook_path, fs::Permissions::from_mode(0o755))
+            .expect("chmod blocking hook");
+
+        let mut command = Command::new(real_git_executable());
+        command
+            .arg("-C")
+            .arg(working_dir)
+            .arg("-c")
+            .arg(format!("core.hooksPath={}", hooks_dir.display()))
+            .arg("-c")
+            .arg(format!("git-ai.testSyncSession={session}"))
+            .args(["commit", "-m", message])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        configure_raw_traced_git_env(&mut command, repo);
+        let child = command.spawn().expect("spawn blocked traced git commit");
+        let mut blocked = Self {
+            child,
+            release_path,
+        };
+
+        let started = Instant::now();
+        while !started_path.exists() {
+            assert!(
+                blocked.is_running(),
+                "git commit exited before reaching its {hook} hook"
+            );
+            assert!(
+                started.elapsed() < Duration::from_secs(20),
+                "git commit never reached its {hook} hook"
+            );
+            thread::sleep(Duration::from_millis(10));
+        }
+        blocked
+    }
+
+    pub(crate) fn is_running(&mut self) -> bool {
+        self.child
+            .try_wait()
+            .expect("poll blocked git commit")
+            .is_none()
+    }
+
+    /// Releases the hook and waits for the commit to finish successfully.
+    pub(crate) fn release(mut self) {
+        fs::write(&self.release_path, b"").expect("release blocking hook");
+        let status = self.child.wait().expect("wait for released git commit");
+        assert!(status.success(), "released git commit failed: {status}");
+    }
+}
+
+#[cfg(not(windows))]
+impl Drop for BlockedTracedGit {
+    fn drop(&mut self) {
+        if fs::write(&self.release_path, b"").is_err() {
+            let _ = self.child.kill();
+        }
+        let _ = self.child.wait();
+    }
 }
 
 /// Create a pre-initialized template repo (cached across all tests in the process).


### PR DESCRIPTION
## Summary

Part 2 of 4. The prior-open-root fence held a completed sequencer entry (and `sync.family`, the shutdown drain, and `await`) for as long as any older mutating git root of the family stayed open, with no bound — the stall itself.

The fence exists for one hazard: a git process that has changed refs while its final frame has not reached the sequencer. This PR decides that from data first, heuristics last:

1. A root whose `atexit` the reader has consumed (or whose socket closed) holds until the worker processes the queued frame, which always clears it.
2. The reader already records each mutating root's worktree `HEAD` reflog length at start. If that reflog has grown, the root has changed refs and holds until it finishes (a post-write hook, say), bounded at 600× the grace. If it has not grown, the root has changed nothing and fences nothing: nobody waits for an editor or a pre-commit hook, not even a grace.
3. Only a root with no worktree `HEAD` reflog to consult falls back to time and liveness: one causal grace (1 s, `GIT_AI_DAEMON_CAUSAL_GRACE_MS`), after which a root whose git process (pid from the trace2 sid; zombies count as gone, `EPERM` as alive) is alive is released and logged once (`reason=causal_grace_expired`), while a gone/unknown process holds until a hard cap (30×, `reason=causal_fence_hard_cap`).

The coalesced per-family drain task owns the re-drain timer and wakes on a dedicated root-fence notify rather than on every trace frame; drains started elsewhere hand fenced families to it. `await` counts an open root as work only while it holds the fence. Release counters feed the health snapshot in PR 3.

Rejected along the way (reviews): hook `child_start` sniffing (hooks are usually absent; `reference-transaction` fires before the write; reader-path cost) and a sticky per-root release (a released editor commit later writes).

## Testing

TDD: tests commit first. Real-git integration tests via a new `BlockedTracedGit` harness helper: a commit blocked in `pre-commit` neither delays nor precedes a later commit in a sibling worktree (line-level attribution asserted for both); a checkpoint during a `pre-commit` block completes at once; a checkpoint during a `post-commit` block waits for the commit and is sequenced after it; `sync.family`/`await` return promptly with an open unwritten root and wait once the root has written. Unit tests cover each fence tier, liveness (live/reaped/zombie/EPERM), and the reflog growth check. Shared harness helpers replace five duplicated raw traced-git env blocks and three synthetic open-root builders. `daemon_mode` (114), `commit_tree_update_ref` (40), full suite green except the two environment-specific lib tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
