### PR TITLE
feat(daemon): status.daemon control request and bg status health snapshot

### DIFF
--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -458,11 +458,14 @@ fn handle_status(repo_working_dir: String) -> Result<(), String> {
     // family-level status query which requires a valid repo.
     if crate::git::find_repository_in_path(&repo_working_dir).is_err() {
         let daemon_running = daemon_is_up(&config);
-        let response = serde_json::json!({
+        let mut response = serde_json::json!({
             "ok": true,
             "git_repo": false,
             "daemon_running": daemon_running,
         });
+        if daemon_running {
+            attach_daemon_health(&config, &mut response);
+        }
         println!(
             "{}",
             serde_json::to_string_pretty(&response).map_err(|e| e.to_string())?
@@ -473,11 +476,36 @@ fn handle_status(repo_working_dir: String) -> Result<(), String> {
     let request = ControlRequest::StatusFamily { repo_working_dir };
     let response =
         send_control_request(&config.control_socket_path, &request).map_err(|e| e.to_string())?;
+    let mut output = serde_json::to_value(&response).map_err(|e| e.to_string())?;
+    attach_daemon_health(&config, &mut output);
     println!(
         "{}",
-        serde_json::to_string_pretty(&response).map_err(|e| e.to_string())?
+        serde_json::to_string_pretty(&output).map_err(|e| e.to_string())?
     );
     Ok(())
+}
+
+/// Adds the daemon-wide pipeline health (`status.daemon`) under `daemon`, or
+/// the reason it is unavailable under `daemon_error`; family status prints
+/// either way.
+fn attach_daemon_health(config: &DaemonConfig, output: &mut serde_json::Value) {
+    match send_control_request(&config.control_socket_path, &ControlRequest::StatusDaemon) {
+        Ok(response) if response.ok => {
+            output["daemon"] = response.data.unwrap_or(serde_json::Value::Null);
+        }
+        Ok(response) => {
+            let error = response.error.unwrap_or_default();
+            let message =
+                if error.contains("invalid control request") && error.contains("status.daemon") {
+                    "the running background service predates status.daemon; run `git-ai bg restart`"
+                        .to_string()
+                } else {
+                    error
+                };
+            output["daemon_error"] = serde_json::Value::String(message);
+        }
+        Err(error) => output["daemon_error"] = serde_json::Value::String(error.to_string()),
+    }
 }
 
 fn handle_tail(args: &[String]) -> Result<(), String> {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2796,6 +2796,19 @@ impl RootFenceProbe {
         }
     }
 
+    /// Performs every observation at once, for a status peek that judges the
+    /// root against several waits without touching the file system or the
+    /// process table again. Runs without any daemon lock held.
+    fn observe_all(&mut self) {
+        if self.finishing {
+            return;
+        }
+        self.observe_reflog();
+        if self.wrote_refs.is_none() {
+            self.alive = self.pid.map(process_alive);
+        }
+    }
+
     /// Whether the root has written its worktree HEAD reflog since it started.
     fn observe_reflog(&mut self) {
         self.wrote_refs = self.head_reflog.as_ref().and_then(|(offsets, worktree)| {
@@ -12491,6 +12504,286 @@ mod tests {
             "a finishing root's frames are queued: waits hold and await keeps it pending"
         );
         assert!(coord.has_pending_daemon_work());
+    }
+
+    #[tokio::test]
+    async fn health_snapshot_counts_sequencer_entries_by_kind_and_reports_fence() {
+        use crate::daemon::health::DaemonHealthSnapshot;
+
+        let coord = ActorDaemonCoordinator::new_with_causal_grace(Duration::from_secs(10));
+        let idle = DaemonHealthSnapshot::capture(&coord);
+        assert!(!idle.snapshot_partial);
+        assert_eq!(idle.sequencer_families, 0);
+        assert_eq!(idle.trace_roots_open_mutating, 0);
+        assert!(idle.families.is_empty());
+
+        let sid = alive_root_sid("health");
+        open_unattributed_commit_root(&coord, &sid);
+        append_ready_rebase(&coord, "family-a");
+
+        let fenced = DaemonHealthSnapshot::capture(&coord);
+        assert!(!fenced.snapshot_partial);
+        assert_eq!(fenced.trace_roots_open_mutating, 1);
+        assert_eq!(fenced.trace_roots_finishing, 0);
+        assert_eq!(fenced.trace_roots_written, 0);
+        assert_eq!(fenced.sequencer_families, 1);
+        assert_eq!(fenced.sequencer_entries_total, 1);
+        assert_eq!(fenced.sequencer_entries_commands, 1);
+        assert_eq!(fenced.sequencer_entries_checkpoints, 0);
+        assert_eq!(fenced.sequencer_fenced_families, 1);
+        assert!(
+            !fenced.sequencer_stalled,
+            "a fence within its bound is not a stall"
+        );
+        assert_eq!(fenced.families.len(), 1);
+        let family = &fenced.families[0];
+        assert_eq!(family.key, "family-a");
+        assert_eq!(family.entries, 1);
+        assert_eq!(family.entries_commands, 1);
+        assert_eq!(family.front_kind, Some("command"));
+        assert!(family.fenced, "the front entry waits for the open root");
+        assert_eq!(family.inflight_effects, 0);
+        assert_eq!(family.side_effect_errors, 0);
+
+        read_root_atexit(&coord, &sid);
+        assert_eq!(
+            DaemonHealthSnapshot::capture(&coord).trace_roots_finishing,
+            1
+        );
+
+        coord.clear_trace_root_tracking(&sid).unwrap();
+        let released = DaemonHealthSnapshot::capture(&coord);
+        assert_eq!(released.trace_roots_open_mutating, 0);
+        assert_eq!(released.sequencer_fenced_families, 0);
+        assert!(!released.families[0].fenced);
+    }
+
+    #[tokio::test]
+    async fn health_snapshot_reports_roots_that_have_written() {
+        use crate::daemon::health::DaemonHealthSnapshot;
+
+        let coord = ActorDaemonCoordinator::new_with_causal_grace(Duration::from_secs(10));
+        let temp = tempfile::tempdir().unwrap();
+        let (repo, family) = init_test_family(&coord, &temp);
+        commit_untraced(&repo);
+        let sid = alive_root_sid("health-written");
+        open_attributed_commit_root(&coord, &sid, &repo);
+        append_ready_rebase(&coord, &family);
+
+        let unwritten = DaemonHealthSnapshot::capture(&coord);
+        assert_eq!(unwritten.trace_roots_written, 0);
+        assert!(
+            !unwritten.families[0].fenced,
+            "a root that has written nothing fences nothing"
+        );
+
+        commit_untraced(&repo);
+        let written = DaemonHealthSnapshot::capture(&coord);
+        assert_eq!(written.trace_roots_written, 1);
+        assert!(
+            written.families[0].fenced,
+            "a root that wrote refs holds the fence"
+        );
+
+        // The reader has read its atexit; the worker has not processed it yet.
+        let mut atexit = serde_json::json!({
+            "event": "atexit",
+            "sid": sid,
+            "code": 0,
+            "time_ns": now_unix_nanos() as u64,
+        });
+        assert!(coord.prepare_trace_payload_for_ingest(&mut atexit));
+        let finishing = DaemonHealthSnapshot::capture(&coord);
+        assert_eq!(finishing.trace_roots_finishing, 1);
+        assert_eq!(
+            finishing.trace_roots_written, 0,
+            "a finishing root is reported as finishing, not re-judged as written"
+        );
+        assert!(finishing.families[0].fenced);
+    }
+
+    #[tokio::test]
+    async fn health_snapshot_lists_families_with_only_side_effect_errors() {
+        use crate::daemon::health::DaemonHealthSnapshot;
+
+        let coord = ActorDaemonCoordinator::new();
+        coord
+            .record_side_effect_error(
+                "family-errors",
+                7,
+                &GitAiError::Generic("notes push rejected".to_string()),
+            )
+            .unwrap();
+        let snapshot = DaemonHealthSnapshot::capture(&coord);
+        assert_eq!(snapshot.side_effect_error_families, 1);
+        assert_eq!(snapshot.side_effect_errors_total, 1);
+        let family = snapshot
+            .families
+            .iter()
+            .find(|f| f.key == "family-errors")
+            .expect("a family with retained errors is listed even without pending work");
+        assert_eq!(family.side_effect_errors, 1);
+        assert_eq!(family.entries, 0);
+        assert_eq!(snapshot.sequencer_families, 0);
+    }
+
+    #[tokio::test]
+    async fn health_snapshot_stall_bound_follows_the_fencing_root() {
+        use crate::daemon::health::DaemonHealthSnapshot;
+
+        // A tiny grace makes both caps (30x and 600x) shorter than the floor
+        // irrelevant: use a grace large enough that 30x < floor < 600x.
+        let grace = Duration::from_millis(500);
+        let coord = ActorDaemonCoordinator::new_with_causal_grace(grace);
+        let temp = tempfile::tempdir().unwrap();
+        let (repo, family) = init_test_family(&coord, &temp);
+        commit_untraced(&repo);
+        let sid = alive_root_sid("stall");
+        open_attributed_commit_root(&coord, &sid, &repo);
+        commit_untraced(&repo); // the root has written: it may hold for 600x grace
+        append_ready_rebase(&coord, &family);
+        {
+            // Backdate the entry past the hard cap (30x grace = 15 s) and floor (10 s).
+            let mut sequencers = coord.family_sequencers_by_family.lock().unwrap();
+            let state = sequencers.get_mut(&family).unwrap();
+            for slot in state.entries.values_mut() {
+                slot.enqueued_at = Instant::now() - Duration::from_secs(20);
+            }
+        }
+        let snapshot = DaemonHealthSnapshot::capture(&coord);
+        assert!(snapshot.families[0].fenced);
+        assert!(
+            !snapshot.sequencer_stalled,
+            "work fenced by a root that wrote refs is bounded by the written-root cap, not the hard cap"
+        );
+
+        coord.clear_trace_root_tracking(&sid).unwrap();
+        let snapshot = DaemonHealthSnapshot::capture(&coord);
+        assert!(!snapshot.families[0].fenced);
+        assert!(
+            snapshot.sequencer_stalled,
+            "unfenced work older than the hard cap is a stall"
+        );
+    }
+
+    #[tokio::test]
+    async fn health_snapshot_observes_fences_without_releasing_them() {
+        use crate::daemon::health::DaemonHealthSnapshot;
+
+        let grace = Duration::from_millis(20);
+        let coord = ActorDaemonCoordinator::new_with_causal_grace(grace);
+        let sid = alive_root_sid("probe");
+        open_unattributed_commit_root(&coord, &sid);
+        append_ready_rebase(&coord, "family-a");
+        tokio::time::sleep(grace * 3).await;
+
+        let snapshot = DaemonHealthSnapshot::capture(&coord);
+        assert!(
+            !snapshot.families[0].fenced,
+            "past the grace an alive, unwritten root no longer fences (the next drain releases it)"
+        );
+        assert_eq!(
+            coord.causal_grace_expirations.load(Ordering::Relaxed),
+            0,
+            "a status probe must not perform the release itself"
+        );
+        assert!(
+            !coord
+                .trace_ingress_state
+                .lock()
+                .unwrap()
+                .root_fence_release_logged
+                .contains(&sid),
+            "a status probe must not log the release either"
+        );
+    }
+
+    #[tokio::test]
+    async fn health_snapshot_observes_a_bounded_number_of_open_roots() {
+        use crate::daemon::health::{DaemonHealthSnapshot, HEALTH_ROOT_OBSERVE_LIMIT};
+
+        // Past a tiny grace, an observed live root without a reflog releases,
+        // so the fence below is held only by roots the peek could not observe.
+        let grace = Duration::from_millis(1);
+        let coord = ActorDaemonCoordinator::new_with_causal_grace(grace);
+        for i in 0..HEALTH_ROOT_OBSERVE_LIMIT {
+            open_unattributed_commit_root(&coord, &alive_root_sid(&format!("many-{i}")));
+        }
+        append_ready_rebase(&coord, "family-a");
+        tokio::time::sleep(grace * 5).await;
+        let full = DaemonHealthSnapshot::capture(&coord);
+        assert_eq!(full.trace_roots_open_mutating, HEALTH_ROOT_OBSERVE_LIMIT);
+        assert!(!full.snapshot_partial);
+        assert!(!full.families[0].fenced, "every root was observed alive");
+
+        open_unattributed_commit_root(&coord, &alive_root_sid("one-too-many"));
+        let capped = DaemonHealthSnapshot::capture(&coord);
+        assert_eq!(
+            capped.trace_roots_open_mutating,
+            HEALTH_ROOT_OBSERVE_LIMIT + 1
+        );
+        assert!(
+            capped.snapshot_partial,
+            "roots beyond the observation limit are counted but not observed"
+        );
+        assert!(
+            capped.families[0].fenced,
+            "an unobserved root is reported as holding, never as released early"
+        );
+        assert!(!capped.sequencer_stalled);
+
+        // The drain releases even a written root at the written-root cap, so
+        // an unobserved root is not reported as holding past it.
+        tokio::time::sleep(grace * FAMILY_WRITTEN_ROOT_FENCE_CAP_MULTIPLIER).await;
+        assert!(!DaemonHealthSnapshot::capture(&coord).families[0].fenced);
+    }
+
+    #[tokio::test]
+    async fn health_snapshot_does_not_call_a_busy_family_stalled() {
+        use crate::daemon::health::DaemonHealthSnapshot;
+
+        let coord = ActorDaemonCoordinator::new();
+        append_ready_rebase(&coord, "family-a");
+        // The entry has waited far past every fence bound and the stall floor.
+        {
+            let mut sequencers = coord.family_sequencers_by_family.lock().unwrap();
+            let slot = sequencers
+                .get_mut("family-a")
+                .and_then(|state| state.entries.values_mut().next())
+                .unwrap();
+            slot.enqueued_at = Instant::now().checked_sub(Duration::from_secs(60)).unwrap();
+        }
+        assert!(
+            DaemonHealthSnapshot::capture(&coord).sequencer_stalled,
+            "an old unfenced entry nobody is draining is a stall"
+        );
+
+        let busy = coord.begin_family_effect_guarded("family-a");
+        let snapshot = DaemonHealthSnapshot::capture(&coord);
+        assert_eq!(snapshot.families[0].inflight_effects, 1);
+        assert!(
+            !snapshot.sequencer_stalled,
+            "entries queued behind a running side-effect pass are busy, not stuck"
+        );
+        drop(busy);
+        assert!(DaemonHealthSnapshot::capture(&coord).sequencer_stalled);
+    }
+
+    #[tokio::test]
+    async fn health_snapshot_is_partial_when_sequencer_lock_is_held() {
+        use crate::daemon::health::DaemonHealthSnapshot;
+
+        let coord = ActorDaemonCoordinator::new();
+        append_ready_rebase(&coord, "family-a");
+        let guard = coord.family_sequencers_by_family.lock().unwrap();
+        let snapshot = DaemonHealthSnapshot::capture(&coord);
+        drop(guard);
+        assert!(
+            snapshot.snapshot_partial,
+            "a contended lock must be reported, never waited on"
+        );
+        assert_eq!(snapshot.sequencer_families, 0);
+        assert!(!DaemonHealthSnapshot::capture(&coord).snapshot_partial);
     }
 
     #[tokio::test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -63,6 +63,7 @@ pub mod domain;
 pub mod family_actor;
 pub mod git_backend;
 pub mod global_actor;
+pub mod health;
 mod memory_watchdog;
 pub mod reducer;
 pub mod ref_cursor;
@@ -2981,6 +2982,7 @@ pub struct ActorDaemonCoordinator {
     /// Outer key: family. Inner key: absolute file path string. Value: registration timestamp (nanos).
     pending_ai_edits_by_family: Mutex<HashMap<String, HashMap<String, u128>>>,
     family_sequencers_by_family: Mutex<HashMap<String, FamilySequencerState>>,
+    started_at: Instant,
     /// See [`FAMILY_CAUSAL_GRACE`].
     causal_grace: Duration,
     /// Fences released because the root's process was alive past the grace
@@ -3124,6 +3126,7 @@ impl ActorDaemonCoordinator {
             inflight_effects_by_family: Mutex::new(HashMap::new()),
             pending_ai_edits_by_family: Mutex::new(HashMap::new()),
             family_sequencers_by_family: Mutex::new(HashMap::new()),
+            started_at: Instant::now(),
             causal_grace: family_causal_grace(),
             causal_grace_expirations: AtomicU64::new(0),
             causal_fence_hard_cap_releases: AtomicU64::new(0),
@@ -7800,6 +7803,11 @@ impl ActorDaemonCoordinator {
     async fn handle_control_request(self: &Arc<Self>, request: ControlRequest) -> ControlResponse {
         let result = match request {
             ControlRequest::Ping => Ok(ControlResponse::ok(None, None)),
+            ControlRequest::StatusDaemon => {
+                serde_json::to_value(crate::daemon::health::DaemonHealthSnapshot::capture(self))
+                    .map(|v| ControlResponse::ok(None, Some(v)))
+                    .map_err(GitAiError::from)
+            }
             ControlRequest::CheckpointRun { .. } => Err(GitAiError::Generic(
                 "checkpoint.run requires the framed checkpoint transport".to_string(),
             )),
@@ -7869,20 +7877,9 @@ impl ActorDaemonCoordinator {
                     ))
                 }
             }
-            ControlRequest::StatsIngest => Ok(ControlResponse::ok(
-                None,
-                Some(json!({
-                    "trace_payloads_dropped_queue_full": self
-                        .trace_payloads_dropped_queue_full
-                        .load(Ordering::Relaxed),
-                    "trace_connections_dropped": self
-                        .trace_connections_dropped
-                        .load(Ordering::Relaxed),
-                    "telemetry_metric_batches_dropped":
-                        crate::daemon::telemetry_worker::metric_batches_dropped(),
-                    "checkpoints_dropped": self.checkpoints_dropped.load(Ordering::Relaxed),
-                })),
-            )),
+            ControlRequest::StatsIngest => serde_json::to_value(IngestLossSnapshot::capture(self))
+                .map(|v| ControlResponse::ok(None, Some(v)))
+                .map_err(GitAiError::from),
             ControlRequest::Await { timeout_secs } => {
                 let result = self.await_completion(timeout_secs).await;
                 serde_json::to_value(result)
@@ -9602,25 +9599,27 @@ fn should_defer_restart_for_checkpoints(
     outstanding_checkpoints > 0 && consecutive_deferrals < SOCKET_HEALTH_MAX_CONSECUTIVE_DEFERRALS
 }
 
-/// Snapshot of the ingest-loss counters for delta reporting.
-#[derive(Clone, Copy, Default, PartialEq, Eq)]
-struct IngestLossSnapshot {
-    payloads_dropped_queue_full: u64,
-    connections_dropped: u64,
-    metric_batches_dropped: u64,
+/// Snapshot of the ingest-loss counters, for delta reporting and for the
+/// `stats.ingest` / `status.daemon` responses (field names are the wire keys).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize)]
+pub(crate) struct IngestLossSnapshot {
+    trace_payloads_dropped_queue_full: u64,
+    trace_connections_dropped: u64,
+    telemetry_metric_batches_dropped: u64,
     checkpoints_dropped: u64,
 }
 
 impl IngestLossSnapshot {
     fn capture(coordinator: &ActorDaemonCoordinator) -> Self {
         Self {
-            payloads_dropped_queue_full: coordinator
+            trace_payloads_dropped_queue_full: coordinator
                 .trace_payloads_dropped_queue_full
                 .load(Ordering::Relaxed),
-            connections_dropped: coordinator
+            trace_connections_dropped: coordinator
                 .trace_connections_dropped
                 .load(Ordering::Relaxed),
-            metric_batches_dropped: crate::daemon::telemetry_worker::metric_batches_dropped(),
+            telemetry_metric_batches_dropped:
+                crate::daemon::telemetry_worker::metric_batches_dropped(),
             checkpoints_dropped: coordinator.checkpoints_dropped.load(Ordering::Relaxed),
         }
     }
@@ -9654,14 +9653,14 @@ fn report_ingest_losses(coordinator: &Arc<ActorDaemonCoordinator>) {
     }
     let values = crate::metrics::events::DaemonIngestAnomalyValues::new(
         current
-            .payloads_dropped_queue_full
-            .saturating_sub(last_reported.payloads_dropped_queue_full),
+            .trace_payloads_dropped_queue_full
+            .saturating_sub(last_reported.trace_payloads_dropped_queue_full),
         current
-            .connections_dropped
-            .saturating_sub(last_reported.connections_dropped),
+            .trace_connections_dropped
+            .saturating_sub(last_reported.trace_connections_dropped),
         current
-            .metric_batches_dropped
-            .saturating_sub(last_reported.metric_batches_dropped),
+            .telemetry_metric_batches_dropped
+            .saturating_sub(last_reported.telemetry_metric_batches_dropped),
         current
             .checkpoints_dropped
             .saturating_sub(last_reported.checkpoints_dropped),

--- a/src/daemon/control_api.rs
+++ b/src/daemon/control_api.rs
@@ -33,6 +33,10 @@ pub enum ControlRequest {
     /// Report ingest loss counters (dropped trace payloads/connections).
     #[serde(rename = "stats.ingest")]
     StatsIngest,
+    /// Snapshot of the daemon's attribution pipeline: per-family pending work
+    /// and fence state, open trace roots, and loss counters.
+    #[serde(rename = "status.daemon")]
+    StatusDaemon,
     #[serde(rename = "snapshot.watermarks")]
     SnapshotWatermarks { repo_working_dir: String },
     #[serde(rename = "bash_session.start")]
@@ -210,6 +214,14 @@ mod tests {
                 "method": "metrics.reingest",
                 "params": { "from_ts": 100, "to_ts": 200 }
             })
+        );
+    }
+
+    #[test]
+    fn status_daemon_request_uses_stable_wire_shape() {
+        assert_eq!(
+            serde_json::to_value(ControlRequest::StatusDaemon).unwrap(),
+            serde_json::json!({ "method": "status.daemon" })
         );
     }
 }

--- a/src/daemon/health.rs
+++ b/src/daemon/health.rs
@@ -1,0 +1,375 @@
+//! Snapshot of the daemon's attribution pipeline, served by the
+//! `status.daemon` control request (`git-ai bg status`) so a fenced or stalled
+//! family is inspectable without the daemon log. Counts come from atomics and
+//! `try_lock`ed maps: a contended map is reported as `snapshot_partial` rather
+//! than waited on; fence state is observed through the drain's own
+//! classification without releasing anything, with the reflog and liveness
+//! observations made after every lock is dropped; and nothing here touches git.
+
+use super::{
+    ActorDaemonCoordinator, FAMILY_CAUSAL_FENCE_HARD_CAP_MULTIPLIER,
+    FAMILY_WRITTEN_ROOT_FENCE_CAP_MULTIPLIER, FamilySequencerEntry, IngestLossSnapshot, RootFence,
+    RootFenceProbe, now_unix_nanos,
+};
+use serde::Serialize;
+use std::collections::BTreeMap;
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+
+/// Pending work older than this is a stall even under a long causal grace.
+const SEQUENCER_STALL_FLOOR: Duration = Duration::from_secs(10);
+
+/// Open mutating roots observed (a reflog stat each) per snapshot. Beyond
+/// this many concurrently open commands the snapshot is reported partial
+/// rather than doing unbounded per-root work on the control path.
+pub(crate) const HEALTH_ROOT_OBSERVE_LIMIT: usize = 32;
+
+/// One family's pending attribution work, oldest first in
+/// [`DaemonHealthSnapshot::families`].
+#[derive(Debug, Clone, Default, Serialize, PartialEq, Eq)]
+pub(crate) struct FamilyHealth {
+    pub key: String,
+    pub entries: usize,
+    pub entries_commands: usize,
+    pub entries_applied: usize,
+    pub entries_checkpoints: usize,
+    /// Age of the entry that has been ready the longest.
+    pub oldest_entry_age_ms: u64,
+    pub front_kind: Option<&'static str>,
+    /// The front entry is waiting for an older open trace root.
+    pub fenced: bool,
+    pub inflight_effects: usize,
+    pub side_effect_errors: usize,
+}
+
+/// What the snapshot needs about a family's front entry to judge its fence.
+struct FrontEntry {
+    started_at_ns: u128,
+    waited: Duration,
+    root_sid: Option<String>,
+}
+
+/// One open mutating trace root as sampled under the ingress lock.
+struct RootSample {
+    probe: RootFenceProbe,
+    started_at_ns: Option<u128>,
+    family: Option<String>,
+    /// Whether the probe's observations ran; a root beyond the observation
+    /// limit is counted but its fence cannot be judged.
+    observed: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct DaemonHealthSnapshot {
+    pub uptime_seconds: u64,
+    pub causal_grace_ms: u64,
+    /// A map was contended when sampled; its counts read as zero here.
+    pub snapshot_partial: bool,
+    pub checkpoints_outstanding: usize,
+    pub checkpoints_outstanding_bytes: usize,
+    pub checkpoints_unadmitted: usize,
+    pub checkpoint_receipt_seq_next: u64,
+    pub checkpoint_receipt_seq_processed: u64,
+    pub trace_payloads_queued: usize,
+    pub trace_ingest_seq_lag: u64,
+    pub trace_roots_open_mutating: usize,
+    /// Roots whose final frame the reader has read but the worker has not yet
+    /// processed. These hold their fence outright and are not re-judged.
+    pub trace_roots_finishing: usize,
+    /// Still-running roots that have already written their worktree `HEAD`.
+    pub trace_roots_written: usize,
+    pub trace_root_oldest_open_age_ms: Option<u64>,
+    pub trace_connections_unidentified: usize,
+    pub sequencer_families: usize,
+    pub sequencer_entries_total: usize,
+    pub sequencer_entries_commands: usize,
+    pub sequencer_entries_applied: usize,
+    pub sequencer_entries_checkpoints: usize,
+    pub sequencer_oldest_entry_age_ms: Option<u64>,
+    pub sequencer_fenced_families: usize,
+    /// Pending work older than the fence's hard cap (and at least
+    /// [`SEQUENCER_STALL_FLOOR`]): nothing legitimate holds work that long.
+    pub sequencer_stalled: bool,
+    pub effects_inflight_families: usize,
+    pub effects_inflight_total: usize,
+    pub side_effect_error_families: usize,
+    pub side_effect_errors_total: usize,
+    pub causal_grace_expirations: u64,
+    pub causal_fence_hard_cap_releases: u64,
+    #[serde(flatten)]
+    pub losses: IngestLossSnapshot,
+    pub families: Vec<FamilyHealth>,
+}
+
+impl DaemonHealthSnapshot {
+    pub(crate) fn capture(coordinator: &ActorDaemonCoordinator) -> Self {
+        let mut snapshot_partial = false;
+        let mut families: BTreeMap<String, FamilyHealth> = BTreeMap::new();
+        let mut fronts: Vec<(String, FrontEntry)> = Vec::new();
+        match coordinator.family_sequencers_by_family.try_lock() {
+            Ok(sequencers) => {
+                for (key, state) in sequencers.iter() {
+                    let Some((order, front)) = state.entries.first_key_value() else {
+                        continue;
+                    };
+                    let (root_sid, kind) =
+                        ActorDaemonCoordinator::sequencer_entry_identity(&front.entry);
+                    fronts.push((
+                        key.clone(),
+                        FrontEntry {
+                            started_at_ns: order.started_at_ns,
+                            waited: front.enqueued_at.elapsed(),
+                            root_sid: root_sid.map(str::to_string),
+                        },
+                    ));
+                    let health = families.entry(key.clone()).or_insert_with(|| FamilyHealth {
+                        key: key.clone(),
+                        front_kind: Some(kind),
+                        ..FamilyHealth::default()
+                    });
+                    for slot in state.entries.values() {
+                        match &slot.entry {
+                            FamilySequencerEntry::ReadyCommand(_) => health.entries_commands += 1,
+                            FamilySequencerEntry::AppliedSideEffects { .. } => {
+                                health.entries_applied += 1
+                            }
+                            FamilySequencerEntry::Checkpoint { .. } => {
+                                health.entries_checkpoints += 1
+                            }
+                        }
+                        health.oldest_entry_age_ms = health
+                            .oldest_entry_age_ms
+                            .max(slot.enqueued_at.elapsed().as_millis() as u64);
+                    }
+                    health.entries = health.entries_commands
+                        + health.entries_applied
+                        + health.entries_checkpoints;
+                }
+            }
+            Err(_) => snapshot_partial = true,
+        }
+
+        let mut effects_inflight_total = 0;
+        match coordinator.inflight_effects_by_family.try_lock() {
+            Ok(effects) => {
+                for (key, count) in effects.iter().filter(|(_, count)| **count > 0) {
+                    families
+                        .entry(key.clone())
+                        .or_insert_with(|| FamilyHealth {
+                            key: key.clone(),
+                            ..FamilyHealth::default()
+                        })
+                        .inflight_effects = *count;
+                    effects_inflight_total += *count;
+                }
+            }
+            Err(_) => snapshot_partial = true,
+        }
+
+        let mut side_effect_error_families = 0;
+        let mut side_effect_errors_total = 0;
+        match coordinator.side_effect_errors_by_family.try_lock() {
+            Ok(errors) => {
+                for (key, family_errors) in errors.iter().filter(|(_, e)| !e.is_empty()) {
+                    side_effect_error_families += 1;
+                    side_effect_errors_total += family_errors.len();
+                    families
+                        .entry(key.clone())
+                        .or_insert_with(|| FamilyHealth {
+                            key: key.clone(),
+                            ..FamilyHealth::default()
+                        })
+                        .side_effect_errors = family_errors.len();
+                }
+            }
+            Err(_) => snapshot_partial = true,
+        }
+
+        let mut trace_connections_unidentified = 0;
+        let mut trace_root_oldest_open_age_ms: Option<u64> = None;
+        let mut samples: Vec<RootSample> = Vec::new();
+        match coordinator.trace_ingress_state.try_lock() {
+            Ok(ingress) => {
+                let now = now_unix_nanos();
+                trace_connections_unidentified = ingress.unidentified_open_connections;
+                for root in ingress.root_open_connections.keys() {
+                    if !ActorDaemonCoordinator::open_root_may_mutate_family(&ingress, root, None) {
+                        continue;
+                    }
+                    let started_at_ns = ingress.root_started_at_ns.get(root).copied();
+                    if let Some(started) = started_at_ns {
+                        let age_ms = (now.saturating_sub(started) / 1_000_000) as u64;
+                        trace_root_oldest_open_age_ms =
+                            Some(trace_root_oldest_open_age_ms.map_or(age_ms, |m| m.max(age_ms)));
+                    }
+                    samples.push(RootSample {
+                        probe: ActorDaemonCoordinator::root_fence_probe(
+                            &ingress,
+                            root,
+                            Duration::ZERO,
+                        ),
+                        started_at_ns,
+                        family: ingress.root_families.get(root).cloned(),
+                        observed: false,
+                    });
+                }
+            }
+            Err(_) => snapshot_partial = true,
+        }
+        // Observations (a reflog stat and a liveness probe per root) run with
+        // every lock dropped, oldest roots first, and never for more roots
+        // than the limit.
+        let grace = coordinator.causal_grace;
+        samples.sort_by_key(|sample| sample.started_at_ns.unwrap_or(u128::MAX));
+        if samples.len() > HEALTH_ROOT_OBSERVE_LIMIT {
+            snapshot_partial = true;
+        }
+        for sample in samples.iter_mut().take(HEALTH_ROOT_OBSERVE_LIMIT) {
+            sample.probe.observe_all();
+            sample.observed = true;
+        }
+        let trace_roots_open_mutating = samples.len();
+        let trace_roots_finishing = samples.iter().filter(|s| s.probe.finishing).count();
+        let trace_roots_written = samples
+            .iter()
+            .filter(|s| s.probe.wrote_refs == Some(true))
+            .count();
+
+        let hard_cap = grace * FAMILY_CAUSAL_FENCE_HARD_CAP_MULTIPLIER;
+        let written_cap = grace * FAMILY_WRITTEN_ROOT_FENCE_CAP_MULTIPLIER;
+        let mut sequencer_stalled = false;
+        for (key, front) in &fronts {
+            let Some(health) = families.get_mut(key) else {
+                continue;
+            };
+            let fence = front_fence(coordinator, &samples, key, front);
+            health.fenced = fence.held;
+            // A family whose side-effect pass is running is busy, not stuck:
+            // its queued entries wait for that pass, not for a fence.
+            if health.inflight_effects > 0 {
+                continue;
+            }
+            // Work fenced by a root that has written may legitimately wait as
+            // long as that root runs; anything else is bounded by the hard cap.
+            let bound = if fence.behind_written_root {
+                written_cap
+            } else {
+                hard_cap
+            };
+            if Duration::from_millis(health.oldest_entry_age_ms) > bound.max(SEQUENCER_STALL_FLOOR)
+            {
+                sequencer_stalled = true;
+            }
+        }
+
+        let mut families: Vec<FamilyHealth> = families.into_values().collect();
+        families.sort_by(|a, b| {
+            b.oldest_entry_age_ms
+                .cmp(&a.oldest_entry_age_ms)
+                .then_with(|| a.key.cmp(&b.key))
+        });
+        let sequencer_oldest_entry_age_ms = families
+            .iter()
+            .filter(|f| f.entries > 0)
+            .map(|f| f.oldest_entry_age_ms)
+            .max();
+        let (checkpoints_outstanding, checkpoints_outstanding_bytes) =
+            coordinator.outstanding_checkpoint_state();
+        let sum = |pick: fn(&FamilyHealth) -> usize| families.iter().map(pick).sum::<usize>();
+
+        Self {
+            uptime_seconds: coordinator.started_at.elapsed().as_secs(),
+            causal_grace_ms: grace.as_millis() as u64,
+            snapshot_partial,
+            checkpoints_outstanding,
+            checkpoints_outstanding_bytes,
+            checkpoints_unadmitted: coordinator.unadmitted_checkpoints.load(Ordering::Acquire),
+            checkpoint_receipt_seq_next: coordinator
+                .next_checkpoint_receipt_seq
+                .load(Ordering::Acquire) as u64,
+            checkpoint_receipt_seq_processed: coordinator
+                .processed_checkpoint_receipt_seq
+                .load(Ordering::Acquire) as u64,
+            trace_payloads_queued: coordinator.queued_trace_payloads.load(Ordering::Acquire),
+            trace_ingest_seq_lag: coordinator
+                .next_trace_ingest_seq
+                .load(Ordering::Acquire)
+                .saturating_sub(
+                    coordinator
+                        .processed_trace_ingest_seq
+                        .load(Ordering::Acquire),
+                ) as u64,
+            trace_roots_open_mutating,
+            trace_roots_finishing,
+            trace_roots_written,
+            trace_root_oldest_open_age_ms,
+            trace_connections_unidentified,
+            sequencer_families: families.iter().filter(|f| f.entries > 0).count(),
+            sequencer_entries_total: sum(|f| f.entries),
+            sequencer_entries_commands: sum(|f| f.entries_commands),
+            sequencer_entries_applied: sum(|f| f.entries_applied),
+            sequencer_entries_checkpoints: sum(|f| f.entries_checkpoints),
+            sequencer_oldest_entry_age_ms,
+            sequencer_fenced_families: families.iter().filter(|f| f.fenced).count(),
+            sequencer_stalled,
+            effects_inflight_families: families.iter().filter(|f| f.inflight_effects > 0).count(),
+            effects_inflight_total,
+            side_effect_error_families,
+            side_effect_errors_total,
+            causal_grace_expirations: coordinator.causal_grace_expirations.load(Ordering::Relaxed),
+            causal_fence_hard_cap_releases: coordinator
+                .causal_fence_hard_cap_releases
+                .load(Ordering::Relaxed),
+            losses: IngestLossSnapshot::capture(coordinator),
+            families,
+        }
+    }
+}
+
+/// How the causal fence stands for a family's front entry, judged from the
+/// sampled roots exactly as the drain would (without applying releases).
+struct FrontFence {
+    held: bool,
+    /// The fence is held by a root that has already written refs.
+    behind_written_root: bool,
+}
+
+fn front_fence(
+    coordinator: &ActorDaemonCoordinator,
+    samples: &[RootSample],
+    family: &str,
+    front: &FrontEntry,
+) -> FrontFence {
+    let mut fence = FrontFence {
+        held: false,
+        behind_written_root: false,
+    };
+    for sample in samples {
+        if front.root_sid.as_deref() == Some(sample.probe.root_sid.as_str())
+            || sample.family.as_deref().is_some_and(|f| f != family)
+            || sample
+                .started_at_ns
+                .is_some_and(|root_started| root_started > front.started_at_ns)
+        {
+            continue;
+        }
+        // An unobserved root cannot be judged: report it as legitimately
+        // holding rather than invent a stall from a partial snapshot, though
+        // no root holds past the written-root cap.
+        if !sample.observed {
+            let written_cap = coordinator.causal_grace * FAMILY_WRITTEN_ROOT_FENCE_CAP_MULTIPLIER;
+            if front.waited < written_cap {
+                fence.held = true;
+                fence.behind_written_root = true;
+            }
+            continue;
+        }
+        let mut probe = sample.probe.clone();
+        probe.waited = front.waited;
+        if matches!(coordinator.classify_root_fence(&probe), RootFence::Held(_)) {
+            fence.held = true;
+            fence.behind_written_root |= probe.wrote_refs == Some(true);
+        }
+    }
+    fence
+}

--- a/tests/daemon_mode.rs
+++ b/tests/daemon_mode.rs
@@ -2908,6 +2908,115 @@ fn daemon_await_completes_with_idle_open_mutating_root() {
     write_trace_frames(&mut open_trace, &[trace_atexit_frame(&sid, 0, 1_002)]);
 }
 
+#[cfg(not(windows))]
+fn status_daemon(repo: &TestRepo) -> Value {
+    let response = send_control_request(
+        &daemon_control_socket_path(repo),
+        &ControlRequest::StatusDaemon,
+    )
+    .expect("status.daemon request");
+    assert!(response.ok, "status.daemon failed: {response:?}");
+    response.data.expect("status.daemon data")
+}
+
+#[test]
+#[cfg(not(windows))]
+fn daemon_status_daemon_reports_open_root_and_fenced_checkpoint() {
+    let repo = TestRepo::new_with_daemon_env(&[("GIT_AI_DAEMON_CAUSAL_GRACE_MS", "10000")]);
+    let idle = status_daemon(&repo);
+    assert_eq!(idle["trace_roots_open_mutating"], json!(0), "{idle}");
+    assert_eq!(idle["sequencer_entries_total"], json!(0), "{idle}");
+    assert_eq!(idle["snapshot_partial"], json!(false), "{idle}");
+    assert!(idle["uptime_seconds"].is_u64(), "{idle}");
+    assert!(idle["checkpoints_dropped"].is_u64(), "{idle}");
+
+    let sid = live_pid_trace_sid("status");
+    let mut open_trace = repo.open_mutating_commit_trace_root(&sid, true);
+    // The reader must have registered the root before anything waits on it.
+    let started = std::time::Instant::now();
+    while status_daemon(&repo)["trace_roots_open_mutating"] != json!(1) {
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "status.daemon never reported the open root"
+        );
+        thread::sleep(Duration::from_millis(25));
+    }
+    // The root writes refs (as a commit running its post-commit hook would):
+    // from here on its family's work is fenced behind it.
+    repo.git_og_with_env(
+        &[
+            "commit",
+            "--allow-empty",
+            "-m",
+            "written under the open root",
+        ],
+        &[("GIT_TRACE2_EVENT", "0")],
+    )
+    .expect("untraced commit");
+    fs::write(repo.path().join("fenced.txt"), "fenced ai\n").unwrap();
+    repo.git_ai_without_pre_sync_for_test(&["checkpoint", "mock_ai", "fenced.txt"])
+        .unwrap();
+
+    let started = std::time::Instant::now();
+    let fenced = loop {
+        let snapshot = status_daemon(&repo);
+        if snapshot["trace_roots_open_mutating"] == json!(1)
+            && snapshot["families"][0]["front_kind"] == json!("checkpoint")
+        {
+            break snapshot;
+        }
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "status.daemon never reported the fenced checkpoint: {snapshot}"
+        );
+        thread::sleep(Duration::from_millis(25));
+    };
+    assert_eq!(
+        fenced["sequencer_entries_checkpoints"],
+        json!(1),
+        "{fenced}"
+    );
+    assert_eq!(fenced["sequencer_fenced_families"], json!(1), "{fenced}");
+    assert_eq!(fenced["trace_roots_written"], json!(1), "{fenced}");
+    assert_eq!(fenced["families"][0]["fenced"], json!(true), "{fenced}");
+    assert_eq!(fenced["sequencer_stalled"], json!(false), "{fenced}");
+
+    write_trace_frames(&mut open_trace, &[trace_atexit_frame(&sid, 0, 1_002)]);
+    let started = std::time::Instant::now();
+    loop {
+        let snapshot = status_daemon(&repo);
+        if snapshot["trace_roots_open_mutating"] == json!(0)
+            && snapshot["sequencer_entries_total"] == json!(0)
+        {
+            break;
+        }
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "status.daemon never reported the drained checkpoint: {snapshot}"
+        );
+        thread::sleep(Duration::from_millis(25));
+    }
+    repo.sync_daemon();
+}
+
+#[test]
+fn daemon_bg_status_includes_daemon_health() {
+    let repo = TestRepo::new_dedicated_daemon();
+    let output = bg_command(&repo, "status", &[]);
+    assert!(output.status.success(), "bg status failed: {output:?}");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let value: Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|error| panic!("bg status must print JSON ({error}): {stdout}"));
+    assert_eq!(value["ok"], json!(true), "{value}");
+    assert!(value["data"]["family_key"].is_string(), "{value}");
+    assert!(value["daemon"]["uptime_seconds"].is_u64(), "{value}");
+    assert!(
+        value["daemon"]["sequencer_entries_total"].is_u64(),
+        "{value}"
+    );
+    assert!(value["daemon"]["families"].is_array(), "{value}");
+}
+
 #[test]
 #[cfg(not(windows))]
 fn daemon_sync_family_ignores_open_mutating_root_from_other_family() {


### PR DESCRIPTION
## Summary

Part 3 of 4. Adds `DaemonHealthSnapshot` (`src/daemon/health.rs`): per-family pending sequencer entries by kind, oldest-entry age, the front entry's kind and whether an older open trace root fences it, open/finishing/written mutating trace roots, in-flight side-effect passes, side-effect errors, causal-fence release counters, the existing ingest-loss counters (now also the source of `stats.ingest`), and a `sequencer_stalled` flag for work older than the fence's hard cap.

Built from atomics and `try_lock`ed maps: a contended map is reported as `snapshot_partial` rather than waited on, and fence state is observed through the same classification the drain uses without applying any release, so a status probe never changes what the drain will do.

Served by the new `status.daemon` control request and printed by `git-ai bg status` under an additive `daemon` key (with a restart hint under `daemon_error` when an older daemon rejects the request), so a fenced or stalled family can be inspected locally and in tests without waiting for the heartbeat.

## Testing

TDD. Unit tests: entry counts by kind and fence reporting, written-root reporting, probe has no side effects (no release, no log), partial snapshot under lock contention, stable wire shape. Integration: `status.daemon` reports an open written root fencing a checkpoint and then its drain; `bg status` includes the `daemon` key. `daemon_mode` (116) and full suite green except the two environment-specific lib tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
