### PR TITLE
feat(telemetry): include daemon health in the heartbeat

### DIFF
--- a/docs/superpowers/specs/2026-06-29-daemon-log-upload-client.md
+++ b/docs/superpowers/specs/2026-06-29-daemon-log-upload-client.md
@@ -8,7 +8,12 @@ This document describes the Git AI client-side daemon diagnostics upload path.
 - Events are buffered in memory by the daemon telemetry worker and flushed with
   the existing API client/auth headers.
 - A heartbeat event is generated roughly every 15 minutes while the daemon is
-  running.
+  running. Besides `uptime_seconds`/`os`/`arch` it carries the daemon health
+  snapshot (the same data as the `status.daemon` control request / `git-ai bg
+  status`): pending sequencer work, open, finishing and written trace roots,
+  causal-fence releases, loss counters, a `sequencer_stalled` flag, and the two
+  families with the oldest pending work as `family_<i>_*` fields. Family keys
+  (local repository paths) are replaced by a stable `family_<i>_id` digest.
 - Upload is best-effort and fire-and-forget. The telemetry worker dispatches at
   most one daemon-log upload at a time on a detached thread and does not await
   endpoint availability.
@@ -54,7 +59,17 @@ Authentication uses the same headers as metrics upload:
       "fields": {
         "uptime_seconds": 900,
         "os": "linux",
-        "arch": "x86_64"
+        "arch": "x86_64",
+        "snapshot_partial": false,
+        "sequencer_entries_total": 1,
+        "sequencer_fenced_families": 1,
+        "sequencer_oldest_entry_age_ms": 420,
+        "sequencer_stalled": false,
+        "trace_roots_open_mutating": 1,
+        "causal_grace_expirations": 0,
+        "family_0_id": "3f2a9c1d8e07",
+        "family_0_front_kind": "checkpoint",
+        "family_0_fenced": true
       }
     }
   ]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -9959,6 +9959,18 @@ pub(crate) async fn run_daemon(config: DaemonConfig) -> Result<DaemonExitAction,
     }
 
     let coordinator = Arc::new(coordinator_inner);
+    // Heartbeats carry the pipeline health snapshot. The provider holds a Weak
+    // reference so the telemetry worker never extends the coordinator's life.
+    let heartbeat_coordinator = Arc::downgrade(&coordinator);
+    crate::daemon::telemetry_worker::set_daemon_heartbeat_fields_provider(Arc::new(move || {
+        heartbeat_coordinator
+            .upgrade()
+            .map(|coordinator| {
+                crate::daemon::health::DaemonHealthSnapshot::capture(&coordinator)
+                    .heartbeat_fields()
+            })
+            .unwrap_or_default()
+    }));
     coordinator.start_trace_ingest_worker()?;
     coordinator.start_checkpoint_ingress_worker()?;
     if let Some(limit_mb) = config::Config::get().daemon_memory_limit_mb()

--- a/src/daemon/health.rs
+++ b/src/daemon/health.rs
@@ -11,13 +11,18 @@ use super::{
     FAMILY_WRITTEN_ROOT_FENCE_CAP_MULTIPLIER, FamilySequencerEntry, IngestLossSnapshot, RootFence,
     RootFenceProbe, now_unix_nanos,
 };
+use crate::api::types::DaemonLogFieldValue;
 use serde::Serialize;
+use serde_json::Value;
 use std::collections::BTreeMap;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 /// Pending work older than this is a stall even under a long causal grace.
 const SEQUENCER_STALL_FLOOR: Duration = Duration::from_secs(10);
+/// Families detailed in the heartbeat (oldest pending work first). With the
+/// aggregates this keeps a heartbeat under the 64-field daemon-log contract.
+pub const HEARTBEAT_FAMILY_DETAIL_LIMIT: usize = 2;
 
 /// Open mutating roots observed (a reflog stat each) per snapshot. Beyond
 /// this many concurrently open commands the snapshot is reported partial
@@ -372,6 +377,71 @@ fn front_fence(
         }
     }
     fence
+}
+
+impl DaemonHealthSnapshot {
+    /// Flattens the snapshot into primitive heartbeat fields: every aggregate
+    /// under its own name, plus the [`HEARTBEAT_FAMILY_DETAIL_LIMIT`] families
+    /// with the oldest pending work as `family_<i>_<field>`. Family keys are
+    /// local repository paths and never leave the machine: the heartbeat
+    /// carries a stable `family_<i>_id` digest instead, enough to correlate
+    /// consecutive heartbeats and daemon log lines that carry the same digest.
+    pub fn heartbeat_fields(&self) -> BTreeMap<String, DaemonLogFieldValue> {
+        let mut fields = BTreeMap::new();
+        let Ok(Value::Object(snapshot)) = serde_json::to_value(self) else {
+            return fields;
+        };
+        for (key, value) in &snapshot {
+            if let Some(value) = primitive_field(value) {
+                fields.insert(key.clone(), value);
+            }
+        }
+        for (index, family) in self
+            .families
+            .iter()
+            .filter(|family| family.entries > 0)
+            .take(HEARTBEAT_FAMILY_DETAIL_LIMIT)
+            .enumerate()
+        {
+            let Ok(Value::Object(family_fields)) = serde_json::to_value(family) else {
+                continue;
+            };
+            fields.insert(
+                format!("family_{index}_id"),
+                DaemonLogFieldValue::from(family_id(&family.key)),
+            );
+            for (key, value) in &family_fields {
+                if key == "key" {
+                    continue;
+                }
+                if let Some(value) = primitive_field(value) {
+                    fields.insert(format!("family_{index}_{key}"), value);
+                }
+            }
+        }
+        fields
+    }
+}
+
+/// A stable, non-reversible digest of a family key (a local path).
+fn family_id(family_key: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let digest = Sha256::digest(family_key.as_bytes());
+    digest
+        .iter()
+        .take(6)
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+fn primitive_field(value: &Value) -> Option<DaemonLogFieldValue> {
+    match value {
+        Value::Null => Some(DaemonLogFieldValue::Null),
+        Value::Bool(value) => Some(DaemonLogFieldValue::Bool(*value)),
+        Value::Number(value) => Some(DaemonLogFieldValue::Number(value.clone())),
+        Value::String(value) => Some(DaemonLogFieldValue::String(value.clone())),
+        Value::Array(_) | Value::Object(_) => None,
+    }
 }
 
 #[cfg(test)]

--- a/src/daemon/health.rs
+++ b/src/daemon/health.rs
@@ -373,3 +373,161 @@ fn front_fence(
     }
     fence
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::types::DaemonLogFieldValue;
+
+    /// The daemon-log upload contract keeps at most this many fields per event
+    /// (see `daemon_log_layer::MAX_FIELDS_PER_EVENT`); the heartbeat must stay
+    /// under it even with the per-family detail attached.
+    const MAX_FIELDS_PER_EVENT: usize = 64;
+
+    fn family(key: &str, oldest_entry_age_ms: u64) -> FamilyHealth {
+        FamilyHealth {
+            key: key.to_string(),
+            oldest_entry_age_ms,
+            entries: 1,
+            entries_checkpoints: 1,
+            front_kind: Some("checkpoint"),
+            fenced: true,
+            ..FamilyHealth::default()
+        }
+    }
+
+    fn snapshot(families: Vec<FamilyHealth>) -> DaemonHealthSnapshot {
+        DaemonHealthSnapshot {
+            uptime_seconds: 1,
+            causal_grace_ms: 1_000,
+            snapshot_partial: false,
+            checkpoints_outstanding: 0,
+            checkpoints_outstanding_bytes: 0,
+            checkpoints_unadmitted: 0,
+            checkpoint_receipt_seq_next: 0,
+            checkpoint_receipt_seq_processed: 0,
+            trace_payloads_queued: 0,
+            trace_ingest_seq_lag: 0,
+            trace_roots_open_mutating: 2,
+            trace_roots_finishing: 0,
+            trace_roots_written: 1,
+            trace_root_oldest_open_age_ms: Some(42),
+            trace_connections_unidentified: 0,
+            sequencer_families: families.len(),
+            sequencer_entries_total: families.len(),
+            sequencer_entries_commands: 0,
+            sequencer_entries_applied: 0,
+            sequencer_entries_checkpoints: families.len(),
+            sequencer_oldest_entry_age_ms: families.iter().map(|f| f.oldest_entry_age_ms).max(),
+            sequencer_fenced_families: families.len(),
+            sequencer_stalled: true,
+            effects_inflight_families: 0,
+            effects_inflight_total: 0,
+            side_effect_error_families: 0,
+            side_effect_errors_total: 0,
+            causal_grace_expirations: 3,
+            causal_fence_hard_cap_releases: 0,
+            losses: IngestLossSnapshot::default(),
+            families,
+        }
+    }
+
+    #[test]
+    fn heartbeat_health_fields_flatten_aggregates_and_worst_families() {
+        let fields = snapshot(vec![
+            family("/repos/slow/.git", 90_000),
+            family("/repos/fast/.git", 5),
+        ])
+        .heartbeat_fields();
+
+        assert_eq!(
+            fields.get("sequencer_stalled"),
+            Some(&DaemonLogFieldValue::from(true))
+        );
+        assert_eq!(
+            fields.get("trace_roots_open_mutating"),
+            Some(&DaemonLogFieldValue::from(2_u64))
+        );
+        assert_eq!(
+            fields.get("trace_root_oldest_open_age_ms"),
+            Some(&DaemonLogFieldValue::from(42_u64))
+        );
+        assert_eq!(
+            fields.get("causal_grace_expirations"),
+            Some(&DaemonLogFieldValue::from(3_u64))
+        );
+        assert!(
+            !fields.contains_key("families"),
+            "nested values are not primitive heartbeat fields"
+        );
+        assert!(
+            fields.values().all(|value| {
+                !matches!(value, DaemonLogFieldValue::String(text) if text.contains("/repos/"))
+            }),
+            "repository paths never leave the machine: {fields:?}"
+        );
+        assert_eq!(
+            fields.get("family_0_id"),
+            Some(&DaemonLogFieldValue::from(family_id("/repos/slow/.git"))),
+            "families are detailed oldest pending work first, by digest"
+        );
+        assert_eq!(
+            fields.get("family_0_oldest_entry_age_ms"),
+            Some(&DaemonLogFieldValue::from(90_000_u64))
+        );
+        assert_eq!(
+            fields.get("family_0_front_kind"),
+            Some(&DaemonLogFieldValue::from("checkpoint"))
+        );
+        assert_eq!(
+            fields.get("family_0_fenced"),
+            Some(&DaemonLogFieldValue::from(true))
+        );
+        assert_eq!(
+            fields.get("family_1_id"),
+            Some(&DaemonLogFieldValue::from(family_id("/repos/fast/.git")))
+        );
+        assert!(!fields.contains_key("family_2_id"));
+        assert_eq!(
+            fields.get("trace_payloads_dropped_queue_full"),
+            Some(&DaemonLogFieldValue::from(0_u64)),
+            "loss counters are flattened under their wire keys"
+        );
+    }
+
+    #[test]
+    fn heartbeat_health_fields_stay_within_daemon_log_field_cap() {
+        let families = (0..20)
+            .map(|index| family(&format!("/repos/{index}/.git"), 20 - index))
+            .collect();
+        let fields = snapshot(families).heartbeat_fields();
+
+        assert!(
+            fields.len() <= MAX_FIELDS_PER_EVENT,
+            "{} heartbeat fields exceed the {MAX_FIELDS_PER_EVENT}-field contract",
+            fields.len()
+        );
+        let detailed_families = fields.keys().filter(|key| key.ends_with("_id")).count();
+        assert_eq!(detailed_families, HEARTBEAT_FAMILY_DETAIL_LIMIT);
+        assert_eq!(
+            fields.get("family_0_id"),
+            Some(&DaemonLogFieldValue::from(family_id("/repos/0/.git")))
+        );
+    }
+
+    #[test]
+    fn heartbeat_health_fields_detail_only_families_with_pending_work() {
+        let idle = FamilyHealth {
+            key: "/repos/idle/.git".to_string(),
+            inflight_effects: 1,
+            ..FamilyHealth::default()
+        };
+        let fields = snapshot(vec![idle, family("/repos/pending/.git", 5)]).heartbeat_fields();
+        assert_eq!(
+            fields.get("family_0_id"),
+            Some(&DaemonLogFieldValue::from(family_id("/repos/pending/.git"))),
+            "a family with only in-flight effects is not pending work"
+        );
+        assert!(!fields.contains_key("family_1_id"));
+    }
+}

--- a/src/daemon/telemetry_worker.rs
+++ b/src/daemon/telemetry_worker.rs
@@ -486,6 +486,26 @@ pub fn set_daemon_internal_telemetry(handle: DaemonTelemetryWorkerHandle) {
     let _ = DAEMON_INTERNAL_TELEMETRY.set(handle);
 }
 
+/// Supplies the pipeline-health fields folded into each heartbeat.
+pub type HeartbeatFieldsProvider =
+    Arc<dyn Fn() -> BTreeMap<String, DaemonLogFieldValue> + Send + Sync>;
+
+/// Registered once at daemon startup by the coordinator, so the worker
+/// carries no coordinator dependency and the 15-minute cadence stays here.
+static DAEMON_HEARTBEAT_FIELDS_PROVIDER: std::sync::OnceLock<HeartbeatFieldsProvider> =
+    std::sync::OnceLock::new();
+
+pub fn set_daemon_heartbeat_fields_provider(provider: HeartbeatFieldsProvider) {
+    let _ = DAEMON_HEARTBEAT_FIELDS_PROVIDER.set(provider);
+}
+
+fn daemon_heartbeat_health_fields() -> BTreeMap<String, DaemonLogFieldValue> {
+    DAEMON_HEARTBEAT_FIELDS_PROVIDER
+        .get()
+        .map(|provider| provider())
+        .unwrap_or_default()
+}
+
 /// Submit telemetry from within the daemon process.
 /// Returns true if the handle was available and envelopes were submitted.
 pub fn submit_daemon_internal_telemetry(envelopes: Vec<TelemetryEnvelope>) -> bool {
@@ -719,7 +739,10 @@ async fn telemetry_flush_loop(
             while next_heartbeat_at <= now {
                 next_heartbeat_at += DAEMON_LOG_HEARTBEAT_INTERVAL;
             }
-            Some(daemon_heartbeat_event(started_at.elapsed()))
+            Some(daemon_heartbeat_event(
+                started_at.elapsed(),
+                daemon_heartbeat_health_fields(),
+            ))
         } else {
             None
         };
@@ -1261,8 +1284,12 @@ fn daemon_run_id() -> &'static str {
     DAEMON_RUN_ID.get_or_init(crate::uuid::generate_v4).as_str()
 }
 
-fn daemon_heartbeat_event(uptime: std::time::Duration) -> DaemonLogEvent {
-    let mut fields = BTreeMap::new();
+/// Builds the heartbeat from the daemon's health `fields`; the contract fields
+/// (`uptime_seconds`, `os`, `arch`) are set last and always win.
+fn daemon_heartbeat_event(
+    uptime: std::time::Duration,
+    mut fields: BTreeMap<String, DaemonLogFieldValue>,
+) -> DaemonLogEvent {
     fields.insert(
         "uptime_seconds".to_string(),
         DaemonLogFieldValue::from(uptime.as_secs()),

--- a/src/daemon/telemetry_worker.rs
+++ b/src/daemon/telemetry_worker.rs
@@ -2862,7 +2862,7 @@ mod tests {
 
     #[test]
     fn daemon_heartbeat_event_uses_upload_contract_shape() {
-        let event = daemon_heartbeat_event(std::time::Duration::from_secs(900));
+        let event = daemon_heartbeat_event(std::time::Duration::from_secs(900), BTreeMap::new());
 
         assert!(event.id.is_some());
         assert_eq!(event.kind, DaemonLogKind::Heartbeat);
@@ -2872,6 +2872,43 @@ mod tests {
         assert_eq!(
             event.fields.get("uptime_seconds"),
             Some(&DaemonLogFieldValue::from(900_u64))
+        );
+        assert!(event.fields.contains_key("os"));
+        assert!(event.fields.contains_key("arch"));
+    }
+
+    #[test]
+    fn daemon_heartbeat_event_merges_health_fields_and_keeps_contract_fields() {
+        let mut health = BTreeMap::new();
+        health.insert(
+            "sequencer_stalled".to_string(),
+            DaemonLogFieldValue::from(false),
+        );
+        health.insert(
+            "trace_roots_open_mutating".to_string(),
+            DaemonLogFieldValue::from(2_u64),
+        );
+        // A provider must not be able to shadow the contract fields.
+        health.insert(
+            "uptime_seconds".to_string(),
+            DaemonLogFieldValue::from(1_u64),
+        );
+
+        let event = daemon_heartbeat_event(std::time::Duration::from_secs(900), health);
+
+        assert_eq!(event.kind, DaemonLogKind::Heartbeat);
+        assert_eq!(event.message, "alive");
+        assert_eq!(
+            event.fields.get("uptime_seconds"),
+            Some(&DaemonLogFieldValue::from(900_u64))
+        );
+        assert_eq!(
+            event.fields.get("sequencer_stalled"),
+            Some(&DaemonLogFieldValue::from(false))
+        );
+        assert_eq!(
+            event.fields.get("trace_roots_open_mutating"),
+            Some(&DaemonLogFieldValue::from(2_u64))
         );
         assert!(event.fields.contains_key("os"));
         assert!(event.fields.contains_key("arch"));


### PR DESCRIPTION
## Summary

Part 4 of 4. The telemetry worker's 15-minute heartbeat now carries the daemon health snapshot through a provider the coordinator registers at startup (a `Weak` reference, so the worker never extends the coordinator's life and keeps no coordinator dependency).

Every snapshot aggregate lands under its own primitive field and the two families with the oldest pending work are flattened as `family_<i>_*`; the contract fields `uptime_seconds`/`os`/`arch` are set last and always win, and the total stays under the 64-field daemon-log cap. Fleet telemetry gains `sequencer_stalled`, fenced families, open/written root counts and ages, and causal-fence release counts to verify the stall fix in production.

## Testing

TDD. Unit tests: contract fields preserved and never shadowed by the provider, aggregates and worst families flattened under wire keys, field count stays under the cap with many families. Full suite green except the two environment-specific lib tests. Docs: heartbeat example updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
