### PR TITLE
fix(daemon): record fence releases against the root; bound dead written roots by the hard cap

### DIFF
--- a/docs/daemon-trace2-ingestion-spec.md
+++ b/docs/daemon-trace2-ingestion-spec.md
@@ -87,9 +87,11 @@ decided from data first and heuristics last:
 2. **Written**: the reader captured the root's worktree `HEAD` reflog length
    when it started; if that reflog has grown, or was modified after the root's
    start on git's clock, the root has changed refs and holds until it
-   finishes (a post-write hook, say), bounded by 600 × grace. The modification
-   time covers a length the reader recorded late, after the root had already
-   written, and cannot be set by a committer date.
+   finishes (a post-write hook, say), bounded by 600 × grace, or by the hard
+   cap once its process is gone (a sibling connection may keep a dead root
+   registered). The modification time covers a length the reader recorded
+   late, after the root had already written, and cannot be set by a committer
+   date.
 3. **Unwritten**: neither signal fired, so the root has changed nothing and
    fences nothing. Nobody waits for an editor or a pre-commit hook, not even a
    grace.
@@ -100,6 +102,15 @@ decided from data first and heuristics last:
    (encoded in its sid, `-P<hex>`) is alive is released
    (`reason=causal_grace_expired`) and one whose process is gone or unknown
    holds until the hard cap (`reason=causal_fence_hard_cap`).
+
+A heuristic release (`causal_grace_expired`, `causal_fence_hard_cap`,
+`written_root_cap`, `finishing_root_cap`) is logged and counted once per
+root. When the root's process was gone at the time, the release is also
+recorded against the root: a dead process cannot write again, so later work,
+`sync.family` and `await` do not wait out the bound behind it while it stays
+registered. A live root's release is per waiter, since it may still write
+and the next waiter's grace covers that write's frames. The hard cap is
+30 × grace.
 
 Unattributed roots (no `def_repo` yet) fail closed and fence every family.
 Roots that started after the waiting work cannot precede it and never fence

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2783,20 +2783,24 @@ struct RootFenceProbe {
     /// as written even when its length was recorded late.
     started_at_ns: Option<u128>,
     pid: Option<u32>,
+    /// This root was released while its process was gone: nothing it could
+    /// still do is in flight.
+    released: bool,
     wrote_refs: Option<bool>,
     alive: Option<bool>,
 }
 
 impl RootFenceProbe {
     /// Performs the observations the classification needs: the reflog stat
-    /// when there is one to consult, else a liveness probe once the grace has
-    /// passed. Runs without any daemon lock held.
+    /// when there is one to consult, and a liveness probe once the grace has
+    /// passed unless the reflog shows the root has changed nothing. Runs
+    /// without any daemon lock held.
     fn observe(&mut self, grace: Duration) {
-        if self.finishing {
+        if self.finishing || self.released {
             return;
         }
         self.observe_reflog();
-        if self.wrote_refs.is_none() && self.waited >= grace {
+        if self.wrote_refs != Some(false) && self.waited >= grace {
             self.alive = self.pid.map(process_alive);
         }
     }
@@ -2805,11 +2809,11 @@ impl RootFenceProbe {
     /// root against several waits without touching the file system or the
     /// process table again. Runs without any daemon lock held.
     fn observe_all(&mut self) {
-        if self.finishing {
+        if self.finishing || self.released {
             return;
         }
         self.observe_reflog();
-        if self.wrote_refs.is_none() {
+        if self.wrote_refs != Some(false) {
             self.alive = self.pid.map(process_alive);
         }
     }
@@ -2964,7 +2968,14 @@ struct TraceIngressState {
     /// EOF must not clear such a root first, and needs no close marker for it.
     root_finishing: HashSet<String>,
     /// Roots whose fence release has been logged and counted already.
+    /// Roots whose heuristic release has been logged and counted (once).
     root_fence_release_logged: HashSet<String>,
+    /// Roots released while their process was gone: a fact about the root,
+    /// since a dead process cannot write again, so later work, `sync` and
+    /// `await` do not wait out the bound behind it. A live root's release is
+    /// not remembered: it may still write, and the next waiter's grace
+    /// covers that write's frames.
+    root_fence_released: HashSet<String>,
     /// Roots the daemon has finished with, remembered (bounded, oldest out)
     /// so a straggling child process of one cannot reopen it: git's detached
     /// auto-maintenance opens its own connections under the parent's sid
@@ -3989,6 +4000,7 @@ impl ActorDaemonCoordinator {
             waited,
             finishing: ingress.root_finishing.contains(root_sid)
                 || ingress.root_close_markers_enqueued.contains(root_sid),
+            released: ingress.root_fence_released.contains(root_sid),
             head_reflog: moves_head
                 .then(|| ingress.root_reflog_start_offsets.get(root_sid).cloned())
                 .flatten()
@@ -4009,9 +4021,13 @@ impl ActorDaemonCoordinator {
     /// - a *finishing* root (atexit read, or socket closed) holds until the
     ///   worker processes its queued frame, which always clears it; should
     ///   that somehow not happen, the hard cap releases it with a warning;
+    /// - otherwise, a root released while its process was gone fences nothing
+    ///   more: a dead process cannot write again, so that release is a fact
+    ///   about the root, not about the work that waited;
     /// - a HEAD-moving root whose worktree HEAD reflog has grown or been
     ///   modified since it started has changed refs and holds until it
-    ///   finishes (a post-write hook, say), bounded by the written-root cap;
+    ///   finishes (a post-write hook, say), bounded by the written-root cap,
+    ///   or by the hard cap once its process is gone;
     /// - a HEAD-moving root whose worktree HEAD reflog is untouched has
     ///   changed nothing: it fences nothing, and nobody waits for an editor or
     ///   a pre-commit hook;
@@ -4029,10 +4045,21 @@ impl ActorDaemonCoordinator {
                 RootFence::Release(release)
             }
         };
+        // Data first: a finishing root's final frame is queued and its command
+        // is about to be sequenced ahead of this work, released or not.
         if probe.finishing {
             return hold_until(hard_cap, "finishing_root_cap");
         }
+        if probe.released {
+            return RootFence::Open;
+        }
         match probe.wrote_refs {
+            // A written root whose process is gone will never finish on its
+            // own (a sibling connection keeps it registered): its frames are
+            // either queued, which would make it finishing, or lost.
+            Some(true) if probe.alive == Some(false) => {
+                return hold_until(hard_cap, "causal_fence_hard_cap");
+            }
             Some(true) => {
                 return hold_until(
                     grace * FAMILY_WRITTEN_ROOT_FENCE_CAP_MULTIPLIER,
@@ -4088,6 +4115,7 @@ impl ActorDaemonCoordinator {
         let mut ingress = lock_ingress()?;
         let mut held: Option<Duration> = None;
         let mut releases = Vec::new();
+        let mut newly_released = false;
         for probe in probes {
             // Cleared while we were observing: it fences nothing any more.
             if !Self::open_root_may_mutate_family(&ingress, &probe.root_sid, None) {
@@ -4100,6 +4128,11 @@ impl ActorDaemonCoordinator {
                     }
                 }
                 RootFence::Release(reason) => {
+                    if probe.alive == Some(false)
+                        && ingress.root_fence_released.insert(probe.root_sid.clone())
+                    {
+                        newly_released = true;
+                    }
                     if ingress
                         .root_fence_release_logged
                         .insert(probe.root_sid.clone())
@@ -4117,10 +4150,12 @@ impl ActorDaemonCoordinator {
             }
         }
         drop(ingress);
-        if !releases.is_empty() {
-            for release in &releases {
-                release.log();
-            }
+        for release in &releases {
+            release.log();
+        }
+        // Other waiters on this root (sync, await, other families) re-judge
+        // it at once rather than at their own timers.
+        if !releases.is_empty() || newly_released {
             self.trace_root_fence_notify.notify_waiters();
         }
         Ok(held)
@@ -4393,6 +4428,7 @@ impl ActorDaemonCoordinator {
         ingress.root_close_markers_enqueued.remove(root_sid);
         ingress.root_finishing.remove(root_sid);
         ingress.root_fence_release_logged.remove(root_sid);
+        ingress.root_fence_released.remove(root_sid);
         // Only a root the daemon saw through its own frames is known to have
         // completed; one known only from a child that closed early may still
         // be running, and its later children must keep failing closed.
@@ -12323,8 +12359,8 @@ mod tests {
         );
         assert_eq!(coord.causal_grace_expirations.load(Ordering::Relaxed), 1);
 
-        // Later work waits its own grace, but the heuristic release is
-        // reported once per root.
+        // A live root may still write, so later work waits its own grace
+        // (which covers that write's frames); the release is reported once.
         append_ready_rebase(&coord, "family-b");
         assert!(is_fenced(coord.family_front_entry_disposition("family-b")));
         tokio::time::sleep(grace * 3).await;
@@ -12542,6 +12578,45 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_released_root_that_turns_finishing_holds_again() {
+        let grace = Duration::from_millis(20);
+        let hard_cap = grace * FAMILY_CAUSAL_FENCE_HARD_CAP_MULTIPLIER;
+        let coord = ActorDaemonCoordinator::new_with_causal_grace(grace);
+        let sid = dead_root_sid("released-then-finishing");
+        open_unattributed_commit_root(&coord, &sid);
+        append_ready_rebase(&coord, "family-a");
+        tokio::time::sleep(hard_cap + grace).await;
+        assert_eq!(
+            coord.family_front_entry_disposition("family-a"),
+            FamilyFrontDisposition::Ready
+        );
+
+        // Its final frame arrives after all: the command it carries sorts
+        // ahead of this work, so the fence holds until the worker clears it.
+        read_root_atexit(&coord, &sid);
+        coord
+            .family_sequencers_by_family
+            .lock()
+            .unwrap()
+            .get_mut("family-a")
+            .unwrap()
+            .entries
+            .clear();
+        append_ready_rebase(&coord, "family-a");
+        assert!(
+            is_fenced(coord.family_front_entry_disposition("family-a")),
+            "a finishing root holds even after a heuristic release"
+        );
+        coord.clear_trace_root_tracking(&sid).unwrap();
+        assert_eq!(
+            coord.family_front_entry_disposition("family-a"),
+            FamilyFrontDisposition::Ready
+        );
+    }
+
+    #[cfg(unix)]
     #[tokio::test]
     async fn written_root_whose_process_is_gone_holds_only_to_the_hard_cap() {
         let grace = Duration::from_millis(20);

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -12496,6 +12496,85 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
+    async fn fence_release_is_a_fact_about_the_root_not_the_waiter() {
+        let grace = Duration::from_millis(20);
+        let hard_cap = grace * FAMILY_CAUSAL_FENCE_HARD_CAP_MULTIPLIER;
+        let coord = ActorDaemonCoordinator::new_with_causal_grace(grace);
+        let sid = dead_root_sid("leaked-fd");
+        open_unattributed_commit_root(&coord, &sid);
+        append_ready_rebase(&coord, "family-a");
+        tokio::time::sleep(hard_cap + grace).await;
+        assert_eq!(
+            coord.family_front_entry_disposition("family-a"),
+            FamilyFrontDisposition::Ready,
+            "the hard cap releases the root"
+        );
+        assert_eq!(
+            coord.causal_fence_hard_cap_releases.load(Ordering::Relaxed),
+            1
+        );
+
+        // The root stays registered (its connection never closed). Work that
+        // arrives later must not pay the whole bound again: the release is
+        // recorded against the root.
+        coord
+            .family_sequencers_by_family
+            .lock()
+            .unwrap()
+            .get_mut("family-a")
+            .unwrap()
+            .entries
+            .clear();
+        append_ready_rebase(&coord, "family-a");
+        assert_eq!(
+            coord.family_front_entry_disposition("family-a"),
+            FamilyFrontDisposition::Ready,
+            "a released root fences nothing for later work"
+        );
+        assert!(
+            !coord.has_open_mutating_roots_holding_fence(),
+            "nor is it pending work for await"
+        );
+        assert_eq!(
+            coord.causal_fence_hard_cap_releases.load(Ordering::Relaxed),
+            1,
+            "one release per root"
+        );
+    }
+
+    #[tokio::test]
+    async fn written_root_whose_process_is_gone_holds_only_to_the_hard_cap() {
+        let grace = Duration::from_millis(20);
+        let hard_cap = grace * FAMILY_CAUSAL_FENCE_HARD_CAP_MULTIPLIER;
+        let coord = ActorDaemonCoordinator::new_with_causal_grace(grace);
+        let temp = tempfile::tempdir().unwrap();
+        let (repo, family) = init_test_family(&coord, &temp);
+        commit_untraced(&repo);
+        // The root wrote refs, then died by signal with a sibling connection
+        // (a maintenance child) keeping it registered: its final frame will
+        // never come.
+        let sid = dead_root_sid("killed-after-write");
+        open_attributed_commit_root(&coord, &sid, &repo);
+        commit_untraced(&repo);
+        append_ready_rebase(&coord, &family);
+        tokio::time::sleep(grace * 3).await;
+        assert!(
+            is_fenced(coord.family_front_entry_disposition(&family)),
+            "a written root holds while it may still be finishing"
+        );
+        tokio::time::sleep(hard_cap).await;
+        assert_eq!(
+            coord.family_front_entry_disposition(&family),
+            FamilyFrontDisposition::Ready,
+            "a written root whose process is gone is bounded by the hard cap, not the written cap"
+        );
+        assert_eq!(
+            coord.causal_fence_hard_cap_releases.load(Ordering::Relaxed),
+            1
+        );
+    }
+
+    #[tokio::test]
     async fn family_fence_holds_past_grace_when_root_process_is_dead() {
         let grace = Duration::from_millis(20);
         let hard_cap = grace * FAMILY_CAUSAL_FENCE_HARD_CAP_MULTIPLIER;

--- a/tests/commit_tree_update_ref.rs
+++ b/tests/commit_tree_update_ref.rs
@@ -1989,7 +1989,7 @@ fn test_delayed_current_branch_update_ref_trace_preserves_new_commit_attribution
 
 #[test]
 fn test_update_ref_side_effect_waits_for_prior_open_trace_root_until_causal_grace() {
-    let repo = TestRepo::new();
+    let repo = TestRepo::new_with_daemon_env(&[("GIT_AI_DAEMON_CAUSAL_GRACE_MS", "2000")]);
     setup_initial_commit(&repo);
 
     repo.git(&["checkout", "-b", "feature"])
@@ -2049,14 +2049,50 @@ fn test_update_ref_side_effect_waits_for_prior_open_trace_root_until_causal_grac
     let released = std::time::Instant::now();
     while !daemon_completed_session(&repo, &session) {
         assert!(
-            released.elapsed() < Duration::from_secs(5),
+            released.elapsed() < Duration::from_secs(8),
             "update-ref side effect stayed fenced behind a live open trace root past the causal grace"
         );
         std::thread::sleep(Duration::from_millis(10));
     }
 
+    // The release is a fact about the root: a later command in the family
+    // does not wait out the grace again while the same root stays open.
+    let later_tree_sha = raw_untraced_git(&repo, &["write-tree"]).trim().to_string();
+    let later_commit_sha = raw_untraced_git(
+        &repo,
+        &[
+            "commit-tree",
+            &later_tree_sha,
+            "-p",
+            &commit_sha,
+            "-m",
+            "later plumbing commit behind a released root",
+        ],
+    )
+    .trim()
+    .to_string();
+    let later_session = new_daemon_test_sync_session_id();
+    let later_start = std::time::Instant::now();
+    raw_traced_git_with_session(
+        &repo,
+        &[
+            "update-ref",
+            "refs/heads/feature",
+            &later_commit_sha,
+            &commit_sha,
+        ],
+        &later_session,
+    );
+    while !daemon_completed_session(&repo, &later_session) {
+        assert!(
+            later_start.elapsed() < Duration::from_millis(1_200),
+            "a later command waited out the causal grace again behind an already released root"
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    }
+
     drop(unfinished_trace);
-    repo.sync_daemon_external_completion_sessions(&[session]);
+    repo.sync_daemon_external_completion_sessions(&[session, later_session]);
 
     assert_note_has_ai_for_file(&repo, &commit_sha, "sequenced-branch-plumbing.txt");
     let mut feature_file = repo.filename("sequenced-branch-plumbing.txt");

--- a/tests/commit_tree_update_ref.rs
+++ b/tests/commit_tree_update_ref.rs
@@ -16,8 +16,8 @@ use repos::test_file::ExpectedLineExt;
 #[cfg(not(windows))]
 use repos::test_repo::configure_raw_traced_git_env_for;
 use repos::test_repo::{
-    TestRepo, configure_raw_traced_git_env, live_pid_trace_sid, new_daemon_test_sync_session_id,
-    real_git_executable,
+    TestRepo, configure_raw_traced_git_env, new_daemon_test_sync_session_id, real_git_executable,
+    reaped_pid_trace_sid,
 };
 use serde_json::{Value, json};
 use std::fs;
@@ -1989,7 +1989,8 @@ fn test_delayed_current_branch_update_ref_trace_preserves_new_commit_attribution
 
 #[test]
 fn test_update_ref_side_effect_waits_for_prior_open_trace_root_until_causal_grace() {
-    let repo = TestRepo::new_with_daemon_env(&[("GIT_AI_DAEMON_CAUSAL_GRACE_MS", "2000")]);
+    // A short grace keeps the hard cap (30 x grace) within the test's reach.
+    let repo = TestRepo::new_with_daemon_env(&[("GIT_AI_DAEMON_CAUSAL_GRACE_MS", "100")]);
     setup_initial_commit(&repo);
 
     repo.git(&["checkout", "-b", "feature"])
@@ -2021,9 +2022,11 @@ fn test_update_ref_side_effect_waits_for_prior_open_trace_root_until_causal_grac
     .trim()
     .to_string();
 
-    // This test process stands in for the still-running git: its pid is alive.
+    // The root's process is gone but its connection never closed (a leaked
+    // inherited socket): the fence has no reflog to consult and no live
+    // process to wait for, so it holds to the hard cap and then releases.
     let unfinished_trace =
-        repo.open_mutating_commit_trace_root(&live_pid_trace_sid("unfinished"), false);
+        repo.open_mutating_commit_trace_root(&reaped_pid_trace_sid("unfinished"), false);
     std::thread::sleep(Duration::from_millis(100));
 
     let session = new_daemon_test_sync_session_id();
@@ -2042,21 +2045,20 @@ fn test_update_ref_side_effect_waits_for_prior_open_trace_root_until_causal_grac
         std::thread::sleep(Duration::from_millis(10));
     }
 
-    // Past the causal grace the daemon checks the root's process: it is alive
-    // and has not written anything, so the command is still running and
-    // nothing causally prior is in flight. The fence releases without waiting
-    // for the trace to close.
+    // Past the grace the daemon checks the root's process; it is gone, so the
+    // fence holds to the hard cap (3 s here) and releases without waiting for
+    // the trace to close.
     let released = std::time::Instant::now();
     while !daemon_completed_session(&repo, &session) {
         assert!(
             released.elapsed() < Duration::from_secs(8),
-            "update-ref side effect stayed fenced behind a live open trace root past the causal grace"
+            "update-ref side effect stayed fenced behind a dead open trace root past the hard cap"
         );
         std::thread::sleep(Duration::from_millis(10));
     }
 
-    // The release is a fact about the root: a later command in the family
-    // does not wait out the grace again while the same root stays open.
+    // A release of a dead root is a fact about the root: a later command in
+    // the family does not wait out the hard cap again while it stays open.
     let later_tree_sha = raw_untraced_git(&repo, &["write-tree"]).trim().to_string();
     let later_commit_sha = raw_untraced_git(
         &repo,
@@ -2085,8 +2087,8 @@ fn test_update_ref_side_effect_waits_for_prior_open_trace_root_until_causal_grac
     );
     while !daemon_completed_session(&repo, &later_session) {
         assert!(
-            later_start.elapsed() < Duration::from_millis(1_200),
-            "a later command waited out the causal grace again behind an already released root"
+            later_start.elapsed() < Duration::from_millis(1_500),
+            "a later command waited out the hard cap again behind an already released dead root"
         );
         std::thread::sleep(Duration::from_millis(10));
     }

--- a/tests/daemon_mode.rs
+++ b/tests/daemon_mode.rs
@@ -29,7 +29,7 @@ use repos::test_repo::live_pid_trace_sid;
 use repos::test_repo::{
     DAEMON_SPAWN_LOADER_RETRY_ATTEMPTS, DaemonTestCompletionLogEntry, DaemonTestScope, TestRepo,
     configure_raw_traced_git_env_for, get_binary_path, is_windows_loader_init_failure,
-    real_git_executable, trace_atexit_frame, write_trace_frames,
+    real_git_executable, reaped_pid_trace_sid, trace_atexit_frame, write_trace_frames,
 };
 use serde_json::Value;
 use serde_json::json;
@@ -2920,18 +2920,6 @@ fn daemon_sync_family_ignores_child_connection_of_a_completed_root() {
         started.elapsed() < Duration::from_secs(3),
         "a completed root's grandchild must not fence its family"
     );
-}
-
-/// A sid whose pid belongs to a process that has already exited, so the fence
-/// cannot mistake the root for a live interactive command.
-fn reaped_pid_trace_sid(tag: &str) -> String {
-    let mut child = std::process::Command::new(real_git_executable())
-        .arg("--version")
-        .stdout(std::process::Stdio::null())
-        .spawn()
-        .expect("spawn a short-lived process");
-    child.wait().expect("reap the short-lived process");
-    format!("20260411T120000.000000-H{tag}-P{:x}", child.id())
 }
 
 #[test]

--- a/tests/integration/repos/test_repo.rs
+++ b/tests/integration/repos/test_repo.rs
@@ -3677,6 +3677,18 @@ pub(crate) fn trace_atexit_frame(sid: &str, code: i32, time_ns: u64) -> serde_js
 
 /// A trace2 root sid whose pid is this test process: alive for as long as the
 /// test runs, standing in for a git command blocked in an editor or a hook.
+/// A sid whose pid belongs to a process that has already exited, so the fence
+/// cannot mistake the root for a live interactive command.
+pub(crate) fn reaped_pid_trace_sid(tag: &str) -> String {
+    let mut child = Command::new(real_git_executable())
+        .arg("--version")
+        .stdout(Stdio::null())
+        .spawn()
+        .expect("spawn a short-lived process");
+    child.wait().expect("reap the short-lived process");
+    format!("20260411T120000.000000-H{tag}-P{:x}", child.id())
+}
+
 pub(crate) fn live_pid_trace_sid(tag: &str) -> String {
     format!("20260411T120000.000000-H{tag}-P{:x}", std::process::id())
 }


### PR DESCRIPTION
## Problem
A heuristic fence release (grace expired, hard cap, written cap, finishing cap) was recomputed per waiter; only its log line and counter were deduplicated. Every later entry, `sync.family` and `await` behind a root that stayed registered with a dead process (leaked inherited socket fd, the phantom from #2306) waited out the full 30 s bound again, while the single log line read as "released".

Separately, a written root whose process had died (kept registered by a sibling connection) held to the 600 × grace written cap; the no-reflog tier already fell back to the hard cap for dead pids.

## Fix
- A release is recorded against the root only when its process was gone at the time: a dead process cannot write again, so later work, `sync.family` and `await` skip it. A live root's release stays per waiter, because it may still write and the next waiter's grace covers that write's frames (review feedback).
- A finishing root holds even if it was released earlier: its final frame is queued and its command sorts ahead.
- Written roots are probed for liveness once the grace has passed; a dead one is bounded by the hard cap.

## Tests
- `fence_release_is_a_fact_about_the_root_not_the_waiter`, `a_released_root_that_turns_finishing_holds_again`, `written_root_whose_process_is_gone_holds_only_to_the_hard_cap` (unit, red first)
- `test_update_ref_side_effect_waits_for_prior_open_trace_root_until_causal_grace` now uses a dead-pid root with a 100 ms grace and asserts a later command does not wait out the hard cap again (TestRepo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)