### PR TITLE
fix(daemon): judge stalls from the front entry's wait; harden the health snapshot and heartbeat

### DIFF
--- a/docs/daemon-trace2-ingestion-spec.md
+++ b/docs/daemon-trace2-ingestion-spec.md
@@ -95,8 +95,9 @@ decided from data first and heuristics last:
 3. **Unwritten**: neither signal fired, so the root has changed nothing and
    fences nothing. Nobody waits for an editor or a pre-commit hook, not even a
    grace.
-4. **No reflog to consult** (the root's worktree is unknown, or the repository
-   has no `HEAD` reflog): time and liveness decide. The root holds for the
+4. **No reflog to consult** (a command that does not move HEAD, such as
+   `push`, `fetch`, `branch` or `update-ref`; a root whose worktree is unknown;
+   or a repository that keeps no reflogs): time and liveness decide. The root holds for the
    causal grace (`FAMILY_CAUSAL_GRACE`, 1 s; `GIT_AI_DAEMON_CAUSAL_GRACE_MS`)
    measured from when the waiting work became ready; past it, a root whose pid
    (encoded in its sid, `-P<hex>`) is alive is released

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -13366,6 +13366,46 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn health_snapshot_judges_a_stall_from_the_front_entry_wait() {
+        use crate::daemon::health::DaemonHealthSnapshot;
+
+        let coord = ActorDaemonCoordinator::new();
+        // An old entry sits behind a front that only just became ready (a
+        // command with an earlier start whose frames arrived late). The drain
+        // measures the fence from the front's wait, so the snapshot must too:
+        // this family is busy, not stuck.
+        coord
+            .append_family_sequencer_entry(
+                "family-a",
+                2_000,
+                FamilySequencerEntry::ReadyCommand(Box::new(test_rebase_command(&[], Vec::new()))),
+            )
+            .unwrap();
+        {
+            let mut sequencers = coord.family_sequencers_by_family.lock().unwrap();
+            let slot = sequencers
+                .get_mut("family-a")
+                .and_then(|state| state.entries.values_mut().next())
+                .unwrap();
+            slot.enqueued_at = Instant::now().checked_sub(Duration::from_secs(60)).unwrap();
+        }
+        coord
+            .append_family_sequencer_entry(
+                "family-a",
+                1_000,
+                FamilySequencerEntry::ReadyCommand(Box::new(test_rebase_command(&[], Vec::new()))),
+            )
+            .unwrap();
+
+        let snapshot = DaemonHealthSnapshot::capture(&coord);
+        assert!(snapshot.families[0].oldest_entry_age_ms >= 60_000);
+        assert!(
+            !snapshot.sequencer_stalled,
+            "the front has barely waited: nothing is stuck"
+        );
+    }
+
+    #[tokio::test]
     async fn health_snapshot_does_not_call_a_busy_family_stalled() {
         use crate::daemon::health::DaemonHealthSnapshot;
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -13329,9 +13329,9 @@ mod tests {
     async fn health_snapshot_observes_a_bounded_number_of_open_roots() {
         use crate::daemon::health::{DaemonHealthSnapshot, HEALTH_ROOT_OBSERVE_LIMIT};
 
-        // Past a tiny grace, an observed live root without a reflog releases,
+        // Past a short grace, an observed live root without a reflog releases,
         // so the fence below is held only by roots the peek could not observe.
-        let grace = Duration::from_millis(1);
+        let grace = Duration::from_millis(20);
         let coord = ActorDaemonCoordinator::new_with_causal_grace(grace);
         for i in 0..HEALTH_ROOT_OBSERVE_LIMIT {
             open_unattributed_commit_root(&coord, &alive_root_sid(&format!("many-{i}")));
@@ -13361,7 +13361,16 @@ mod tests {
 
         // The drain releases even a written root at the written-root cap, so
         // an unobserved root is not reported as holding past it.
-        tokio::time::sleep(grace * FAMILY_WRITTEN_ROOT_FENCE_CAP_MULTIPLIER).await;
+        {
+            let mut sequencers = coord.family_sequencers_by_family.lock().unwrap();
+            let slot = sequencers
+                .get_mut("family-a")
+                .and_then(|state| state.entries.values_mut().next())
+                .unwrap();
+            slot.enqueued_at = Instant::now()
+                .checked_sub(grace * FAMILY_WRITTEN_ROOT_FENCE_CAP_MULTIPLIER + grace)
+                .unwrap();
+        }
         assert!(!DaemonHealthSnapshot::capture(&coord).families[0].fenced);
     }
 

--- a/src/daemon/health.rs
+++ b/src/daemon/health.rs
@@ -503,6 +503,25 @@ mod tests {
     }
 
     #[test]
+    fn family_ids_are_stable_within_a_run_but_not_a_bare_digest_of_the_path() {
+        use sha2::{Digest, Sha256};
+
+        let key = "/Users/someone/src/project/.git";
+        assert_eq!(family_id(key), family_id(key));
+        assert_ne!(family_id(key), family_id("/Users/someone/src/other/.git"));
+        let bare: String = Sha256::digest(key.as_bytes())
+            .iter()
+            .take(6)
+            .map(|byte| format!("{byte:02x}"))
+            .collect();
+        assert_ne!(
+            family_id(key),
+            bare,
+            "a bare digest of a low-entropy local path is confirmable by dictionary"
+        );
+    }
+
+    #[test]
     fn heartbeat_health_fields_flatten_aggregates_and_worst_families() {
         let fields = snapshot(vec![
             family("/repos/slow/.git", 90_000),

--- a/src/daemon/health.rs
+++ b/src/daemon/health.rs
@@ -68,7 +68,8 @@ struct RootSample {
 pub(crate) struct DaemonHealthSnapshot {
     pub uptime_seconds: u64,
     pub causal_grace_ms: u64,
-    /// A map was contended when sampled; its counts read as zero here.
+    /// A map was contended when sampled (its counts read as zero here), or
+    /// more roots were open than the snapshot observes.
     pub snapshot_partial: bool,
     pub checkpoints_outstanding: usize,
     pub checkpoints_outstanding_bytes: usize,
@@ -256,13 +257,14 @@ impl DaemonHealthSnapshot {
             }
             // Work fenced by a root that has written may legitimately wait as
             // long as that root runs; anything else is bounded by the hard cap.
+            // Judged from the front entry's own wait, the clock the drain
+            // uses: an older entry behind a fresh front is queued, not stuck.
             let bound = if fence.behind_written_root {
                 written_cap
             } else {
                 hard_cap
             };
-            if Duration::from_millis(health.oldest_entry_age_ms) > bound.max(SEQUENCER_STALL_FLOOR)
-            {
+            if front.waited > bound.max(SEQUENCER_STALL_FLOOR) {
                 sequencer_stalled = true;
             }
         }
@@ -384,8 +386,8 @@ impl DaemonHealthSnapshot {
     /// under its own name, plus the [`HEARTBEAT_FAMILY_DETAIL_LIMIT`] families
     /// with the oldest pending work as `family_<i>_<field>`. Family keys are
     /// local repository paths and never leave the machine: the heartbeat
-    /// carries a stable `family_<i>_id` digest instead, enough to correlate
-    /// consecutive heartbeats and daemon log lines that carry the same digest.
+    /// carries a salted `family_<i>_id` digest instead, stable for one daemon
+    /// process, enough to follow a family across consecutive heartbeats.
     pub fn heartbeat_fields(&self) -> BTreeMap<String, DaemonLogFieldValue> {
         let mut fields = BTreeMap::new();
         let Ok(Value::Object(snapshot)) = serde_json::to_value(self) else {
@@ -423,10 +425,18 @@ impl DaemonHealthSnapshot {
     }
 }
 
-/// A stable, non-reversible digest of a family key (a local path).
+/// A digest of a family key (a local path) that is stable within one daemon
+/// process, so successive heartbeats can be correlated, but salted with a
+/// secret that is never uploaded, so the low-entropy path cannot be confirmed
+/// by dictionary on the receiving side.
 fn family_id(family_key: &str) -> String {
     use sha2::{Digest, Sha256};
-    let digest = Sha256::digest(family_key.as_bytes());
+    static SALT: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+    let salt = SALT.get_or_init(crate::uuid::generate_v4);
+    let mut hasher = Sha256::new();
+    hasher.update(salt.as_bytes());
+    hasher.update(family_key.as_bytes());
+    let digest = hasher.finalize();
     digest
         .iter()
         .take(6)

--- a/src/daemon/telemetry_worker.rs
+++ b/src/daemon/telemetry_worker.rs
@@ -506,6 +506,41 @@ fn daemon_heartbeat_health_fields() -> BTreeMap<String, DaemonLogFieldValue> {
         .unwrap_or_default()
 }
 
+/// How long a heartbeat waits for its health sample before going out without
+/// one. Sampling stats files and probes processes, so it runs on its own
+/// thread rather than this runtime's shared blocking pool, which the metrics
+/// persistence and backfill work may be occupying.
+const HEARTBEAT_HEALTH_SAMPLE_TIMEOUT: Duration = Duration::from_secs(2);
+/// Whether a health sample thread is still running: a sample that hung (a
+/// stat on an unresponsive mount) must not be joined by another every
+/// heartbeat, so at most one sampler exists at a time.
+static HEARTBEAT_HEALTH_SAMPLE_IN_FLIGHT: AtomicBool = AtomicBool::new(false);
+
+async fn sample_heartbeat_health_fields() -> BTreeMap<String, DaemonLogFieldValue> {
+    if HEARTBEAT_HEALTH_SAMPLE_IN_FLIGHT
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_err()
+    {
+        return BTreeMap::new();
+    }
+    let (sender, receiver) = tokio::sync::oneshot::channel();
+    let spawned = std::thread::Builder::new()
+        .name("git-ai-heartbeat-health".to_string())
+        .spawn(move || {
+            let fields = daemon_heartbeat_health_fields();
+            HEARTBEAT_HEALTH_SAMPLE_IN_FLIGHT.store(false, Ordering::Release);
+            let _ = sender.send(fields);
+        });
+    if spawned.is_err() {
+        HEARTBEAT_HEALTH_SAMPLE_IN_FLIGHT.store(false, Ordering::Release);
+        return BTreeMap::new();
+    }
+    match tokio::time::timeout(HEARTBEAT_HEALTH_SAMPLE_TIMEOUT, receiver).await {
+        Ok(Ok(fields)) => fields,
+        _ => BTreeMap::new(),
+    }
+}
+
 /// Submit telemetry from within the daemon process.
 /// Returns true if the handle was available and envelopes were submitted.
 pub fn submit_daemon_internal_telemetry(envelopes: Vec<TelemetryEnvelope>) -> bool {
@@ -741,7 +776,7 @@ async fn telemetry_flush_loop(
             }
             Some(daemon_heartbeat_event(
                 started_at.elapsed(),
-                daemon_heartbeat_health_fields(),
+                sample_heartbeat_health_fields().await,
             ))
         } else {
             None

--- a/tests/daemon_mode.rs
+++ b/tests/daemon_mode.rs
@@ -29,7 +29,7 @@ use repos::test_repo::live_pid_trace_sid;
 use repos::test_repo::{
     DAEMON_SPAWN_LOADER_RETRY_ATTEMPTS, DaemonTestCompletionLogEntry, DaemonTestScope, TestRepo,
     configure_raw_traced_git_env_for, get_binary_path, is_windows_loader_init_failure,
-    real_git_executable, reaped_pid_trace_sid, trace_atexit_frame, write_trace_frames,
+    real_git_executable, reaped_pid_trace_sid, trace_atexit_frame, unix_now_ns, write_trace_frames,
 };
 use serde_json::Value;
 use serde_json::json;
@@ -2875,7 +2875,10 @@ fn daemon_sync_family_returns_promptly_with_open_unwritten_mutating_root() {
         "sync.family must not wait for a root that has written nothing"
     );
 
-    write_trace_frames(&mut open_trace, &[trace_atexit_frame(&sid, 0, 1_002)]);
+    write_trace_frames(
+        &mut open_trace,
+        &[trace_atexit_frame(&sid, 0, unix_now_ns())],
+    );
 }
 
 #[test]
@@ -2884,7 +2887,7 @@ fn daemon_sync_family_ignores_child_connection_of_a_completed_root() {
     // The root ran, wrote its atexit and exited; the daemon has processed it.
     let sid = reaped_pid_trace_sid("gc-parent");
     let mut root = repo.open_mutating_commit_trace_root(&sid, true);
-    write_trace_frames(&mut root, &[trace_atexit_frame(&sid, 0, 1_002)]);
+    write_trace_frames(&mut root, &[trace_atexit_frame(&sid, 0, unix_now_ns())]);
     drop(root);
     repo.sync_daemon();
 
@@ -2949,7 +2952,10 @@ fn daemon_await_completes_with_idle_open_mutating_root() {
         "await should return well before its 5s deadline"
     );
 
-    write_trace_frames(&mut open_trace, &[trace_atexit_frame(&sid, 0, 1_002)]);
+    write_trace_frames(
+        &mut open_trace,
+        &[trace_atexit_frame(&sid, 0, unix_now_ns())],
+    );
 }
 
 #[cfg(not(windows))]
@@ -3025,7 +3031,10 @@ fn daemon_status_daemon_reports_open_root_and_fenced_checkpoint() {
     assert_eq!(fenced["families"][0]["fenced"], json!(true), "{fenced}");
     assert_eq!(fenced["sequencer_stalled"], json!(false), "{fenced}");
 
-    write_trace_frames(&mut open_trace, &[trace_atexit_frame(&sid, 0, 1_002)]);
+    write_trace_frames(
+        &mut open_trace,
+        &[trace_atexit_frame(&sid, 0, unix_now_ns())],
+    );
     let started = std::time::Instant::now();
     loop {
         let snapshot = status_daemon(&repo);
@@ -3120,7 +3129,10 @@ fn daemon_sync_family_ignores_open_mutating_root_from_other_family() {
         "unrelated sync.family request failed: {unrelated_sync:?}"
     );
 
-    write_trace_frames(&mut open_trace, &[trace_atexit_frame(sid, 0, 1_002)]);
+    write_trace_frames(
+        &mut open_trace,
+        &[trace_atexit_frame(sid, 0, unix_now_ns())],
+    );
     let own_sync_response = own_sync_rx
         .recv_timeout(Duration::from_secs(1))
         .expect("own-family sync should complete after the trace root closes")

--- a/tests/integration/repos/test_repo.rs
+++ b/tests/integration/repos/test_repo.rs
@@ -2508,11 +2508,14 @@ impl TestRepo {
             Duration::from_secs(2),
         )
         .expect("connect trace root to daemon");
+        // Stamped on git's clock as a real root would be, so a reflog older
+        // than the root cannot pass for one it wrote.
+        let started_at_ns = unix_now_ns();
         let mut frames = vec![serde_json::json!({
             "event": "start",
             "sid": sid,
             "argv": ["git", "commit", "-m", "still running"],
-            "time_ns": 1_000u64,
+            "time_ns": started_at_ns,
         })];
         if attribute_to_repo {
             frames.push(serde_json::json!({
@@ -2520,7 +2523,7 @@ impl TestRepo {
                 "sid": sid,
                 "worktree": self.path().to_string_lossy(),
                 "repo": self.path().join(".git").to_string_lossy(),
-                "time_ns": 1_001u64,
+                "time_ns": started_at_ns + 1,
             }));
         }
         write_trace_frames(&mut stream, &frames);
@@ -3664,6 +3667,14 @@ pub(crate) fn write_trace_frames(stream: &mut impl Write, frames: &[serde_json::
         stream.write_all(b"\n").expect("write trace frame newline");
     }
     stream.flush().expect("flush trace frames");
+}
+
+/// The current time on git's clock, for stamping synthetic trace frames.
+pub(crate) fn unix_now_ns() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("clock after the epoch")
+        .as_nanos() as u64
 }
 
 pub(crate) fn trace_atexit_frame(sid: &str, code: i32, time_ns: u64) -> serde_json::Value {


### PR DESCRIPTION
## Changes
- `sequencer_stalled` compared the oldest entry's age with the front entry's fence bound, so an older entry behind a fresh front read as a stall. It now uses the front's own wait, the clock the drain uses.
- Heartbeat family ids are salted with a per-process secret that is never uploaded (the daemon run id travels with every upload, so it would not have resisted dictionary confirmation): stable across one process's heartbeats, no longer a bare digest of a local path.
- The heartbeat's health snapshot (file stats, liveness probes) runs on its own thread with a 2 s timeout instead of the telemetry runtime's shared two-thread blocking pool, so a busy pool cannot delay flushes.
- The bounded-observation unit test backdates the entry past the written cap instead of sleeping through it with a 1 ms grace (CI flake risk).
- The integration trace-root helper stamps roots and their atexit on git's clock, so a reflog older than the root can no longer pass for one it wrote (makes the status test's `trace_roots_written` assertion real).
- Spec: tier 4 also covers commands that do not move HEAD and repositories that keep no reflogs; `snapshot_partial` also covers more open roots than observed.

## Tests
- `health_snapshot_judges_a_stall_from_the_front_entry_wait`, `family_ids_are_stable_within_a_run_but_not_a_bare_digest_of_the_path` (red first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)