### PR TITLE
ci(mdm): per-PR end-to-end tests for the login-start scripts

### DIFF
--- a/.github/workflows/mdm-login-start.yml
+++ b/.github/workflows/mdm-login-start.yml
@@ -1,0 +1,126 @@
+name: MDM Login Start
+
+# Exercises mdm/*/install-login-start.* with a locally built binary: the login
+# mechanism must bring the daemon up and must not interfere with the daemon's
+# own lifecycle (uptime restart, lock-guarded single instance).
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    paths:
+      - 'mdm/**'
+      - 'scripts/mdm/**'
+      - 'src/commands/daemon.rs'
+      - 'src/daemon.rs'
+      - 'install.sh'
+      - 'install.ps1'
+      - '.github/workflows/mdm-login-start.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'mdm/**'
+      - 'scripts/mdm/**'
+      - 'src/commands/daemon.rs'
+      - 'src/daemon.rs'
+      - 'install.sh'
+      - 'install.ps1'
+      - '.github/workflows/mdm-login-start.yml'
+  merge_group:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  login-start-unix:
+    name: Login start on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+        with:
+          toolchain: stable
+
+      - name: Build git-ai
+        run: cargo build --release --bin git-ai
+
+      - name: Ensure a systemd user manager is running
+        if: runner.os == 'Linux'
+        run: |
+          set -euo pipefail
+          uid="$(id -u)"
+          sudo loginctl enable-linger "$(id -un)"
+          export XDG_RUNTIME_DIR="/run/user/$uid"
+          export DBUS_SESSION_BUS_ADDRESS="unix:path=/run/user/$uid/bus"
+          for _ in $(seq 1 30); do
+            systemctl --user show-environment >/dev/null 2>&1 && break
+            sleep 1
+          done
+          systemctl --user show-environment >/dev/null
+          {
+            echo "XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR"
+            echo "DBUS_SESSION_BUS_ADDRESS=$DBUS_SESSION_BUS_ADDRESS"
+          } >> "$GITHUB_ENV"
+
+      - name: Run lifecycle scenario
+        env:
+          BINARY_SOURCE: local
+          GIT_AI_LOCAL_BINARY: ${{ github.workspace }}/target/release/git-ai
+          MDM_TEST_LOG_DIR: ${{ runner.temp }}/mdm-logs
+        run: bash scripts/mdm/test-login-start.sh lifecycle
+
+      - name: Upload daemon and launcher logs
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: mdm-login-start-${{ matrix.os }}
+          path: ${{ runner.temp }}/mdm-logs
+          retention-days: 7
+          if-no-files-found: warn
+
+  login-start-windows:
+    name: Login start on windows-latest
+    runs-on: windows-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+        with:
+          toolchain: stable
+
+      - name: Build git-ai
+        run: cargo build --release --bin git-ai
+
+      - name: Run lifecycle scenario
+        shell: pwsh
+        env:
+          BINARY_SOURCE: local
+          GIT_AI_LOCAL_BINARY: ${{ github.workspace }}\target\release\git-ai.exe
+          MDM_TEST_LOG_DIR: ${{ runner.temp }}\mdm-logs
+        run: ./scripts/mdm/test-login-start.ps1 -Scenario lifecycle
+
+      - name: Upload daemon and launcher logs
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: mdm-login-start-windows-latest
+          path: ${{ runner.temp }}\mdm-logs
+          retention-days: 7
+          if-no-files-found: warn

--- a/scripts/mdm/test-login-start.ps1
+++ b/scripts/mdm/test-login-start.ps1
@@ -250,3 +250,6 @@ try {
 } finally {
     Invoke-Cleanup
 }
+# Cleanup's best-effort `bg shutdown` leaves a non-zero $LASTEXITCODE when no
+# daemon is running; do not let pwsh -File report that as the script's result.
+exit 0

--- a/scripts/mdm/test-login-start.ps1
+++ b/scripts/mdm/test-login-start.ps1
@@ -1,0 +1,218 @@
+# End-to-end test for mdm/windows/install-login-start.ps1.
+#
+# Installs git-ai into $HOME, registers the logon task, starts it as the logon
+# trigger would, and checks that the daemon (a) comes up, (b) survives the task
+# instance ending, (c) restarts itself on schedule while registered, and
+# (d) the task stays healthy throughout. The auto-update scenario additionally
+# starts from an older release and waits for the daemon to self-update.
+#
+# Usage: test-login-start.ps1 [-Scenario lifecycle|auto-update]
+#
+# Environment: BINARY_SOURCE (local|release), GIT_AI_LOCAL_BINARY,
+# GIT_AI_RELEASE_TAG, LATEST_TAG, MDM_TEST_LOG_DIR — same meaning as in
+# test-login-start.sh.
+param(
+    [ValidateSet('lifecycle', 'auto-update')]
+    [string]$Scenario = 'lifecycle'
+)
+
+$ErrorActionPreference = 'Stop'
+
+$BinarySource = if ($env:BINARY_SOURCE) { $env:BINARY_SOURCE } else { 'local' }
+$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$LogOut = if ($env:MDM_TEST_LOG_DIR) { $env:MDM_TEST_LOG_DIR } else { Join-Path ($env:RUNNER_TEMP, $env:TEMP | Where-Object { $_ } | Select-Object -First 1) 'mdm-logs' }
+$Bin = Join-Path $HOME '.git-ai\bin\git-ai.exe'
+$DaemonDir = Join-Path $HOME '.git-ai\internal\daemon'
+$TaskPath = '\GitAI\'
+$TaskName = 'Start bg at logon'
+$MdmScript = Join-Path $RepoRoot 'mdm\windows\install-login-start.ps1'
+$StatusRepo = Join-Path ([IO.Path]::GetTempPath()) ("mdm-status-" + [guid]::NewGuid().ToString('N'))
+
+function Write-Log([string]$Message) { Write-Host "[mdm-test] $Message" }
+function Fail([string]$Message) { throw "[mdm-test] FAIL: $Message" }
+
+# --- helpers -----------------------------------------------------------------
+
+function Install-Binary {
+    switch ($BinarySource) {
+        'local' {
+            if (-not ($env:GIT_AI_LOCAL_BINARY -and (Test-Path $env:GIT_AI_LOCAL_BINARY))) {
+                Fail 'GIT_AI_LOCAL_BINARY must point at a built git-ai.exe'
+            }
+        }
+        'release' { }
+        default { Fail 'BINARY_SOURCE must be local or release' }
+    }
+    Push-Location $RepoRoot
+    try {
+        pwsh -NoProfile -ExecutionPolicy Bypass -File .\install.ps1
+        if ($LASTEXITCODE -ne 0) { Fail "install.ps1 exited $LASTEXITCODE" }
+    } finally {
+        Pop-Location
+    }
+    if (-not (Test-Path $Bin)) { Fail "$Bin missing after install" }
+    Write-Log "installed $(& $Bin --version)"
+}
+
+function Get-InstalledVersion {
+    return (& $Bin --version).Trim().Split()[0].TrimStart('v')
+}
+
+function Get-DaemonPid {
+    $file = Join-Path $DaemonDir 'daemon.pid.json'
+    if (-not (Test-Path $file)) { return $null }
+    try { return (Get-Content -Raw $file | ConvertFrom-Json).pid } catch { return $null }
+}
+
+function Test-PidAlive($ProcessId) {
+    return $ProcessId -and (Get-Process -Id $ProcessId -ErrorAction SilentlyContinue)
+}
+
+function Test-DaemonUp {
+    if (-not (Test-PidAlive (Get-DaemonPid))) { return $false }
+    Push-Location $StatusRepo
+    try {
+        & $Bin bg status *> $null
+        return $LASTEXITCODE -eq 0
+    } finally {
+        Pop-Location
+    }
+}
+
+function Wait-For([int]$Seconds, [string]$What, [scriptblock]$Condition) {
+    $deadline = (Get-Date).AddSeconds($Seconds)
+    while (-not (& $Condition)) {
+        if ((Get-Date) -ge $deadline) { Fail "timed out after ${Seconds}s waiting for $What" }
+        Start-Sleep -Seconds 1
+    }
+    Write-Log $What
+}
+
+function Invoke-MdmScript {
+    # Windows PowerShell, as MDM tooling and `irm | iex` would use it.
+    & powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -File $MdmScript @args
+    if ($LASTEXITCODE -ne 0) { Fail "install-login-start.ps1 $args exited $LASTEXITCODE" }
+}
+
+function Get-Task {
+    return Get-ScheduledTask -TaskPath $TaskPath -TaskName $TaskName -ErrorAction SilentlyContinue
+}
+
+function Test-Registered { return [bool](Get-Task) }
+
+function Wait-TaskIdle {
+    Wait-For 60 'task instance finished' { (Get-Task).State -ne 'Running' }
+}
+
+function Test-MechanismSane {
+    $task = Get-Task
+    if (-not $task) { Fail 'scheduled task missing' }
+    Wait-TaskIdle
+    $info = Get-ScheduledTaskInfo -TaskPath $TaskPath -TaskName $TaskName
+    if ($info.LastTaskResult -ne 0) { Fail "task last result 0x$($info.LastTaskResult.ToString('X'))" }
+    Write-Log 'login mechanism healthy'
+}
+
+function Invoke-Lint {
+    if (Get-Module -ListAvailable PSScriptAnalyzer) {
+        $findings = Invoke-ScriptAnalyzer -Path $MdmScript -Severity Error
+        if ($findings) { $findings | Format-Table | Out-String | Write-Host; Fail 'PSScriptAnalyzer errors' }
+    }
+}
+
+function Get-DaemonStartedVersions {
+    Get-ChildItem (Join-Path $DaemonDir 'logs') -Filter '*.log' -ErrorAction SilentlyContinue |
+        Select-String -Pattern 'daemon started .*version="([^"]*)"' |
+        ForEach-Object { $_.Matches[0].Groups[1].Value }
+}
+
+function Invoke-Cleanup {
+    New-Item -ItemType Directory -Path $LogOut -Force | Out-Null
+    Copy-Item (Join-Path $DaemonDir 'logs') (Join-Path $LogOut 'daemon-logs') -Recurse -Force -ErrorAction SilentlyContinue
+    Get-Task | Get-ScheduledTaskInfo -ErrorAction SilentlyContinue | Out-File (Join-Path $LogOut 'task-info.txt')
+    Copy-Item (Join-Path $HOME '.git-ai\login\start-bg.ps1') $LogOut -Force -ErrorAction SilentlyContinue
+    & powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -File $MdmScript --uninstall *> $null
+    if (Test-Path $Bin) { & $Bin bg shutdown *> $null }
+    Remove-Item $StatusRepo -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+# --- scenarios ---------------------------------------------------------------
+
+function Register-AndWaitForDaemon {
+    Invoke-MdmScript @args
+    if (-not (Test-Registered)) { Fail 'login start not registered after install' }
+    Wait-For 45 'daemon up after logon trigger' { Test-DaemonUp }
+}
+
+function Invoke-LifecycleScenario {
+    Install-Binary
+    # Keep the uptime restart deterministic: no network update checks.
+    & $Bin config set disable_auto_updates true
+    & $Bin bg shutdown *> $null
+
+    Register-AndWaitForDaemon --env GIT_AI_DAEMON_UPDATE_CHECK_INTERVAL=5 --env GIT_AI_DAEMON_MAX_UPTIME_SECS=25
+    $pid1 = Get-DaemonPid
+
+    Start-Sleep -Seconds 10
+    if (-not (Test-PidAlive $pid1)) { Fail "daemon $pid1 died after the task instance ended (job object torn down?)" }
+    if (-not (Test-DaemonUp)) { Fail 'daemon not answering after task instance ended' }
+    Write-Log 'daemon survived task instance ending'
+
+    # Max uptime (25s) is past the survival check above but well inside this wait.
+    Wait-For 60 'daemon restarted itself on schedule' { $p = Get-DaemonPid; $p -and $p -ne $pid1 }
+    $pid2 = Get-DaemonPid
+    Wait-For 15 'restarted daemon healthy' { Test-DaemonUp }
+    Test-MechanismSane
+
+    Start-ScheduledTask -TaskPath $TaskPath -TaskName $TaskName
+    Wait-TaskIdle
+    Start-Sleep -Seconds 3
+    if (-not (Test-DaemonUp)) { Fail 'daemon unhealthy after re-trigger' }
+    if ((Get-DaemonPid) -ne $pid2) { Fail "re-triggering logon restarted the daemon (pid $pid2 -> $(Get-DaemonPid))" }
+    Test-MechanismSane
+    Write-Log 're-triggered logon start was a no-op'
+
+    Invoke-Lint
+
+    Invoke-MdmScript --uninstall
+    if (Test-Registered) { Fail 'task still registered after --uninstall' }
+    Write-Log 'uninstall clean'
+}
+
+function Invoke-AutoUpdateScenario {
+    if ($BinarySource -ne 'release') { Fail 'auto-update needs BINARY_SOURCE=release' }
+    if (-not $env:GIT_AI_RELEASE_TAG) { Fail 'auto-update needs GIT_AI_RELEASE_TAG (an older release)' }
+    if (-not $env:LATEST_TAG) { Fail 'auto-update needs LATEST_TAG' }
+    $latest = $env:LATEST_TAG.TrimStart('v')
+
+    Install-Binary
+    $before = Get-InstalledVersion
+    if ($before -eq $latest) { Fail 'GIT_AI_RELEASE_TAG must be older than LATEST_TAG' }
+    & $Bin bg shutdown *> $null
+
+    Register-AndWaitForDaemon --env GIT_AI_DAEMON_UPDATE_CHECK_INTERVAL=10
+    $pid1 = Get-DaemonPid
+
+    # The Windows installer runs detached and waits for the exe lock to clear.
+    Wait-For 300 "binary updated to $latest" { (Get-InstalledVersion) -eq $latest }
+    Wait-For 120 'daemon restarted after update' { $p = Get-DaemonPid; $p -and $p -ne $pid1 }
+    Wait-For 30 'updated daemon healthy' { Test-DaemonUp }
+    if (-not ((Get-DaemonStartedVersions) -contains $latest)) { Fail "no 'daemon started' log line for version $latest" }
+    Test-MechanismSane
+
+    Invoke-MdmScript --uninstall
+    if (Test-Registered) { Fail 'task still registered after --uninstall' }
+    Write-Log "auto-update $before -> $latest completed under logon start"
+}
+
+New-Item -ItemType Directory -Path $StatusRepo -Force | Out-Null
+git -C $StatusRepo init -q
+try {
+    switch ($Scenario) {
+        'lifecycle' { Invoke-LifecycleScenario }
+        'auto-update' { Invoke-AutoUpdateScenario }
+    }
+    Write-Log "PASS $Scenario on windows"
+} finally {
+    Invoke-Cleanup
+}

--- a/scripts/mdm/test-login-start.ps1
+++ b/scripts/mdm/test-login-start.ps1
@@ -79,6 +79,18 @@ function Test-DaemonUp {
     }
 }
 
+function Get-DaemonProcesses {
+    Get-CimInstance Win32_Process -Filter "Name = 'git-ai.exe'" |
+        Where-Object { $_.CommandLine -match 'bg run' -and $_.ExecutablePath -like "$HOME\*" }
+}
+
+# `bg shutdown` returns before the old process has released the daemon lock;
+# a logon start racing that window would have to retry.
+function Stop-Daemon {
+    & $Bin bg shutdown *> $null
+    Wait-For 30 'previous daemon exited' { -not (Get-DaemonProcesses) }
+}
+
 function Wait-For([int]$Seconds, [string]$What, [scriptblock]$Condition) {
     $deadline = (Get-Date).AddSeconds($Seconds)
     while (-not (& $Condition)) {
@@ -148,7 +160,7 @@ function Invoke-LifecycleScenario {
     Install-Binary
     # Keep the uptime restart deterministic: no network update checks.
     & $Bin config set disable_auto_updates true
-    & $Bin bg shutdown *> $null
+    Stop-Daemon
 
     Register-AndWaitForDaemon --env GIT_AI_DAEMON_UPDATE_CHECK_INTERVAL=5 --env GIT_AI_DAEMON_MAX_UPTIME_SECS=25
     $pid1 = Get-DaemonPid
@@ -177,6 +189,28 @@ function Invoke-LifecycleScenario {
     Invoke-MdmScript --uninstall
     if (Test-Registered) { Fail 'task still registered after --uninstall' }
     Write-Log 'uninstall clean'
+
+    Stop-Daemon
+    Invoke-UnusualBinaryPathScenario
+}
+
+# --bin must cope with every path an admin might install to: spaces, quotes,
+# parentheses, percent signs, non-ASCII.
+function Invoke-UnusualBinaryPathScenario {
+    $dir = Join-Path $HOME "mdm test (weird) 100% 'quoted' ünïcode"
+    New-Item -ItemType Directory -Path $dir -Force | Out-Null
+    Copy-Item $Bin (Join-Path $dir 'git-ai.exe') -Force
+
+    Invoke-MdmScript --bin (Join-Path $dir 'git-ai.exe')
+    if (-not (Test-Registered)) { Fail 'login start not registered with unusual --bin' }
+    Wait-For 45 'daemon up from unusual binary path' { Test-DaemonUp }
+    $running = @(Get-DaemonProcesses | Where-Object { $_.ExecutablePath -like "$dir\*" })
+    if (-not $running) { Fail "daemon is not running from $dir" }
+    Write-Log 'daemon runs from the unusual path'
+    Test-MechanismSane
+
+    Invoke-MdmScript --uninstall
+    Stop-Daemon
 }
 
 function Invoke-AutoUpdateScenario {
@@ -188,7 +222,7 @@ function Invoke-AutoUpdateScenario {
     Install-Binary
     $before = Get-InstalledVersion
     if ($before -eq $latest) { Fail 'GIT_AI_RELEASE_TAG must be older than LATEST_TAG' }
-    & $Bin bg shutdown *> $null
+    Stop-Daemon
 
     Register-AndWaitForDaemon --env GIT_AI_DAEMON_UPDATE_CHECK_INTERVAL=10
     $pid1 = Get-DaemonPid

--- a/scripts/mdm/test-login-start.ps1
+++ b/scripts/mdm/test-login-start.ps1
@@ -192,6 +192,7 @@ function Invoke-LifecycleScenario {
 
     Stop-Daemon
     Invoke-UnusualBinaryPathScenario
+    Invoke-LauncherRetryScenario
 }
 
 # --bin must cope with every path an admin might install to: spaces, quotes,
@@ -211,6 +212,59 @@ function Invoke-UnusualBinaryPathScenario {
 
     Invoke-MdmScript --uninstall
     Stop-Daemon
+}
+
+# Writes a fake git-ai.cmd that fails until its Nth invocation, then hands off
+# to the real binary. Attempts are counted in a file next to it.
+function Write-FakeBinary([string]$Path, [int]$SucceedAt) {
+    $lines = @(
+        '@echo off',
+        'setlocal',
+        'set n=0',
+        'if exist "%~dp0attempts" set /p n=<"%~dp0attempts"',
+        'set /a n+=1',
+        '>"%~dp0attempts" echo %n%',
+        "if %n% lss $SucceedAt exit /b 1",
+        "`"$Bin`" %*",
+        'exit /b %errorlevel%'
+    )
+    Set-Content -LiteralPath $Path -Value ($lines -join "`r`n") -Encoding ASCII
+}
+
+function Get-Attempts([string]$Dir) {
+    $file = Join-Path $Dir 'attempts'
+    if (Test-Path $file) { return [int](Get-Content $file | Select-Object -First 1).Trim() }
+    return 0
+}
+
+# The launcher retries bg start a few times: transient failures must end in a
+# healthy daemon, and persistent failure must surface as a failed logon task.
+function Invoke-LauncherRetryScenario {
+    $fakeDir = Join-Path $HOME 'mdm-fake'
+    New-Item -ItemType Directory -Path $fakeDir -Force | Out-Null
+    $fake = Join-Path $fakeDir 'git-ai.cmd'
+
+    Write-FakeBinary $fake 3
+    Invoke-MdmScript --bin $fake
+    Wait-For 60 'daemon up after transient launcher failures' { Test-DaemonUp }
+    $attempts = Get-Attempts $fakeDir
+    if ($attempts -ne 3) { Fail "expected 3 attempts, got $attempts" }
+    Test-MechanismSane
+    Invoke-MdmScript --uninstall
+    Stop-Daemon
+
+    Remove-Item (Join-Path $fakeDir 'attempts') -Force -ErrorAction SilentlyContinue
+    Write-FakeBinary $fake 99
+    Invoke-MdmScript --bin $fake --no-start
+    Start-ScheduledTask -TaskPath $TaskPath -TaskName $TaskName
+    Wait-TaskIdle
+    $info = Get-ScheduledTaskInfo -TaskPath $TaskPath -TaskName $TaskName
+    if ($info.LastTaskResult -eq 0) { Fail 'persistent launcher failure was reported as success' }
+    $attempts = Get-Attempts $fakeDir
+    if ($attempts -ne 5) { Fail "expected 5 attempts, got $attempts" }
+    if (Test-DaemonUp) { Fail 'no daemon should be running after persistent failure' }
+    Invoke-MdmScript --uninstall
+    Write-Log 'launcher retry semantics verified'
 }
 
 function Invoke-AutoUpdateScenario {

--- a/scripts/mdm/test-login-start.sh
+++ b/scripts/mdm/test-login-start.sh
@@ -230,6 +230,7 @@ scenario_lifecycle() {
 
   stop_daemon
   scenario_unusual_binary_path
+  scenario_launcher_retry
 }
 
 # --bin must cope with every path an admin might install to: spaces, quotes,
@@ -250,6 +251,60 @@ scenario_unusual_binary_path() {
 
   run_mdm_script --uninstall
   stop_daemon
+}
+
+# Writes a fake git-ai that fails until its Nth invocation, then hands off to
+# the real binary. Attempts are counted in $2.
+write_fake_binary() {
+  local path="$1" attempts="$2" succeed_at="$3"
+  cat >"$path" <<EOF
+#!/bin/sh
+n=\$(cat "$attempts" 2>/dev/null || echo 0); n=\$((n + 1)); echo "\$n" >"$attempts"
+[ "\$n" -ge $succeed_at ] || exit 1
+exec "$BIN" "\$@"
+EOF
+  chmod +x "$path"
+}
+
+mechanism_failed() {
+  case "$OS" in
+    macos) launchctl print "gui/$(id -u)/$LABEL" | grep -Eq "last exit code = [1-9]" ;;
+    linux) systemctl --user is-failed --quiet "$UNIT" ;;
+  esac
+}
+
+# Runs the registered launcher once; the login mechanism itself must report failure.
+trigger_login_expect_failure() {
+  case "$OS" in
+    macos) launchctl bootstrap "gui/$(id -u)" "$HOME/Library/LaunchAgents/$LABEL.plist" ;;
+    linux) ! systemctl --user start "$UNIT" ;;
+  esac
+}
+
+# The launcher retries bg start a few times: transient failures must end in a
+# healthy daemon, and persistent failure must surface as a failed login start.
+scenario_launcher_retry() {
+  local fake_dir="$HOME/mdm-fake" attempts="$HOME/mdm-fake/attempts"
+  mkdir -p "$fake_dir"
+
+  write_fake_binary "$fake_dir/git-ai" "$attempts" 3
+  run_mdm_script --bin "$fake_dir/git-ai"
+  wait_for 45 "daemon up after transient launcher failures" daemon_up
+  [ "$(cat "$attempts")" = 3 ] || fail "expected 3 attempts, got $(cat "$attempts")"
+  mechanism_sane
+  run_mdm_script --uninstall
+  stop_daemon
+
+  rm -f "$attempts"
+  write_fake_binary "$fake_dir/git-ai" "$attempts" 99
+  run_mdm_script --bin "$fake_dir/git-ai" --no-start
+  trigger_login_expect_failure
+  wait_for 45 "persistent launcher failure reported by the login mechanism" mechanism_failed
+  [ "$(cat "$attempts")" = 5 ] || fail "expected 5 attempts, got $(cat "$attempts")"
+  daemon_up && fail "no daemon should be running after persistent failure"
+  run_mdm_script --uninstall
+  [ "$OS" != linux ] || systemctl --user reset-failed "$UNIT" 2>/dev/null || true
+  log "launcher retry semantics verified"
 }
 
 scenario_auto_update() {

--- a/scripts/mdm/test-login-start.sh
+++ b/scripts/mdm/test-login-start.sh
@@ -94,6 +94,18 @@ wait_for() {
 
 pid_changed_from() { local now; now="$(daemon_pid)"; [ -n "$now" ] && [ "$now" != "$1" ]; }
 
+# Only daemons under this HOME: a developer box may run its own git-ai daemon.
+no_daemon_process() { ! pgrep -f "^$HOME/.*git-ai bg run" >/dev/null; }
+
+# `bg shutdown` returns before the old process has released the daemon lock;
+# a login start racing that window would have to retry.
+stop_daemon() {
+  "$BIN" bg shutdown >/dev/null 2>&1 || true
+  wait_for 30 "previous daemon exited" no_daemon_process
+}
+
+daemon_command_line() { ps -p "$(daemon_pid)" -o args= 2>/dev/null || true; }
+
 mdm_script_args() {
   if [ "${MDM_TEST_ISOLATED_HOME:-0}" = "1" ]; then
     printf '%s\n' --bin "$BIN" --env "HOME=$HOME"
@@ -103,7 +115,8 @@ mdm_script_args() {
 run_mdm_script() {
   local extra=()
   while IFS= read -r line; do extra+=("$line"); done < <(mdm_script_args)
-  sh "$MDM_SCRIPT" "$@" "${extra[@]+"${extra[@]}"}"
+  # Isolation flags go first so a caller's own --bin wins (last one wins).
+  sh "$MDM_SCRIPT" "${extra[@]+"${extra[@]}"}" "$@"
 }
 
 registered() {
@@ -184,7 +197,7 @@ scenario_lifecycle() {
   install_binary
   # Keep the uptime restart deterministic: no network update checks.
   "$BIN" config set disable_auto_updates true
-  "$BIN" bg shutdown >/dev/null 2>&1 || true
+  stop_daemon
 
   register_and_wait_for_daemon \
     --env GIT_AI_DAEMON_UPDATE_CHECK_INTERVAL=5 \
@@ -214,6 +227,29 @@ scenario_lifecycle() {
   run_mdm_script --uninstall
   ! registered || fail "login start still registered after --uninstall"
   log "uninstall clean"
+
+  stop_daemon
+  scenario_unusual_binary_path
+}
+
+# --bin must cope with every path an admin might install to: spaces, quotes,
+# parentheses, percent signs, non-ASCII.
+scenario_unusual_binary_path() {
+  local dir="$HOME/mdm test (weird) 100% 'quoted' ünïcode"
+  mkdir -p "$dir"
+  cp "$BIN" "$dir/git-ai"
+
+  run_mdm_script --bin "$dir/git-ai"
+  registered || fail "login start not registered with unusual --bin"
+  wait_for 30 "daemon up from unusual binary path" daemon_up
+  case "$(daemon_command_line)" in
+    *"$dir/git-ai"*) log "daemon runs from the unusual path" ;;
+    *) fail "daemon command line does not reference $dir: $(daemon_command_line)" ;;
+  esac
+  mechanism_sane
+
+  run_mdm_script --uninstall
+  stop_daemon
 }
 
 scenario_auto_update() {
@@ -225,7 +261,7 @@ scenario_auto_update() {
   install_binary
   local before; before="$(installed_version)"
   [ "$before" != "$latest" ] || fail "GIT_AI_RELEASE_TAG must be older than LATEST_TAG"
-  "$BIN" bg shutdown >/dev/null 2>&1 || true
+  stop_daemon
 
   register_and_wait_for_daemon --env GIT_AI_DAEMON_UPDATE_CHECK_INTERVAL=10
   local pid1; pid1="$(daemon_pid)"

--- a/scripts/mdm/test-login-start.sh
+++ b/scripts/mdm/test-login-start.sh
@@ -136,13 +136,18 @@ trigger_login() {
   esac
 }
 
+launcher_exited() { launchctl print "gui/$(id -u)/$LABEL" 2>/dev/null | grep -q "state = not running"; }
+
 mechanism_sane() {
   case "$OS" in
     macos)
-      local out
-      out="$(launchctl print "gui/$(id -u)/$LABEL")" || fail "launchd job missing"
-      if grep -E "last exit code = [1-9]" <<<"$out"; then fail "launchd job exited non-zero"; fi
-      grep -q "state = not running" <<<"$out" || fail "launchd job still running: launcher did not exit"
+      launchctl print "gui/$(id -u)/$LABEL" >/dev/null 2>&1 || fail "launchd job missing"
+      # The daemon answers before `bg start` returns and launchd notices; give
+      # the launcher a moment to exit rather than asserting instantly.
+      wait_for 20 "launcher exited" launcher_exited
+      if launchctl print "gui/$(id -u)/$LABEL" | grep -E "last exit code = [1-9]"; then
+        fail "launchd job exited non-zero"
+      fi
       ;;
     linux)
       [ "$(systemctl --user is-active "$UNIT")" = "active" ] || fail "unit not active"

--- a/scripts/mdm/test-login-start.sh
+++ b/scripts/mdm/test-login-start.sh
@@ -1,0 +1,250 @@
+#!/usr/bin/env bash
+# End-to-end test for mdm/{macos,linux}/install-login-start.sh.
+#
+# Installs git-ai into $HOME, registers the login start, simulates the login
+# trigger, and checks that the daemon (a) comes up, (b) survives the launcher
+# exiting, (c) restarts itself on schedule while registered, and (d) the login
+# mechanism stays healthy throughout. The auto-update scenario additionally
+# starts from an older release and waits for the daemon to self-update.
+#
+# Usage: test-login-start.sh [lifecycle|auto-update]
+#
+# Environment:
+#   BINARY_SOURCE          local (default) | release
+#   GIT_AI_LOCAL_BINARY    binary to install when BINARY_SOURCE=local
+#   GIT_AI_RELEASE_TAG     release tag to install when BINARY_SOURCE=release
+#                          (empty = latest); required for auto-update
+#   LATEST_TAG             tag the auto-update scenario must reach
+#   MDM_TEST_LOG_DIR       where daemon logs are copied (default $RUNNER_TEMP/mdm-logs)
+#   MDM_TEST_ISOLATED_HOME set to 1 when $HOME is a scratch directory: passes
+#                          --bin/--env HOME so the launcher does not resolve the
+#                          real home. On Linux also export XDG_CONFIG_HOME to the
+#                          real ~/.config so the user manager sees the unit.
+set -euo pipefail
+
+SCENARIO="${1:-lifecycle}"
+BINARY_SOURCE="${BINARY_SOURCE:-local}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+LOG_OUT="${MDM_TEST_LOG_DIR:-${RUNNER_TEMP:-/tmp}/mdm-logs}"
+BIN="$HOME/.git-ai/bin/git-ai"
+DAEMON_DIR="$HOME/.git-ai/internal/daemon"
+LABEL="com.usegitai.bg"
+UNIT="git-ai-bg.service"
+
+case "$(uname -s)" in
+  Darwin) OS=macos ;;
+  Linux) OS=linux ;;
+  *) echo "unsupported OS: $(uname -s)" >&2; exit 1 ;;
+esac
+MDM_SCRIPT="$REPO_ROOT/mdm/$OS/install-login-start.sh"
+
+log() { printf '[mdm-test] %s\n' "$*"; }
+fail() { printf '[mdm-test] FAIL: %s\n' "$*" >&2; exit 1; }
+
+# --- helpers -----------------------------------------------------------------
+
+install_binary() {
+  case "$BINARY_SOURCE" in
+    local)
+      [ -x "${GIT_AI_LOCAL_BINARY:-}" ] || fail "GIT_AI_LOCAL_BINARY must point at a built git-ai"
+      GIT_AI_LOCAL_BINARY="$GIT_AI_LOCAL_BINARY" bash "$REPO_ROOT/install.sh"
+      ;;
+    release)
+      if [ -n "${GIT_AI_RELEASE_TAG:-}" ]; then
+        GIT_AI_RELEASE_TAG="$GIT_AI_RELEASE_TAG" bash "$REPO_ROOT/install.sh"
+      else
+        bash "$REPO_ROOT/install.sh"
+      fi
+      ;;
+    *) fail "BINARY_SOURCE must be local or release" ;;
+  esac
+  [ -x "$BIN" ] || fail "$BIN missing after install"
+  log "installed $("$BIN" --version | head -1)"
+}
+
+installed_version() {
+  "$BIN" --version | head -1 | awk '{print $1}' | sed 's/^v//'
+}
+
+daemon_pid() {
+  jq -r '.pid // empty' "$DAEMON_DIR/daemon.pid.json" 2>/dev/null || true
+}
+
+pid_alive() { [ -n "$1" ] && kill -0 "$1" 2>/dev/null; }
+
+STATUS_REPO="$(mktemp -d)"
+git -C "$STATUS_REPO" init -q
+
+daemon_up() {
+  local pid
+  pid="$(daemon_pid)"
+  pid_alive "$pid" && (cd "$STATUS_REPO" && "$BIN" bg status >/dev/null 2>&1)
+}
+
+# wait_for <seconds> <description> <command...>
+wait_for() {
+  local secs="$1" what="$2"; shift 2
+  local deadline=$((SECONDS + secs))
+  until "$@"; do
+    [ "$SECONDS" -lt "$deadline" ] || fail "timed out after ${secs}s waiting for $what"
+    sleep 1
+  done
+  log "$what"
+}
+
+pid_changed_from() { local now; now="$(daemon_pid)"; [ -n "$now" ] && [ "$now" != "$1" ]; }
+
+mdm_script_args() {
+  if [ "${MDM_TEST_ISOLATED_HOME:-0}" = "1" ]; then
+    printf '%s\n' --bin "$BIN" --env "HOME=$HOME"
+  fi
+}
+
+run_mdm_script() {
+  local extra=()
+  while IFS= read -r line; do extra+=("$line"); done < <(mdm_script_args)
+  sh "$MDM_SCRIPT" "$@" "${extra[@]+"${extra[@]}"}"
+}
+
+registered() {
+  case "$OS" in
+    macos) [ -f "$HOME/Library/LaunchAgents/$LABEL.plist" ] && launchctl print "gui/$(id -u)/$LABEL" >/dev/null 2>&1 ;;
+    linux) [ -f "${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user/$UNIT" ] && [ "$(systemctl --user is-enabled "$UNIT" 2>/dev/null)" = "enabled" ] ;;
+  esac
+}
+
+# Re-fires the login trigger while the daemon is up; must be a no-op.
+trigger_login() {
+  case "$OS" in
+    macos) launchctl kickstart "gui/$(id -u)/$LABEL" ;;
+    # `start` is a no-op while the oneshot is active, so also run the launcher
+    # directly to prove idempotency.
+    linux) systemctl --user start "$UNIT"; "$BIN" bg start ;;
+  esac
+}
+
+mechanism_sane() {
+  case "$OS" in
+    macos)
+      local out
+      out="$(launchctl print "gui/$(id -u)/$LABEL")" || fail "launchd job missing"
+      if grep -E "last exit code = [1-9]" <<<"$out"; then fail "launchd job exited non-zero"; fi
+      grep -q "state = not running" <<<"$out" || fail "launchd job still running: launcher did not exit"
+      ;;
+    linux)
+      [ "$(systemctl --user is-active "$UNIT")" = "active" ] || fail "unit not active"
+      ! systemctl --user is-failed --quiet "$UNIT" || fail "unit failed"
+      # Self-restarted daemons must stay in the unit's cgroup so logout stops them.
+      grep -q "$UNIT" "/proc/$(daemon_pid)/cgroup" || fail "daemon $(daemon_pid) escaped the unit cgroup"
+      ;;
+  esac
+  log "login mechanism healthy"
+}
+
+lint_definition() {
+  case "$OS" in
+    macos) plutil -lint "$HOME/Library/LaunchAgents/$LABEL.plist" ;;
+    linux)
+      if command -v systemd-analyze >/dev/null 2>&1; then
+        systemd-analyze --user verify "$UNIT" || log "WARN: systemd-analyze verify reported issues"
+      fi
+      ;;
+  esac
+}
+
+daemon_started_versions() {
+  grep -ho 'daemon started .*version="[^"]*"' "$DAEMON_DIR"/logs/*.log 2>/dev/null | sed 's/.*version="//; s/"$//' || true
+}
+
+cleanup() {
+  local rc=$?
+  set +e
+  mkdir -p "$LOG_OUT"
+  cp -R "$DAEMON_DIR/logs" "$LOG_OUT/daemon-logs" 2>/dev/null
+  case "$OS" in
+    macos) launchctl print "gui/$(id -u)/$LABEL" >"$LOG_OUT/launchctl-print.txt" 2>&1 ;;
+    linux) systemctl --user status "$UNIT" --no-pager >"$LOG_OUT/systemctl-status.txt" 2>&1 ;;
+  esac
+  run_mdm_script --uninstall >/dev/null 2>&1
+  [ -x "$BIN" ] && "$BIN" bg shutdown >/dev/null 2>&1
+  rm -rf "$STATUS_REPO"
+  exit "$rc"
+}
+trap cleanup EXIT
+
+# --- scenarios ---------------------------------------------------------------
+
+register_and_wait_for_daemon() {
+  run_mdm_script "$@"
+  registered || fail "login start not registered after install"
+  wait_for 30 "daemon up after login trigger" daemon_up
+}
+
+scenario_lifecycle() {
+  install_binary
+  # Keep the uptime restart deterministic: no network update checks.
+  "$BIN" config set disable_auto_updates true
+  "$BIN" bg shutdown >/dev/null 2>&1 || true
+
+  register_and_wait_for_daemon \
+    --env GIT_AI_DAEMON_UPDATE_CHECK_INTERVAL=5 \
+    --env GIT_AI_DAEMON_MAX_UPTIME_SECS=25
+  local pid1; pid1="$(daemon_pid)"
+
+  sleep 10
+  pid_alive "$pid1" || fail "daemon $pid1 died after the launcher exited (process group torn down?)"
+  daemon_up || fail "daemon not answering after launcher exit"
+  log "daemon survived launcher exit"
+
+  # Max uptime (25s) is past the survival check above but well inside this wait.
+  wait_for 60 "daemon restarted itself on schedule" pid_changed_from "$pid1"
+  local pid2; pid2="$(daemon_pid)"
+  wait_for 15 "restarted daemon healthy" daemon_up
+  mechanism_sane
+
+  trigger_login
+  sleep 3
+  daemon_up || fail "daemon unhealthy after re-trigger"
+  [ "$(daemon_pid)" = "$pid2" ] || fail "re-triggering login restarted the daemon (pid $pid2 -> $(daemon_pid))"
+  mechanism_sane
+  log "re-triggered login start was a no-op"
+
+  lint_definition
+
+  run_mdm_script --uninstall
+  ! registered || fail "login start still registered after --uninstall"
+  log "uninstall clean"
+}
+
+scenario_auto_update() {
+  [ "$BINARY_SOURCE" = "release" ] || fail "auto-update needs BINARY_SOURCE=release"
+  [ -n "${GIT_AI_RELEASE_TAG:-}" ] || fail "auto-update needs GIT_AI_RELEASE_TAG (an older release)"
+  [ -n "${LATEST_TAG:-}" ] || fail "auto-update needs LATEST_TAG"
+  local latest="${LATEST_TAG#v}"
+
+  install_binary
+  local before; before="$(installed_version)"
+  [ "$before" != "$latest" ] || fail "GIT_AI_RELEASE_TAG must be older than LATEST_TAG"
+  "$BIN" bg shutdown >/dev/null 2>&1 || true
+
+  register_and_wait_for_daemon --env GIT_AI_DAEMON_UPDATE_CHECK_INTERVAL=10
+  local pid1; pid1="$(daemon_pid)"
+
+  version_is_latest() { [ "$(installed_version)" = "$latest" ]; }
+  wait_for 240 "binary updated to $latest" version_is_latest
+  wait_for 120 "daemon restarted after update" pid_changed_from "$pid1"
+  wait_for 30 "updated daemon healthy" daemon_up
+  daemon_started_versions | grep -qx "$latest" || fail "no 'daemon started' log line for version $latest"
+  mechanism_sane
+
+  run_mdm_script --uninstall
+  ! registered || fail "login start still registered after --uninstall"
+  log "auto-update $before -> $latest completed under login start"
+}
+
+case "$SCENARIO" in
+  lifecycle) scenario_lifecycle ;;
+  auto-update) scenario_auto_update ;;
+  *) fail "unknown scenario: $SCENARIO" ;;
+esac
+log "PASS $SCENARIO on $OS"


### PR DESCRIPTION
Add scripts/mdm/test-login-start.{sh,ps1}, which install git-ai, register
the login start, simulate the login trigger, and assert the daemon comes up,
survives the launcher exiting, restarts itself on schedule while registered,
and stays healthy after a re-trigger. The lifecycle scenario runs per PR on
ubuntu, macOS, and Windows via .github/workflows/mdm-login-start.yml with a
locally built binary; the auto-update scenario is wired up for the nightly
workflow.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>