### PR TITLE
release: publish MDM login-start scripts as release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -768,10 +768,17 @@ jobs:
           ' repo/install.ps1 > release/install.ps1
           echo "Generated version-pinned install.ps1 for $VERSION from $REPO"
 
+      - name: Copy MDM login-start scripts
+        run: |
+          cp repo/mdm/macos/install-login-start.sh release/git-ai-login-start-macos.sh
+          cp repo/mdm/linux/install-login-start.sh release/git-ai-login-start-linux.sh
+          cp repo/mdm/windows/install-login-start.ps1 release/git-ai-login-start-windows.ps1
+          chmod +x release/git-ai-login-start-*.sh
+
       - name: Add install scripts to SHA256SUMS
         run: |
           cd release
-          sha256sum install.sh install.ps1 >> SHA256SUMS
+          sha256sum install.sh install.ps1 git-ai-login-start-* >> SHA256SUMS
 
       - name: Generate attestations for release artifacts
         uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
@@ -827,6 +834,12 @@ jobs:
             - **macOS PKG (Intel)**: `git-ai-macos-x64.pkg`
             - **macOS PKG (Apple Silicon)**: `git-ai-macos-arm64.pkg`
             - **macOS PKG (Universal)**: `git-ai-macos-universal.pkg`
+
+            ### MDM login-start scripts
+            Register `git-ai bg start` to run at login (see `mdm/README.md`):
+            - **macOS LaunchAgent**: `git-ai-login-start-macos.sh`
+            - **Linux systemd user unit**: `git-ai-login-start-linux.sh`
+            - **Windows Scheduled Task**: `git-ai-login-start-windows.ps1`
 
             ### SHA256 Checksums
             ```

--- a/tests/mdm_scripts.rs
+++ b/tests/mdm_scripts.rs
@@ -11,11 +11,13 @@
 use std::fs;
 use std::path::PathBuf;
 
-fn mdm_file(relative: &str) -> String {
-    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("mdm")
-        .join(relative);
+fn repo_file(relative: &str) -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(relative);
     fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
+fn mdm_file(relative: &str) -> String {
+    repo_file(&format!("mdm/{relative}"))
 }
 
 fn macos_script() -> String {
@@ -157,4 +159,29 @@ fn readme_documents_the_launch_invariants() {
             "mdm/README.md must explain {keyword}"
         );
     }
+}
+
+#[test]
+fn release_workflow_publishes_the_scripts_as_assets() {
+    let release = repo_file(".github/workflows/release.yml");
+    let readme = mdm_file("README.md");
+
+    for asset in [
+        "git-ai-login-start-macos.sh",
+        "git-ai-login-start-linux.sh",
+        "git-ai-login-start-windows.ps1",
+    ] {
+        assert!(
+            release.contains(asset),
+            "release.yml must copy {asset} into the release assets"
+        );
+        assert!(
+            readme.contains(asset),
+            "mdm/README.md must document the {asset} download"
+        );
+    }
+    assert!(
+        release.contains("sha256sum install.sh install.ps1 git-ai-login-start-*"),
+        "login-start assets must be covered by SHA256SUMS"
+    );
 }


### PR DESCRIPTION
Copy mdm/*/install-login-start.* into the release as
git-ai-login-start-{macos,linux,windows}.{sh,ps1}, cover them in SHA256SUMS
(the existing release/git-ai-* globs already attest and upload them), and
list them in the release notes so MDM docs can point at
releases/latest/download/.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>