### PR TITLE
feat(metrics): record commit_source on the Committed metric

### DIFF
--- a/src/authorship/post_commit.rs
+++ b/src/authorship/post_commit.rs
@@ -93,7 +93,7 @@ pub(crate) fn post_commit_from_working_log_with_recovery_timestamps(
     base_commit: Option<String>,
     commit_sha: String,
     human_author: String,
-    supress_output: bool,
+    options: PostCommitOptions,
     recovery_file_timestamps: Option<&FileTimestampsByPath>,
     before_external_recovery: Option<&dyn Fn(&UnknownLinesByFile)>,
 ) -> Result<(String, AuthorshipLog), GitAiError> {
@@ -102,11 +102,7 @@ pub(crate) fn post_commit_from_working_log_with_recovery_timestamps(
         base_commit,
         commit_sha,
         human_author,
-        PostCommitOptions {
-            supress_output,
-            compute_stats: true,
-            recover_attribution: true,
-        },
+        options,
         PostCommitContext {
             precomputed_parent_diff: None,
             recovery_file_timestamps,
@@ -116,11 +112,30 @@ pub(crate) fn post_commit_from_working_log_with_recovery_timestamps(
     )
 }
 
+/// `commit_source` value for commits the daemon never saw through trace2 and
+/// attributed later from their reflog record.
+pub const UNTRACED_FIXUP_COMMIT_SOURCE: &str = "untraced_fixup";
+
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct PostCommitOptions {
     pub supress_output: bool,
     pub compute_stats: bool,
     pub recover_attribution: bool,
+    /// Recorded on the `Committed` metric as `commit_source`; `None` (null) for
+    /// commits attributed on the normal traced path.
+    pub commit_source: Option<&'static str>,
+}
+
+impl PostCommitOptions {
+    /// The daemon's post-commit pass: quiet, with stats and attribution recovery.
+    pub(crate) fn with_recovery(commit_source: Option<&'static str>) -> Self {
+        Self {
+            supress_output: true,
+            compute_stats: true,
+            recover_attribution: true,
+            commit_source,
+        }
+    }
 }
 
 pub(crate) struct PostCommitDetailedResult {
@@ -156,6 +171,7 @@ where
             supress_output,
             compute_stats: true,
             recover_attribution: true,
+            commit_source: None,
         },
         transform,
     )
@@ -495,6 +511,7 @@ where
                 &computed,
                 &parent_working_log,
                 hunks_json.as_deref(),
+                options.commit_source,
             );
             stats = Some(computed);
         }
@@ -1127,6 +1144,7 @@ fn record_commit_metrics(
     stats: &crate::authorship::stats::CommitStats,
     checkpoints: &[Checkpoint],
     hunks_json: Option<&str>,
+    commit_source: Option<&str>,
 ) {
     use crate::metrics::{CommittedValues, record};
 
@@ -1177,6 +1195,10 @@ fn record_commit_metrics(
         values.hunks(hunks)
     } else {
         values.hunks_null()
+    };
+    let values = match commit_source {
+        Some(source) => values.commit_source(source),
+        None => values.commit_source_null(),
     };
 
     let attrs = commit_metric_attrs(repo, commit_sha, parent_sha, human_author);

--- a/src/authorship/rewrite.rs
+++ b/src/authorship/rewrite.rs
@@ -675,6 +675,7 @@ fn post_squash_resolution_working_log(
                 supress_output: true,
                 compute_stats: false,
                 recover_attribution: false,
+                commit_source: None,
             },
             move |resolution_log| {
                 Ok(

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -990,6 +990,7 @@ fn post_conflict_resolution_working_log(
             supress_output: true,
             compute_stats: false,
             recover_attribution: false,
+            commit_source: None,
         },
         precomputed_parent_diff,
         move |resolution_log| {
@@ -7110,7 +7111,7 @@ impl ActorDaemonCoordinator {
                                     base_opt.clone(),
                                     new_head.clone(),
                                     author,
-                                    true,
+                                    crate::authorship::post_commit::PostCommitOptions::with_recovery(None),
                                     recovery_file_timestamps.as_ref(),
                                     Some(&recovery_preflight),
                                 )

--- a/src/metrics/events.rs
+++ b/src/metrics/events.rs
@@ -32,6 +32,7 @@ pub mod committed_pos {
     pub const AUTHOR_TS: usize = 15; // u64 (git author timestamp, %at)
     pub const COMMIT_TS: usize = 16; // u64 (git committer timestamp, %ct)
     pub const PATCH_ID: usize = 17; // String (git patch-id --stable)
+    pub const COMMIT_SOURCE: usize = 18; // String (nullable; how the commit reached attribution)
 }
 
 /// Values for Event ID 1: committed
@@ -63,6 +64,7 @@ pub mod committed_pos {
 /// | 15 | author_ts | u64 |
 /// | 16 | commit_ts | u64 |
 /// | 17 | patch_id | String |
+/// | 18 | commit_source | String (nullable; e.g. `untraced_fixup`, null for traced commits) |
 #[derive(Debug, Clone, Default)]
 pub struct CommittedValues {
     // Scalar fields
@@ -84,6 +86,7 @@ pub struct CommittedValues {
     pub author_ts: PosField<u64>,
     pub commit_ts: PosField<u64>,
     pub patch_id: PosField<String>,
+    pub commit_source: PosField<String>,
 }
 
 impl CommittedValues {
@@ -242,6 +245,16 @@ impl CommittedValues {
         self.patch_id = Some(None);
         self
     }
+
+    pub fn commit_source(mut self, value: impl Into<String>) -> Self {
+        self.commit_source = Some(Some(value.into()));
+        self
+    }
+
+    pub fn commit_source_null(mut self) -> Self {
+        self.commit_source = Some(None);
+        self
+    }
 }
 
 impl PosEncoded for CommittedValues {
@@ -319,6 +332,11 @@ impl PosEncoded for CommittedValues {
             committed_pos::PATCH_ID,
             string_to_json(&self.patch_id),
         );
+        sparse_set(
+            &mut map,
+            committed_pos::COMMIT_SOURCE,
+            string_to_json(&self.commit_source),
+        );
 
         map
     }
@@ -344,6 +362,7 @@ impl PosEncoded for CommittedValues {
             author_ts: sparse_get_u64(arr, committed_pos::AUTHOR_TS),
             commit_ts: sparse_get_u64(arr, committed_pos::COMMIT_TS),
             patch_id: sparse_get_string(arr, committed_pos::PATCH_ID),
+            commit_source: sparse_get_string(arr, committed_pos::COMMIT_SOURCE),
         }
     }
 }
@@ -1377,10 +1396,19 @@ mod tests {
             .commit_body_null()
             .author_ts(1700000100)
             .commit_ts(1700000200)
-            .patch_id("stable-patch-id");
+            .patch_id("stable-patch-id")
+            .commit_source("untraced_fixup");
 
         let sparse = PosEncoded::to_sparse(&original);
+        assert_eq!(
+            sparse.get("18"),
+            Some(&Value::String("untraced_fixup".to_string()))
+        );
         let restored = <CommittedValues as PosEncoded>::from_sparse(&sparse);
+        assert_eq!(
+            restored.commit_source,
+            Some(Some("untraced_fixup".to_string()))
+        );
 
         assert_eq!(restored.human_additions, Some(Some(25)));
         assert_eq!(restored.first_checkpoint_ts, Some(Some(1700000000)));
@@ -1392,6 +1420,19 @@ mod tests {
         assert_eq!(restored.author_ts, Some(Some(1700000100)));
         assert_eq!(restored.commit_ts, Some(Some(1700000200)));
         assert_eq!(restored.patch_id, Some(Some("stable-patch-id".to_string())));
+    }
+
+    #[test]
+    fn test_committed_values_commit_source_null_for_traced_commits() {
+        use super::PosEncoded;
+
+        let unset = PosEncoded::to_sparse(&CommittedValues::new());
+        assert_eq!(unset.get("18"), None);
+
+        let traced = PosEncoded::to_sparse(&CommittedValues::new().commit_source_null());
+        assert_eq!(traced.get("18"), Some(&Value::Null));
+        let restored = <CommittedValues as PosEncoded>::from_sparse(&traced);
+        assert_eq!(restored.commit_source, Some(None));
     }
 
     #[test]

--- a/tests/integration/commit_metric_metadata.rs
+++ b/tests/integration/commit_metric_metadata.rs
@@ -135,6 +135,11 @@ fn committed_metric_includes_git_author_commit_timestamps_and_patch_id() {
     );
     let patch_id = sparse_str(&event.values, committed_pos::PATCH_ID).expect("patch id");
     assert!(looks_like_patch_id(patch_id), "patch_id={patch_id}");
+    assert_eq!(
+        event.values.get(&committed_pos::COMMIT_SOURCE.to_string()),
+        Some(&serde_json::Value::Null),
+        "traced commits record a null commit_source"
+    );
 
     let mut file = repo.filename("generated.txt");
     file.assert_committed_lines(lines!["base".unattributed_human(), "ai line".ai()]);


### PR DESCRIPTION
## Summary

Adds nullable position 18 `commit_source` to the `Committed` metric so analytics can tell commits attributed on the traced path (null) from commits attributed later by the untraced-commit fixup (`untraced_fixup`, emitted by the next PR). Mirrors `CheckpointValues::checkpoint_type`.

`PostCommitOptions` carries the value into `record_commit_metrics`; the daemon's recovery-timestamps entry point now takes the options struct instead of two loose flags (`PostCommitOptions::with_recovery(commit_source)`).

## Test plan

- [x] sparse encode/decode round-trip for position 18; unset vs explicit null
- [x] `commit_metric_metadata` integration test asserts traced commits record a null `commit_source`
- [x] `task lint`, `task fmt`
