### PR TITLE
feat(daemon): untraced commit fixup pass and fixup.scan control request

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2,13 +2,14 @@ use crate::authorship::authorship_log_serialization::AuthorshipLog;
 use crate::checkpoint_content_budget::CheckpointContentBudget;
 use crate::config;
 use crate::daemon::git_backend::GitBackend;
+use crate::daemon::ref_cursor::{UntracedClaimRequest, UntracedReflogCursor, is_untraced_root_sid};
 use crate::error::GitAiError;
 use crate::git::cli_parser::{
     ParsedGitInvocation, explicit_rebase_branch_arg, parse_git_cli_args, summarize_rebase_args,
 };
 use crate::git::find_repository_in_path;
 use crate::git::repo_state::{
-    common_dir_for_worktree, git_dir_for_worktree, worktree_root_for_path,
+    common_dir_for_worktree, git_dir_for_worktree, worktree_root_for_path, worktrees_for_common_dir,
 };
 use crate::git::repository::{
     Repository, discover_repository_in_path_no_git_exec, exec_git, exec_git_stdin,
@@ -2720,6 +2721,27 @@ enum FamilySequencerEntry {
         receipt_seq: u64,
         reservation: CheckpointIngressReservation,
     },
+    /// One untraced-commit fixup pass over a worktree `HEAD` reflog (see
+    /// `RefCursor::claim_untraced_commits`). Sequenced like a command so it is
+    /// fenced behind older open roots and serialized with the family's other
+    /// passes; it never runs while a traced command of the family is in flight.
+    UntracedCommitScan {
+        git_dir: PathBuf,
+        worktree: PathBuf,
+        /// Persisted cursor for a worktree this daemon has not seen yet.
+        seed: Option<UntracedReflogCursor>,
+        /// `HEAD` reflog length when the pass was scheduled. The causal fence
+        /// only holds a pass for roots that started before it, so records
+        /// written after this point are left for a later pass.
+        max_offset: Option<u64>,
+    },
+}
+
+/// Worktrees whose fixup pass a `fixup.scan` request scheduled.
+#[derive(Debug, Clone, Serialize)]
+struct UntracedScanSchedule {
+    families: usize,
+    worktrees: usize,
 }
 
 /// Position of an entry in its family sequencer: the moment its originating
@@ -2991,6 +3013,11 @@ pub struct ActorDaemonCoordinator {
     causal_grace_expirations: AtomicU64,
     /// Fences released at a time bound (hard cap, written-root cap).
     causal_fence_hard_cap_releases: AtomicU64,
+    /// Untraced-commit fixup outcomes (see `run_untraced_commit_scan`).
+    untraced_commits_fixed: AtomicU64,
+    untraced_commits_skipped: AtomicU64,
+    untraced_cursor_reseeds: AtomicU64,
+    untraced_scan_errors: AtomicU64,
     /// Fired when a root clears or is released: fenced drains and waits
     /// re-evaluate. Distinct from the per-frame ingest progress notify so a
     /// fenced family does not wake on every trace frame the daemon sees.
@@ -3131,6 +3158,10 @@ impl ActorDaemonCoordinator {
             causal_grace: family_causal_grace(),
             causal_grace_expirations: AtomicU64::new(0),
             causal_fence_hard_cap_releases: AtomicU64::new(0),
+            untraced_commits_fixed: AtomicU64::new(0),
+            untraced_commits_skipped: AtomicU64::new(0),
+            untraced_cursor_reseeds: AtomicU64::new(0),
+            untraced_scan_errors: AtomicU64::new(0),
             trace_root_fence_notify: Notify::new(),
             commit_file_timestamp_snapshots_by_root: Mutex::new(HashMap::new()),
             recent_replay_prerequisites_by_family: Mutex::new(HashMap::new()),
@@ -3935,6 +3966,7 @@ impl ActorDaemonCoordinator {
                 "applied_side_effects",
             ),
             FamilySequencerEntry::Checkpoint { .. } => (None, "checkpoint"),
+            FamilySequencerEntry::UntracedCommitScan { .. } => (None, "untraced_scan"),
         }
     }
 
@@ -4282,17 +4314,26 @@ impl ActorDaemonCoordinator {
         result: &Result<(), GitAiError>,
         error_order: u64,
     ) -> Result<(), GitAiError> {
-        let sync_tracked = crate::daemon::test_sync::tracks_primary_command_for_test_sync(
-            applied.command.primary_command.as_deref(),
-            &applied.command.invoked_args,
-        );
+        // A fixup-synthesized commit is not a command a test issued, so it must
+        // never satisfy a test's wait for its own traced commands.
+        let untraced = is_untraced_root_sid(&applied.command.root_sid);
+        let sync_tracked = !untraced
+            && crate::daemon::test_sync::tracks_primary_command_for_test_sync(
+                applied.command.primary_command.as_deref(),
+                &applied.command.invoked_args,
+            );
         let test_sync_session = crate::daemon::test_sync::test_sync_session_from_invocation(
             &parsed_invocation_for_normalized_command(&applied.command),
         );
         let log_entry = TestCompletionLogEntry {
             seq: applied.seq,
             family_key: family.to_string(),
-            kind: "command".to_string(),
+            kind: if untraced {
+                "untraced_fixup"
+            } else {
+                "command"
+            }
+            .to_string(),
             primary_command: applied.command.primary_command.clone(),
             test_sync_session,
             exit_code: Some(applied.command.exit_code),
@@ -5363,6 +5404,223 @@ impl ActorDaemonCoordinator {
         read_only_root
     }
 
+    /// Claims the commits no traced command owns from one worktree `HEAD`
+    /// reflog and runs the normal post-commit side effects for each, exactly
+    /// as for a traced `git commit`. Returns the cursor to persist.
+    ///
+    /// A pass stops at `UNTRACED_FIXUP_MAX_COMMITS_PER_PASS` commits (or a
+    /// reflog byte budget) so the family's exec lock is released between
+    /// passes; when it does, a follow-up pass is queued at once rather than
+    /// waiting for the next tick. Once records are claimed nothing here is
+    /// allowed to abandon them: every later failure is logged per commit.
+    ///
+    /// Returns the cursor to persist, or `None` when a side effect failed: the
+    /// in-memory cursor has moved on (the traced path does not retry side
+    /// effects either), but leaving the durable cursor behind lets the next
+    /// daemon lifetime retry the commit, skipping any that did get their note.
+    async fn run_untraced_commit_scan(
+        &self,
+        family: &str,
+        git_dir: PathBuf,
+        worktree: PathBuf,
+        seed: Option<UntracedReflogCursor>,
+        max_offset: Option<u64>,
+        order: u64,
+    ) -> Result<Option<UntracedReflogCursor>, GitAiError> {
+        let request = UntracedClaimRequest {
+            git_dir: git_dir.clone(),
+            worktree: worktree.clone(),
+            seed,
+            // Reflog timestamps are whole seconds: round the age up so a
+            // sub-second override never becomes "no minimum age".
+            min_age_secs: untraced_fixup_min_age().as_millis().div_ceil(1000) as i64,
+            now_secs: crate::utils::unix_timestamp_now() as i64,
+            max_commits: UNTRACED_FIXUP_MAX_COMMITS_PER_PASS,
+            max_offset,
+        };
+        let outcome = self
+            .coordinator
+            .claim_untraced_commits(crate::daemon::domain::FamilyKey::new(family), request)
+            .await?;
+        self.untraced_commits_skipped
+            .fetch_add(outcome.skipped as u64, Ordering::Relaxed);
+        if outcome.reseeded {
+            self.untraced_cursor_reseeds.fetch_add(1, Ordering::Relaxed);
+        }
+
+        // A pass that died between writing a note and recording its cursor
+        // would claim the same commit twice; the note is the durable receipt.
+        let new_heads = outcome
+            .applied
+            .iter()
+            .filter_map(commit_created_new_head)
+            .map(str::to_string)
+            .collect::<Vec<_>>();
+        let already_noted = if new_heads.is_empty() {
+            HashSet::new()
+        } else {
+            let worktree = worktree.clone();
+            run_blocking_side_effect(move || {
+                let repo = find_repository_in_path(&worktree.to_string_lossy())?;
+                crate::git::notes_api::commits_with_notes(&repo, &new_heads)
+            })
+            .unwrap_or_else(|error| {
+                // Best-effort guard against a pass that died mid-way; the
+                // claimed commits must still be attributed.
+                tracing::warn!(%error, %family, "could not check existing notes before fixup");
+                HashSet::new()
+            })
+        };
+
+        // A record whose command could not be reduced was consumed without any
+        // side effect: that pass is not settled either.
+        let mut all_side_effects_succeeded = outcome.dropped == 0;
+        if outcome.dropped > 0 {
+            self.untraced_scan_errors
+                .fetch_add(outcome.dropped as u64, Ordering::Relaxed);
+        }
+        for applied in &outcome.applied {
+            if commit_created_new_head(applied).is_some_and(|head| already_noted.contains(head)) {
+                self.untraced_commits_skipped
+                    .fetch_add(1, Ordering::Relaxed);
+                continue;
+            }
+            let mut snapshots = CommitFileTimestampSnapshotHandles::default();
+            let future = self.maybe_apply_side_effects_for_applied_command(
+                Some(family),
+                applied,
+                &mut snapshots,
+            );
+            let result = match futures::FutureExt::catch_unwind(std::panic::AssertUnwindSafe(
+                future,
+            ))
+            .await
+            {
+                Ok(result) => result,
+                Err(panic_payload) => Err(GitAiError::Generic(format!(
+                    "daemon command side effect panic: {}",
+                    panic_payload_message(panic_payload.as_ref())
+                ))),
+            };
+            match &result {
+                Ok(()) => {
+                    self.untraced_commits_fixed.fetch_add(1, Ordering::Relaxed);
+                }
+                Err(error) => {
+                    all_side_effects_succeeded = false;
+                    self.untraced_scan_errors.fetch_add(1, Ordering::Relaxed);
+                    let _ = self.record_side_effect_error(family, order, error);
+                    tracing::error!(
+                        %error,
+                        %family,
+                        seq = applied.seq,
+                        "untraced commit side effect failed"
+                    );
+                }
+            }
+            if let Err(error) = self.append_command_completion_log(family, applied, &result, order)
+            {
+                tracing::error!(%error, %family, order, "command completion log write failed");
+            }
+        }
+        if outcome.more {
+            let max_offset = head_reflog_len(&git_dir);
+            self.append_family_sequencer_entry(
+                family,
+                now_unix_nanos(),
+                FamilySequencerEntry::UntracedCommitScan {
+                    git_dir,
+                    worktree,
+                    seed: None,
+                    max_offset,
+                },
+            )?;
+        }
+        Ok(all_side_effects_succeeded.then_some(outcome.cursor))
+    }
+
+    /// Schedules one fixup pass per worktree of the given repository (or of
+    /// every family this daemon knows) and returns how many were scheduled.
+    async fn schedule_untraced_commit_scans(
+        self: &Arc<Self>,
+        repo_working_dir: Option<String>,
+    ) -> Result<UntracedScanSchedule, GitAiError> {
+        let mut targets = Vec::new();
+        match repo_working_dir {
+            Some(dir) => {
+                // The whole family: every worktree of the repository, with the
+                // named one included even when enumeration cannot see it.
+                let family = self.backend.resolve_family(Path::new(&dir))?;
+                let worktree = worktree_root_for_path(Path::new(&dir)).ok_or_else(|| {
+                    GitAiError::Generic(format!("{dir} is not inside a git worktree"))
+                })?;
+                let git_dir = git_dir_for_worktree(&worktree)
+                    .ok_or_else(|| GitAiError::Generic(format!("{dir} has no git directory")))?;
+                for (git_dir, worktree) in worktrees_for_common_dir(Path::new(&family.0)) {
+                    targets.push((family.0.clone(), git_dir, worktree));
+                }
+                if !targets.iter().any(|(_, known, _)| *known == git_dir) {
+                    targets.push((family.0, git_dir, worktree));
+                }
+            }
+            None => {
+                for family in self.coordinator.family_keys().await {
+                    for (git_dir, worktree) in worktrees_for_common_dir(Path::new(&family)) {
+                        targets.push((family.clone(), git_dir, worktree));
+                    }
+                }
+            }
+        }
+        let mut families = HashSet::new();
+        let mut worktrees = 0;
+        for (family, git_dir, worktree) in targets {
+            if self.family_has_pending_untraced_scan(&family, &git_dir)? {
+                continue;
+            }
+            let max_offset = head_reflog_len(&git_dir);
+            self.append_family_sequencer_entry(
+                &family,
+                now_unix_nanos(),
+                FamilySequencerEntry::UntracedCommitScan {
+                    git_dir,
+                    worktree,
+                    seed: None,
+                    max_offset,
+                },
+            )?;
+            worktrees += 1;
+            if families.insert(family.clone()) {
+                self.schedule_family_drain(family);
+            }
+        }
+        Ok(UntracedScanSchedule {
+            families: families.len(),
+            worktrees,
+        })
+    }
+
+    /// Whether a fixup pass for this worktree is already queued (a pass held
+    /// behind an open root must not pile up duplicates every tick).
+    fn family_has_pending_untraced_scan(
+        &self,
+        family: &str,
+        git_dir: &Path,
+    ) -> Result<bool, GitAiError> {
+        let sequencers = self
+            .family_sequencers_by_family
+            .lock()
+            .map_err(|_| GitAiError::Generic("family sequencer map lock poisoned".to_string()))?;
+        Ok(sequencers.get(family).is_some_and(|state| {
+            state.entries.values().any(|slot| {
+                matches!(
+                    &slot.entry,
+                    FamilySequencerEntry::UntracedCommitScan { git_dir: pending, .. }
+                        if pending == git_dir
+                )
+            })
+        }))
+    }
+
     fn side_effect_exec_lock(&self, family: &str) -> Result<Arc<AsyncMutex<()>>, GitAiError> {
         let mut map = self
             .side_effect_exec_locks
@@ -5436,6 +5694,9 @@ impl ActorDaemonCoordinator {
                     ),
                     FamilySequencerEntry::Checkpoint { receipt_seq, .. } => {
                         format!("checkpoint:seq={receipt_seq}")
+                    }
+                    FamilySequencerEntry::UntracedCommitScan { worktree, .. } => {
+                        format!("untraced_scan:{}", worktree.display())
                     }
                 };
                 format!("order={order} entry={entry}")
@@ -5575,6 +5836,30 @@ impl ActorDaemonCoordinator {
                             order,
                             "command completion log write failed"
                         );
+                    }
+                }
+                FamilySequencerEntry::UntracedCommitScan {
+                    git_dir,
+                    worktree,
+                    seed,
+                    max_offset,
+                } => {
+                    let _side_effect_permit = self
+                        .command_side_effect_semaphore
+                        .acquire()
+                        .await
+                        .map_err(|_| {
+                            GitAiError::Generic("command side-effect semaphore closed".to_string())
+                        })?;
+                    if let Err(error) = self
+                        .run_untraced_commit_scan(
+                            family, git_dir, worktree, seed, max_offset, order,
+                        )
+                        .await
+                    {
+                        self.untraced_scan_errors.fetch_add(1, Ordering::Relaxed);
+                        let _ = self.record_side_effect_error(family, order, &error);
+                        tracing::error!(%error, %family, order, "untraced commit scan failed");
                     }
                 }
                 FamilySequencerEntry::Checkpoint {
@@ -7078,6 +7363,9 @@ impl ActorDaemonCoordinator {
                             let repo = find_repository_in_path(&worktree)?;
                             let author = repo.effective_author_identity().formatted_or_unknown();
                             let base_opt = base.clone().filter(|b| !b.is_empty() && b != "initial");
+                            let commit_source = is_untraced_root_sid(&cmd.root_sid).then_some(
+                                crate::authorship::post_commit::UNTRACED_FIXUP_COMMIT_SOURCE,
+                            );
                             crate::wltrace::wltrace(
                                 "commit.post_commit",
                                 Path::new(cmd.worktree.as_deref().unwrap_or(Path::new(""))),
@@ -7111,7 +7399,7 @@ impl ActorDaemonCoordinator {
                                     base_opt.clone(),
                                     new_head.clone(),
                                     author,
-                                    crate::authorship::post_commit::PostCommitOptions::with_recovery(None),
+                                    crate::authorship::post_commit::PostCommitOptions::with_recovery(commit_source),
                                     recovery_file_timestamps.as_ref(),
                                     Some(&recovery_preflight),
                                 )
@@ -7881,6 +8169,14 @@ impl ActorDaemonCoordinator {
             ControlRequest::StatsIngest => serde_json::to_value(IngestLossSnapshot::capture(self))
                 .map(|v| ControlResponse::ok(None, Some(v)))
                 .map_err(GitAiError::from),
+            ControlRequest::UntracedFixupScan { repo_working_dir } => self
+                .schedule_untraced_commit_scans(repo_working_dir)
+                .await
+                .and_then(|scheduled| {
+                    serde_json::to_value(scheduled)
+                        .map(|v| ControlResponse::ok(None, Some(v)))
+                        .map_err(GitAiError::from)
+                }),
             ControlRequest::Await { timeout_secs } => {
                 let result = self.await_completion(timeout_secs).await;
                 serde_json::to_value(result)
@@ -9290,6 +9586,46 @@ fn env_duration_ms(var: &str, default: Duration) -> Duration {
 
 fn family_causal_grace() -> Duration {
     env_duration_ms("GIT_AI_DAEMON_CAUSAL_GRACE_MS", FAMILY_CAUSAL_GRACE)
+}
+
+/// Reflog records younger than this are left for a later untraced-commit
+/// fixup pass: the trace2 frames of the command that wrote them may still be
+/// on their way to the daemon.
+const UNTRACED_FIXUP_MIN_AGE: Duration = Duration::from_secs(5);
+
+/// Commits one untraced-commit fixup pass attributes before yielding the
+/// family; the rest wait for the next pass.
+const UNTRACED_FIXUP_MAX_COMMITS_PER_PASS: usize = 10;
+
+fn untraced_fixup_min_age() -> Duration {
+    // Zero is meaningful here (tests claim records at once), unlike the
+    // positive-only overrides `env_duration_ms` accepts.
+    std::env::var("GIT_AI_DAEMON_UNTRACED_FIXUP_MIN_AGE_MS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .map(Duration::from_millis)
+        .unwrap_or(UNTRACED_FIXUP_MIN_AGE)
+}
+
+/// Current length of a worktree's `HEAD` reflog (`None` when it has none):
+/// the upper bound a fixup pass scheduled now may claim up to.
+fn head_reflog_len(git_dir: &Path) -> Option<u64> {
+    fs::metadata(git_dir.join("logs").join("HEAD"))
+        .ok()
+        .map(|metadata| metadata.len())
+}
+
+fn commit_created_new_head(applied: &crate::daemon::domain::AppliedCommand) -> Option<&str> {
+    applied
+        .analysis
+        .events
+        .iter()
+        .find_map(|event| match event {
+            crate::daemon::domain::SemanticEvent::CommitCreated { new_head, .. } => {
+                Some(new_head.as_str())
+            }
+            _ => None,
+        })
 }
 
 fn daemon_socket_health_check_interval() -> u64 {

--- a/src/daemon/control_api.rs
+++ b/src/daemon/control_api.rs
@@ -33,6 +33,10 @@ pub enum ControlRequest {
     /// Report ingest loss counters (dropped trace payloads/connections).
     #[serde(rename = "stats.ingest")]
     StatsIngest,
+    /// Run one untraced-commit fixup pass now for the repository's family, or
+    /// for every family the daemon knows when no repository is given.
+    #[serde(rename = "fixup.scan")]
+    UntracedFixupScan { repo_working_dir: Option<String> },
     /// Snapshot of the daemon's attribution pipeline: per-family pending work
     /// and fence state, open trace roots, and loss counters.
     #[serde(rename = "status.daemon")]

--- a/src/daemon/health.rs
+++ b/src/daemon/health.rs
@@ -38,6 +38,7 @@ pub(crate) struct FamilyHealth {
     pub entries_commands: usize,
     pub entries_applied: usize,
     pub entries_checkpoints: usize,
+    pub entries_untraced_scans: usize,
     /// Age of the entry that has been ready the longest.
     pub oldest_entry_age_ms: u64,
     pub front_kind: Option<&'static str>,
@@ -101,6 +102,15 @@ pub(crate) struct DaemonHealthSnapshot {
     pub side_effect_errors_total: usize,
     pub causal_grace_expirations: u64,
     pub causal_fence_hard_cap_releases: u64,
+    pub sequencer_entries_untraced_scans: usize,
+    /// Commits the untraced-commit fixup attributed (no trace2 ever saw them).
+    pub untraced_commits_fixed: u64,
+    /// Reflog records the fixup settled without a claim (rewrites, replays,
+    /// detached commits, already-noted commits).
+    pub untraced_commits_skipped: u64,
+    /// Fixup cursors that no longer matched their reflog and restarted at its end.
+    pub untraced_cursor_reseeds: u64,
+    pub untraced_scan_errors: u64,
     #[serde(flatten)]
     pub losses: IngestLossSnapshot,
     pub families: Vec<FamilyHealth>,
@@ -137,6 +147,9 @@ impl DaemonHealthSnapshot {
                             FamilySequencerEntry::ReadyCommand(_) => health.entries_commands += 1,
                             FamilySequencerEntry::AppliedSideEffects { .. } => {
                                 health.entries_applied += 1
+                            }
+                            FamilySequencerEntry::UntracedCommitScan { .. } => {
+                                health.entries_untraced_scans += 1
                             }
                             FamilySequencerEntry::Checkpoint { .. } => {
                                 health.entries_checkpoints += 1
@@ -325,6 +338,11 @@ impl DaemonHealthSnapshot {
             causal_fence_hard_cap_releases: coordinator
                 .causal_fence_hard_cap_releases
                 .load(Ordering::Relaxed),
+            sequencer_entries_untraced_scans: sum(|f| f.entries_untraced_scans),
+            untraced_commits_fixed: coordinator.untraced_commits_fixed.load(Ordering::Relaxed),
+            untraced_commits_skipped: coordinator.untraced_commits_skipped.load(Ordering::Relaxed),
+            untraced_cursor_reseeds: coordinator.untraced_cursor_reseeds.load(Ordering::Relaxed),
+            untraced_scan_errors: coordinator.untraced_scan_errors.load(Ordering::Relaxed),
             losses: IngestLossSnapshot::capture(coordinator),
             families,
         }
@@ -497,6 +515,11 @@ mod tests {
             side_effect_errors_total: 0,
             causal_grace_expirations: 3,
             causal_fence_hard_cap_releases: 0,
+            sequencer_entries_untraced_scans: 0,
+            untraced_commits_fixed: 0,
+            untraced_commits_skipped: 0,
+            untraced_cursor_reseeds: 0,
+            untraced_scan_errors: 0,
             losses: IngestLossSnapshot::default(),
             families,
         }

--- a/src/git/repo_state.rs
+++ b/src/git/repo_state.rs
@@ -84,6 +84,58 @@ pub fn common_dir_for_repo_path(path: &Path) -> Option<PathBuf> {
     None
 }
 
+/// Every worktree of a repository as `(git_dir, worktree)` pairs, from the
+/// filesystem alone: the main worktree (a `.git` common dir's parent, or the
+/// `core.worktree` a submodule / `--separate-git-dir` repository points at)
+/// plus the linked worktrees registered under `<common_dir>/worktrees/`. Bare
+/// repositories and linked worktrees whose directory is gone are omitted.
+pub fn worktrees_for_common_dir(common_dir: &Path) -> Vec<(PathBuf, PathBuf)> {
+    let mut out = Vec::new();
+    if let Some(main) = main_worktree_for_common_dir(common_dir) {
+        out.push((common_dir.to_path_buf(), main));
+    }
+    let Ok(linked) = fs::read_dir(common_dir.join("worktrees")) else {
+        return out;
+    };
+    let mut linked = linked
+        .flatten()
+        .filter_map(|entry| {
+            let git_dir = entry.path();
+            let dot_git = fs::read_to_string(git_dir.join("gitdir")).ok()?;
+            // Since git 2.48 (`worktree.useRelativePaths`) the pointer may be
+            // relative to the linked git dir.
+            let dot_git = git_dir.join(dot_git.trim());
+            let worktree = dot_git.parent()?.to_path_buf();
+            worktree.is_dir().then_some((git_dir, worktree))
+        })
+        .collect::<Vec<_>>();
+    linked.sort();
+    out.extend(linked);
+    out
+}
+
+fn main_worktree_for_common_dir(common_dir: &Path) -> Option<PathBuf> {
+    // The ordinary layout needs no config read (the daemon asks about every
+    // known family on every tick).
+    if common_dir.file_name().is_some_and(|name| name == ".git") {
+        let main = common_dir.parent()?.to_path_buf();
+        return main.is_dir().then_some(main);
+    }
+    let config =
+        crate::git::repository::git_config_file_for_repo_paths(common_dir, common_dir).ok();
+    let config_value = |key: &str| {
+        config
+            .as_ref()
+            .and_then(|config| config.string(key))
+            .map(|value| value.to_string())
+    };
+    if config_value("core.bare").is_some_and(|bare| bare.eq_ignore_ascii_case("true")) {
+        return None;
+    }
+    let main = common_dir.join(config_value("core.worktree")?);
+    main.is_dir().then_some(main)
+}
+
 pub fn read_head_state_for_worktree(worktree: &Path) -> Option<HeadState> {
     use crate::git::fast_reader::{FastRefReader, HeadKind};
     let git_dir = git_dir_for_worktree(worktree)?;
@@ -150,5 +202,75 @@ mod tests {
         );
         assert_eq!(state.branch.as_deref(), Some("main"));
         assert!(!state.detached);
+    }
+
+    #[test]
+    fn worktrees_for_common_dir_lists_main_and_linked_worktrees() {
+        let temp = tempfile::tempdir().unwrap();
+        let main = temp.path().join("repo");
+        let common_dir = main.join(".git");
+        write_file(&common_dir.join("HEAD"), "ref: refs/heads/main\n");
+        let linked = temp.path().join("feature");
+        fs::create_dir_all(&linked).unwrap();
+        let linked_git_dir = common_dir.join("worktrees").join("feature");
+        write_file(
+            &linked_git_dir.join("gitdir"),
+            &format!("{}\n", linked.join(".git").display()),
+        );
+        // A registration whose worktree directory was deleted is skipped.
+        write_file(
+            &common_dir.join("worktrees").join("gone").join("gitdir"),
+            &format!("{}\n", temp.path().join("gone").join(".git").display()),
+        );
+
+        assert_eq!(
+            worktrees_for_common_dir(&common_dir),
+            vec![(common_dir.clone(), main), (linked_git_dir, linked)]
+        );
+    }
+
+    #[test]
+    fn worktrees_for_common_dir_skips_bare_repositories() {
+        let temp = tempfile::tempdir().unwrap();
+        let bare = temp.path().join("repo.git");
+        write_file(&bare.join("HEAD"), "ref: refs/heads/main\n");
+        write_file(&bare.join("config"), "[core]\n\tbare = true\n");
+
+        assert!(worktrees_for_common_dir(&bare).is_empty());
+    }
+
+    #[test]
+    fn worktrees_for_common_dir_follows_core_worktree_and_relative_pointers() {
+        // A submodule's git dir (`.git/modules/sub`) names its worktree through
+        // core.worktree; a linked worktree may register a relative gitdir.
+        let temp = tempfile::tempdir().unwrap();
+        let common_dir = temp.path().join("super/.git/modules/sub");
+        let sub = temp.path().join("super/sub");
+        fs::create_dir_all(&sub).unwrap();
+        write_file(&common_dir.join("HEAD"), "ref: refs/heads/main\n");
+        write_file(
+            &common_dir.join("config"),
+            "[core]\n\tbare = false\n\tworktree = ../../../sub\n",
+        );
+        let linked = temp.path().join("sub-feature");
+        fs::create_dir_all(&linked).unwrap();
+        let linked_git_dir = common_dir.join("worktrees").join("feature");
+        write_file(
+            &linked_git_dir.join("gitdir"),
+            "../../../../../../sub-feature/.git\n",
+        );
+
+        let worktrees = worktrees_for_common_dir(&common_dir);
+        assert_eq!(worktrees.len(), 2, "{worktrees:?}");
+        assert_eq!(worktrees[0].0, common_dir);
+        assert_eq!(
+            worktrees[0].1.canonicalize().unwrap(),
+            sub.canonicalize().unwrap()
+        );
+        assert_eq!(worktrees[1].0, linked_git_dir);
+        assert_eq!(
+            worktrees[1].1.canonicalize().unwrap(),
+            linked.canonicalize().unwrap()
+        );
     }
 }

--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -2264,7 +2264,12 @@ fn discover_repository_paths_no_git_exec(
     )))
 }
 
-fn git_config_file_for_repo_paths(
+/// The effective git config for a repository given its git dir and common
+/// dir (globals, `<common>/config`, `config.worktree`, environment), read
+/// without spawning git. Callers that already know the git dir (the daemon's
+/// family registry) use this instead of discovery from a path, which would
+/// climb out of a submodule's `.git/modules/<name>` into the superproject.
+pub(crate) fn git_config_file_for_repo_paths(
     git_dir: &Path,
     git_common_dir: &Path,
 ) -> Result<gix_config::File<'static>, GitAiError> {

--- a/tests/integration/commit_metric_metadata.rs
+++ b/tests/integration/commit_metric_metadata.rs
@@ -1,72 +1,10 @@
 use crate::repos::test_file::ExpectedLineExt;
 use crate::repos::test_repo::TestRepo;
-use crate::test_utils::isolated_metrics_db_path;
-use git_ai::metrics::MetricEvent;
-use git_ai::metrics::attrs::attr_pos;
-use git_ai::metrics::db::MetricsDatabase;
+use crate::test_utils::{
+    codex_checkpoint, committed_metric_for_commit, isolated_metrics_db_path, sparse_str, sparse_u64,
+};
 use git_ai::metrics::events::committed_pos;
-use git_ai::metrics::types::{MetricEventId, SparseArray};
-use serde_json::json;
 use std::fs;
-use std::path::Path;
-use std::time::{Duration, Instant};
-
-fn codex_checkpoint(
-    repo: &TestRepo,
-    file_path: &Path,
-    session_id: &str,
-    hook_event_name: &str,
-    tool_use_id: &str,
-) {
-    let hook_input = json!({
-        "session_id": session_id,
-        "cwd": repo.canonical_path().to_string_lossy().to_string(),
-        "hook_event_name": hook_event_name,
-        "tool_name": "apply_patch",
-        "tool_use_id": tool_use_id,
-        "model": "gpt-5",
-        "tool_input": {
-            "patch": format!("*** Update File: {}\n", file_path.to_string_lossy())
-        },
-    })
-    .to_string();
-
-    repo.git_ai(&["checkpoint", "codex", "--hook-input", &hook_input])
-        .expect("codex checkpoint should succeed");
-}
-
-fn sparse_str(values: &SparseArray, pos: usize) -> Option<&str> {
-    values
-        .get(&pos.to_string())
-        .and_then(|value| value.as_str())
-}
-
-fn sparse_u64(values: &SparseArray, pos: usize) -> Option<u64> {
-    values
-        .get(&pos.to_string())
-        .and_then(|value| value.as_u64())
-}
-
-fn committed_metric_for_commit(db_path: &str, commit_sha: &str) -> MetricEvent {
-    let deadline = Instant::now() + Duration::from_secs(5);
-    loop {
-        let db = MetricsDatabase::open_at_path(Path::new(db_path))
-            .expect("metrics db should open at isolated path");
-        let records = db
-            .get_metric_history(0, None, &[MetricEventId::Committed as u16])
-            .expect("metric history should load");
-        if let Some(record) = records.into_iter().find(|record| {
-            sparse_str(&record.event.attrs, attr_pos::COMMIT_SHA) == Some(commit_sha)
-        }) {
-            return record.event;
-        }
-
-        if Instant::now() >= deadline {
-            panic!("committed metric for {commit_sha} was not persisted");
-        }
-        std::thread::sleep(Duration::from_millis(50));
-    }
-}
 
 fn looks_like_patch_id(value: &str) -> bool {
     matches!(value.len(), 40 | 64) && value.chars().all(|c| c.is_ascii_hexdigit())

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -148,6 +148,7 @@ mod sweep_e2e;
 mod test_utils_unit;
 mod tls_native_certs;
 mod token_usage;
+mod untraced_commit_fixup;
 mod usage_period;
 mod utf8_filenames;
 mod virtual_attribution_unit;

--- a/tests/integration/repos/test_repo.rs
+++ b/tests/integration/repos/test_repo.rs
@@ -1764,6 +1764,50 @@ impl TestRepo {
         self.feature_flags = feature_flags;
     }
 
+    /// Runs one untraced-commit fixup pass for this repository's family and
+    /// waits for its side effects, like the daemon's periodic scan would.
+    pub(crate) fn request_untraced_fixup_scan(&self) -> serde_json::Value {
+        let response = send_control_request(
+            &self.daemon_control_socket_path(),
+            &ControlRequest::UntracedFixupScan {
+                repo_working_dir: Some(self.canonical_path().to_string_lossy().to_string()),
+            },
+        )
+        .expect("fixup.scan should reach the daemon");
+        assert!(response.ok, "fixup.scan failed: {:?}", response.error);
+        self.sync_daemon_force();
+        response.data.unwrap_or(serde_json::Value::Null)
+    }
+
+    /// Runs one untraced-commit fixup pass for the family of `repo_working_dir`
+    /// (another repository than this one) and waits for it.
+    pub(crate) fn request_untraced_fixup_scan_for(
+        &self,
+        repo_working_dir: &Path,
+    ) -> serde_json::Value {
+        let response = send_control_request(
+            &self.daemon_control_socket_path(),
+            &ControlRequest::UntracedFixupScan {
+                repo_working_dir: Some(repo_working_dir.to_string_lossy().to_string()),
+            },
+        )
+        .expect("fixup.scan should reach the daemon");
+        assert!(response.ok, "fixup.scan failed: {:?}", response.error);
+        self.sync_daemon_force();
+        response.data.unwrap_or(serde_json::Value::Null)
+    }
+
+    /// The daemon's health snapshot (`status.daemon`).
+    pub(crate) fn daemon_status(&self) -> serde_json::Value {
+        let response = send_control_request(
+            &self.daemon_control_socket_path(),
+            &ControlRequest::StatusDaemon,
+        )
+        .expect("status.daemon should reach the daemon");
+        assert!(response.ok, "status.daemon failed: {:?}", response.error);
+        response.data.unwrap_or(serde_json::Value::Null)
+    }
+
     pub(crate) fn daemon_control_socket_path(&self) -> PathBuf {
         self.daemon_process
             .as_ref()

--- a/tests/integration/test_utils.rs
+++ b/tests/integration/test_utils.rs
@@ -1,6 +1,13 @@
 #![allow(dead_code)]
 
-use std::path::PathBuf;
+use crate::repos::test_repo::TestRepo;
+use git_ai::metrics::MetricEvent;
+use git_ai::metrics::attrs::attr_pos;
+use git_ai::metrics::db::MetricsDatabase;
+use git_ai::metrics::types::{MetricEventId, SparseArray};
+use serde_json::json;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
 
 /// Get the path to a test fixture file
 ///
@@ -48,4 +55,68 @@ pub fn isolated_metrics_db_path() -> (tempfile::TempDir, String) {
     let dir = tempfile::tempdir().expect("failed to create isolated metrics db dir");
     let path = dir.path().join("metrics.db");
     (dir, path.to_string_lossy().to_string())
+}
+
+/// A codex pre/post edit hook checkpoint for `file_path` (the mock presets are
+/// excluded from commit metrics, so metric tests need a real preset).
+pub fn codex_checkpoint(
+    repo: &TestRepo,
+    file_path: &Path,
+    session_id: &str,
+    hook_event_name: &str,
+    tool_use_id: &str,
+) {
+    let hook_input = json!({
+        "session_id": session_id,
+        "cwd": repo.canonical_path().to_string_lossy().to_string(),
+        "hook_event_name": hook_event_name,
+        "tool_name": "apply_patch",
+        "tool_use_id": tool_use_id,
+        "model": "gpt-5",
+        "tool_input": {
+            "patch": format!("*** Update File: {}\n", file_path.to_string_lossy())
+        },
+    })
+    .to_string();
+
+    repo.git_ai(&["checkpoint", "codex", "--hook-input", &hook_input])
+        .expect("codex checkpoint should succeed");
+}
+
+pub fn sparse_str(values: &SparseArray, pos: usize) -> Option<&str> {
+    values
+        .get(&pos.to_string())
+        .and_then(|value| value.as_str())
+}
+
+pub fn sparse_u64(values: &SparseArray, pos: usize) -> Option<u64> {
+    values
+        .get(&pos.to_string())
+        .and_then(|value| value.as_u64())
+}
+
+/// Every persisted `Committed` metric for `commit_sha` right now.
+pub fn committed_metrics_for_commit(db_path: &str, commit_sha: &str) -> Vec<MetricEvent> {
+    let db = MetricsDatabase::open_at_path(Path::new(db_path))
+        .expect("metrics db should open at isolated path");
+    db.get_metric_history(0, None, &[MetricEventId::Committed as u16])
+        .expect("metric history should load")
+        .into_iter()
+        .filter(|record| sparse_str(&record.event.attrs, attr_pos::COMMIT_SHA) == Some(commit_sha))
+        .map(|record| record.event)
+        .collect()
+}
+
+/// Waits for the `Committed` metric of `commit_sha` to be persisted.
+pub fn committed_metric_for_commit(db_path: &str, commit_sha: &str) -> MetricEvent {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        if let Some(event) = committed_metrics_for_commit(db_path, commit_sha).pop() {
+            return event;
+        }
+        if Instant::now() >= deadline {
+            panic!("committed metric for {commit_sha} was not persisted");
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
 }

--- a/tests/integration/untraced_commit_fixup.rs
+++ b/tests/integration/untraced_commit_fixup.rs
@@ -1,0 +1,429 @@
+//! Best-effort attribution for commits the daemon never saw through trace2:
+//! made while it was off, by clients that emit no trace2 (JGit, libgit2), or
+//! from sandboxes that cannot reach its socket. The fixup pass claims such
+//! commits from the worktree HEAD reflog and runs the normal post-commit path.
+
+use crate::repos::test_file::ExpectedLineExt;
+use crate::repos::test_repo::{DaemonTestScope, TestRepo, real_git_executable};
+use crate::test_utils::{
+    codex_checkpoint, committed_metric_for_commit, committed_metrics_for_commit,
+    isolated_metrics_db_path,
+};
+use git_ai::metrics::events::committed_pos;
+use serde_json::Value;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const TRACE2_DISABLED_ENV: [(&str, &str); 3] = [
+    ("GIT_TRACE2", "0"),
+    ("GIT_TRACE2_EVENT", "0"),
+    ("GIT_TRACE2_PERF", "0"),
+];
+
+/// A repository with a dedicated daemon whose fixup pass claims records
+/// immediately (no minimum age) and persists metrics to an isolated db.
+fn fixup_repo() -> (tempfile::TempDir, String, TestRepo) {
+    let (metrics_dir, metrics_db_path) = isolated_metrics_db_path();
+    let repo = TestRepo::new_with_daemon_env(&[
+        ("GIT_AI_TEST_METRICS_DB_PATH", metrics_db_path.as_str()),
+        ("GIT_AI_DAEMON_UNTRACED_FIXUP_MIN_AGE_MS", "0"),
+    ]);
+    (metrics_dir, metrics_db_path, repo)
+}
+
+/// Git that the daemon never hears about: no trace2 at all.
+fn raw_git(repo: &TestRepo, args: &[&str]) -> String {
+    repo.git_og_with_env(args, &TRACE2_DISABLED_ENV)
+        .unwrap_or_else(|error| panic!("raw trace-disabled git {:?} failed: {}", args, error))
+}
+
+fn raw_head(repo: &TestRepo) -> String {
+    raw_git(repo, &["rev-parse", "HEAD"]).trim().to_string()
+}
+
+fn raw_commit_all(repo: &TestRepo, message: &str) -> String {
+    raw_git(repo, &["add", "-A"]);
+    raw_git(repo, &["commit", "-m", message]);
+    raw_head(repo)
+}
+
+fn write_file(repo: &TestRepo, path: &str, content: &str) {
+    fs::write(repo.path().join(path), content).unwrap();
+}
+
+/// Runs git in `path` with trace2 disabled; the daemon never hears about it.
+fn raw_git_in(path: &Path, args: &[&str]) -> String {
+    let mut command = std::process::Command::new(real_git_executable());
+    command.arg("-C").arg(path).args(args);
+    for (key, value) in TRACE2_DISABLED_ENV {
+        command.env(key, value);
+    }
+    let output = command.output().expect("raw trace-disabled git runs");
+    assert!(
+        output.status.success(),
+        "raw trace-disabled git {args:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+/// An empty repository next to `repo` (same temp dir) that the daemon has
+/// never heard of. `repo` itself does not qualify: the harness probes it the
+/// moment its daemon starts, and the startup tick may seed a fixup cursor in
+/// it while it is still empty.
+fn sibling_repo(repo: &TestRepo, suffix: &str) -> PathBuf {
+    let path = repo.path().parent().expect("temp parent").join(format!(
+        "{}-{suffix}",
+        repo.path().file_name().unwrap().to_string_lossy()
+    ));
+    fs::create_dir_all(&path).unwrap();
+    raw_git_in(&path, &["init", "-q", "."]);
+    raw_git_in(&path, &["config", "user.email", "a@b.c"]);
+    raw_git_in(&path, &["config", "user.name", "a"]);
+    path
+}
+
+fn raw_commit_all_in(path: &Path, message: &str) -> String {
+    raw_git_in(path, &["add", "-A"]);
+    raw_git_in(path, &["commit", "-qm", message]);
+    raw_git_in(path, &["rev-parse", "HEAD"])
+}
+
+/// Records one codex edit of `path` through the daemon and waits for it to be
+/// processed: the working log now carries AI attribution for the lines that
+/// changed.
+fn codex_edit(repo: &TestRepo, path: &str, content: &str, tool_use_id: &str) {
+    let file_path = repo.path().join(path);
+    codex_checkpoint(repo, &file_path, "fixup-session", "PreToolUse", tool_use_id);
+    fs::write(&file_path, content).unwrap();
+    codex_checkpoint(
+        repo,
+        &file_path,
+        "fixup-session",
+        "PostToolUse",
+        tool_use_id,
+    );
+    repo.sync_daemon();
+}
+
+fn commit_source(db_path: &str, commit_sha: &str) -> Option<&'static str> {
+    let event = committed_metric_for_commit(db_path, commit_sha);
+    match event.values.get(&committed_pos::COMMIT_SOURCE.to_string()) {
+        Some(Value::String(source)) if source == "untraced_fixup" => Some("untraced_fixup"),
+        Some(Value::Null) | None => None,
+        other => panic!("unexpected commit_source {other:?}"),
+    }
+}
+
+fn health_counter(repo: &TestRepo, field: &str) -> u64 {
+    repo.daemon_status()
+        .get(field)
+        .and_then(Value::as_u64)
+        .unwrap_or_else(|| panic!("status.daemon lacks {field}"))
+}
+
+fn working_log_dir(repo: &TestRepo, base_commit: &str) -> std::path::PathBuf {
+    repo.path()
+        .join(".git")
+        .join("ai")
+        .join("working_logs")
+        .join(base_commit)
+}
+
+#[test]
+fn untraced_commit_with_delivered_checkpoints_is_attributed_after_scan() {
+    let (_metrics_dir, metrics_db_path, repo) = fixup_repo();
+    write_file(&repo, "agent.txt", "base\n");
+    let base = repo
+        .stage_all_and_commit("traced base")
+        .expect("traced base commit")
+        .commit_sha;
+    repo.request_untraced_fixup_scan();
+
+    // The agent's hooks reached the daemon, but its commit (JGit, sandbox,
+    // daemon down) never did.
+    codex_edit(&repo, "agent.txt", "base\nai line\n", "tool-use-1");
+    assert!(working_log_dir(&repo, &base).is_dir());
+    let untraced = raw_commit_all(&repo, "agent commit");
+    assert!(repo.read_authorship_note(&untraced).is_none());
+
+    repo.request_untraced_fixup_scan();
+
+    let mut file = repo.filename("agent.txt");
+    file.assert_committed_lines(lines!["base".unattributed_human(), "ai line".ai()]);
+    assert!(
+        !working_log_dir(&repo, &base).is_dir(),
+        "the working log is consumed exactly like the traced path does"
+    );
+    assert_eq!(
+        commit_source(&metrics_db_path, &untraced),
+        Some("untraced_fixup")
+    );
+    assert_eq!(health_counter(&repo, "untraced_commits_fixed"), 1);
+
+    // A second pass is a no-op: one note, one metric row.
+    repo.request_untraced_fixup_scan();
+    assert_eq!(
+        committed_metrics_for_commit(&metrics_db_path, &untraced).len(),
+        1
+    );
+    assert_eq!(health_counter(&repo, "untraced_commits_fixed"), 1);
+}
+
+#[test]
+fn traced_commits_keep_a_null_commit_source_and_are_never_reclaimed() {
+    let (_metrics_dir, metrics_db_path, repo) = fixup_repo();
+    write_file(&repo, "agent.txt", "base\n");
+    repo.stage_all_and_commit("traced base")
+        .expect("traced base commit");
+    codex_edit(&repo, "agent.txt", "base\nai line\n", "tool-use-1");
+    let traced = repo
+        .stage_all_and_commit("traced agent commit")
+        .expect("traced agent commit")
+        .commit_sha;
+    assert_eq!(commit_source(&metrics_db_path, &traced), None);
+
+    repo.request_untraced_fixup_scan();
+    repo.request_untraced_fixup_scan();
+
+    let mut file = repo.filename("agent.txt");
+    file.assert_committed_lines(lines!["base".unattributed_human(), "ai line".ai()]);
+    assert_eq!(
+        committed_metrics_for_commit(&metrics_db_path, &traced).len(),
+        1
+    );
+    assert_eq!(health_counter(&repo, "untraced_commits_fixed"), 0);
+}
+
+#[test]
+fn untraced_commit_without_checkpoints_gets_a_note_from_recovery() {
+    let (_metrics_dir, metrics_db_path, repo) = fixup_repo();
+    write_file(&repo, "plain.txt", "base\n");
+    repo.stage_all_and_commit("traced base")
+        .expect("traced base commit");
+    repo.request_untraced_fixup_scan();
+
+    write_file(&repo, "plain.txt", "base\nhand written\n");
+    let untraced = raw_commit_all(&repo, "typed by hand");
+
+    repo.request_untraced_fixup_scan();
+
+    assert!(
+        repo.read_authorship_note(&untraced).is_some(),
+        "the normal post-commit path writes a note even without a working log"
+    );
+    let mut file = repo.filename("plain.txt");
+    file.assert_committed_lines(lines![
+        "base".unattributed_human(),
+        "hand written".unattributed_human()
+    ]);
+    assert_eq!(
+        commit_source(&metrics_db_path, &untraced),
+        Some("untraced_fixup")
+    );
+}
+
+#[test]
+fn first_sighting_of_a_repository_never_backfills_history() {
+    let (_metrics_dir, _metrics_db_path, repo) = fixup_repo();
+    // A repository the daemon has never heard of: its commits are history by
+    // the time the daemon first looks at it.
+    let history = sibling_repo(&repo, "history");
+    let history_git_dir = history.join(".git");
+    fs::write(
+        history.join("old.txt"),
+        "written before git-ai knew this repo\n",
+    )
+    .unwrap();
+    raw_commit_all_in(&history, "pre-existing untraced history");
+    fs::write(
+        history.join("old.txt"),
+        "written before git-ai knew this repo\nstill before\n",
+    )
+    .unwrap();
+    let before_first_sighting = raw_commit_all_in(&history, "more pre-existing history");
+
+    repo.request_untraced_fixup_scan_for(&history);
+    repo.request_untraced_fixup_scan_for(&history);
+
+    assert!(
+        repo.read_authorship_note_in_git_dir(&history_git_dir, &before_first_sighting)
+            .is_none(),
+        "commits from before the daemon knew the repo are history, not fixup work"
+    );
+    assert_eq!(health_counter(&repo, "untraced_commits_fixed"), 0);
+    assert_eq!(health_counter(&repo, "untraced_commits_skipped"), 0);
+
+    // Once known, the next untraced commit is claimed.
+    fs::write(history.join("new.txt"), "after first sighting\n").unwrap();
+    let after = raw_commit_all_in(&history, "untraced after first sighting");
+    repo.request_untraced_fixup_scan_for(&history);
+    assert!(
+        repo.read_authorship_note_in_git_dir(&history_git_dir, &after)
+            .is_some()
+    );
+    assert_eq!(health_counter(&repo, "untraced_commits_fixed"), 1);
+}
+
+#[test]
+fn untraced_amend_is_a_rewrite_and_is_skipped() {
+    let (_metrics_dir, metrics_db_path, repo) = fixup_repo();
+    write_file(&repo, "agent.txt", "base\n");
+    repo.stage_all_and_commit("traced base")
+        .expect("traced base commit");
+    codex_edit(&repo, "agent.txt", "base\nai line\n", "tool-use-1");
+    let traced = repo
+        .stage_all_and_commit("traced agent commit")
+        .expect("traced agent commit")
+        .commit_sha;
+    repo.request_untraced_fixup_scan();
+
+    raw_git(
+        &repo,
+        &["commit", "--amend", "-m", "amended while untraced"],
+    );
+    let amended = raw_head(&repo);
+    assert_ne!(amended, traced);
+
+    repo.request_untraced_fixup_scan();
+
+    assert!(repo.read_authorship_note(&amended).is_none());
+    assert!(repo.read_authorship_note(&traced).is_some());
+    assert!(committed_metrics_for_commit(&metrics_db_path, &amended).is_empty());
+    assert_eq!(health_counter(&repo, "untraced_commits_skipped"), 1);
+    assert_eq!(health_counter(&repo, "untraced_commits_fixed"), 0);
+}
+
+#[test]
+fn untraced_rebase_of_traced_commits_is_not_fixed_up() {
+    let (_metrics_dir, metrics_db_path, repo) = fixup_repo();
+    write_file(&repo, "base.txt", "base\n");
+    repo.stage_all_and_commit("traced base")
+        .expect("traced base commit");
+    let main_branch = raw_git(&repo, &["rev-parse", "--abbrev-ref", "HEAD"])
+        .trim()
+        .to_string();
+    repo.request_untraced_fixup_scan();
+
+    repo.git(&["checkout", "-b", "topic"]).unwrap();
+    write_file(&repo, "agent.txt", "");
+    codex_edit(&repo, "agent.txt", "ai line\n", "tool-use-1");
+    let topic_commit = repo
+        .stage_all_and_commit("traced topic commit")
+        .expect("traced topic commit")
+        .commit_sha;
+    let mut file = repo.filename("agent.txt");
+    file.assert_committed_lines(lines!["ai line".ai()]);
+
+    repo.git(&["checkout", &main_branch]).unwrap();
+    write_file(&repo, "main.txt", "main moved on\n");
+    repo.stage_all_and_commit("traced main commit")
+        .expect("traced main commit");
+
+    // The rebase happens where the daemon cannot see it.
+    raw_git(&repo, &["checkout", "topic"]);
+    raw_git(&repo, &["rebase", &main_branch]);
+    let rebased = raw_head(&repo);
+    assert_ne!(rebased, topic_commit);
+
+    repo.request_untraced_fixup_scan();
+
+    assert!(
+        repo.read_authorship_note(&rebased).is_none(),
+        "rewrites are never fixed up; only genuinely new commits are"
+    );
+    assert!(repo.read_authorship_note(&topic_commit).is_some());
+    assert!(committed_metrics_for_commit(&metrics_db_path, &rebased).is_empty());
+    assert_eq!(health_counter(&repo, "untraced_commits_fixed"), 0);
+}
+
+#[test]
+fn untraced_pull_of_remote_commits_is_not_fixed_up() {
+    let (_metrics_dir, metrics_db_path, repo) = fixup_repo();
+    let origin = TestRepo::new_with_daemon_scope(DaemonTestScope::NoDaemon);
+    write_file(&origin, "remote.txt", "remote base\n");
+    raw_commit_all(&origin, "remote base");
+    let branch = raw_git(&origin, &["rev-parse", "--abbrev-ref", "HEAD"])
+        .trim()
+        .to_string();
+    raw_git(
+        &repo,
+        &[
+            "remote",
+            "add",
+            "origin",
+            origin.path().to_str().expect("origin path is utf-8"),
+        ],
+    );
+    repo.request_untraced_fixup_scan();
+
+    write_file(
+        &origin,
+        "remote.txt",
+        "remote base\nmade on another machine\n",
+    );
+    let remote_commit = raw_commit_all(&origin, "remote commit");
+    raw_git(&repo, &["pull", "--ff-only", "origin", &branch]);
+    assert_eq!(raw_head(&repo), remote_commit);
+
+    repo.request_untraced_fixup_scan();
+
+    assert!(
+        repo.read_authorship_note(&remote_commit).is_none(),
+        "pulled commits were not made on this machine"
+    );
+    assert!(committed_metrics_for_commit(&metrics_db_path, &remote_commit).is_empty());
+    assert_eq!(health_counter(&repo, "untraced_commits_fixed"), 0);
+}
+
+#[test]
+fn untraced_detached_head_commit_is_skipped() {
+    let (_metrics_dir, _metrics_db_path, repo) = fixup_repo();
+    write_file(&repo, "base.txt", "base\n");
+    repo.stage_all_and_commit("traced base")
+        .expect("traced base commit");
+    repo.request_untraced_fixup_scan();
+
+    raw_git(&repo, &["checkout", "--detach"]);
+    write_file(&repo, "detached.txt", "on no branch\n");
+    let detached = raw_commit_all(&repo, "detached commit");
+
+    repo.request_untraced_fixup_scan();
+
+    assert!(repo.read_authorship_note(&detached).is_none());
+    // Both the `checkout:` record and the detached commit are settled unclaimed.
+    assert_eq!(health_counter(&repo, "untraced_commits_skipped"), 2);
+}
+
+#[test]
+fn fixup_scan_for_one_repository_covers_every_worktree_of_its_family() {
+    let (_metrics_dir, _metrics_db_path, repo) = fixup_repo();
+    write_file(&repo, "base.txt", "base\n");
+    repo.stage_all_and_commit("traced base")
+        .expect("traced base commit");
+    let scheduled = repo.request_untraced_fixup_scan();
+    assert_eq!(scheduled.get("worktrees").and_then(Value::as_u64), Some(1));
+    assert!(Path::new(&repo.path().join(".git")).is_dir());
+
+    let linked = repo.path().parent().expect("temp parent").join(format!(
+        "{}-linked",
+        repo.path().file_name().unwrap().to_string_lossy()
+    ));
+    raw_git(
+        &repo,
+        &[
+            "worktree",
+            "add",
+            "-b",
+            "linked",
+            linked.to_str().expect("utf-8 path"),
+        ],
+    );
+    let scheduled = repo.request_untraced_fixup_scan();
+    assert_eq!(
+        scheduled.get("worktrees").and_then(Value::as_u64),
+        Some(2),
+        "a request naming one worktree scans the whole family"
+    );
+    let _ = fs::remove_dir_all(&linked);
+}


### PR DESCRIPTION
## Summary

Wires the untraced-commit claim into the daemon as a sequenced pass, driven for now by an explicit control request (the periodic worker lands in the last PR of the stack).

- `FamilySequencerEntry::UntracedCommitScan` is appended at the current time, so the causal fence holds it behind older open trace roots and the family exec lock serializes it with commands and checkpoints. It never runs concurrently with the traced path for its family.
- Each claimed commit goes through `maybe_apply_side_effects_for_applied_command` unchanged: working logs are consumed and carried forward, attribution recovery fills holes, the note is written, and the `Committed` metric carries `commit_source = untraced_fixup`. Commits that already have a note are skipped (one `commits_with_notes` batch per pass), so a pass that died before recording its cursor cannot double-record.
- A pass attributes at most 10 commits (or one reflog byte budget), then queues a follow-up so bursts drain quickly while the exec lock is released between passes. Each scheduled pass carries the `HEAD` reflog length at scheduling time as its upper bound, because the causal fence only holds it for roots that started earlier. Once records are claimed nothing abandons them: the notes pre-check, per-commit side effects and the completion log all log and continue; when a side effect fails the pass reports no cursor to persist, so the next daemon lifetime retries that commit (skipping any that did get a note). A worktree with a pass already queued is not queued again.
- `fixup.scan` with a repository scans every worktree of that repository's family, not just the named one.
- Synthetic commits are logged as `untraced_fixup` and never `sync_tracked`, so they cannot satisfy a test's wait for its own traced commands.
- `fixup.scan { repo_working_dir? }` schedules a pass per worktree of a family (or of every known family) and returns counts. `status.daemon`, `bg status` and the heartbeat gain `untraced_commits_fixed/skipped`, `untraced_cursor_reseeds`, `untraced_scan_errors`.
- Records younger than `GIT_AI_DAEMON_UNTRACED_FIXUP_MIN_AGE_MS` (5 s) wait for a later pass. `repo_state::worktrees_for_common_dir` lists a family's worktrees from the filesystem: the main worktree (a `.git` common dir's parent, or `core.worktree` for submodules / `--separate-git-dir`, none for bare) plus linked worktrees, following relative `gitdir` pointers.

## Test plan

- [x] `tests/integration/untraced_commit_fixup.rs` (dedicated daemons, untraced git via trace2-disabled `git_og_with_env`, isolated metrics db, line-level asserts after every commit): delivered checkpoints → AI lines attributed and the working log consumed; recovery-only note without checkpoints; traced commits keep a null source and are never reclaimed (one metric row); untraced amend, rebase of traced commits, pull of remote commits, detached-HEAD commit all skipped; first sighting never backfills (asserted on a sibling repository the daemon has never seen: the harness probes the test repo itself the moment its daemon starts, and a startup tick may seed a cursor in a still-empty repo, which makes every later commit legitimately claimable); scan idempotent
- [x] unit tests for `worktrees_for_common_dir` (main + linked, bare, submodule `core.worktree` + relative gitdir)
- [x] `daemon_mode`, `cold_trace2_repo`, `commit_metric_metadata` suites; `task lint`, `task fmt`
