### PR TITLE
feat(daemon): persist repo families and fixup cursors across restarts

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -9,7 +9,8 @@ use crate::git::cli_parser::{
 };
 use crate::git::find_repository_in_path;
 use crate::git::repo_state::{
-    common_dir_for_worktree, git_dir_for_worktree, worktree_root_for_path, worktrees_for_common_dir,
+    common_dir_for_worktree, git_dir_for_worktree, worktree_belongs_to_git_dir,
+    worktree_root_for_path, worktrees_for_common_dir,
 };
 use crate::git::repository::{
     Repository, discover_repository_in_path_no_git_exec, exec_git, exec_git_stdin,
@@ -68,6 +69,7 @@ pub mod health;
 mod memory_watchdog;
 pub mod reducer;
 pub mod ref_cursor;
+pub mod repo_family_store;
 pub mod rewrite_metrics;
 pub mod sentry_layer;
 pub mod stream_worker;
@@ -3047,6 +3049,13 @@ pub struct ActorDaemonCoordinator {
     // exits via the shutdown select! arm instead of relying on channel closure.
     trace_ingest_tx: std::sync::OnceLock<mpsc::Sender<Value>>,
     telemetry_worker: Option<crate::daemon::telemetry_worker::DaemonTelemetryWorkerHandle>,
+    /// Families and fixup cursors remembered across restarts; `None` when the
+    /// database could not be opened (fixup then only covers this process).
+    repo_family_store: Option<Arc<crate::daemon::repo_family_store::RepoFamilyStore>>,
+    /// Worktree git dirs whose fixup cursor must not be persisted again this
+    /// lifetime: a pass had a side effect fail, and the durable cursor has to
+    /// stay behind that commit so a later lifetime can retry it.
+    untraced_persistence_blocked: Mutex<HashSet<String>>,
     stream_worker: Option<crate::daemon::stream_worker::StreamWorkerHandle>,
     token_usage_worker: Option<crate::daemon::token_usage_worker::TokenUsageWorkerHandle>,
     transcript_shutdown_notify: std::sync::OnceLock<Arc<tokio::sync::Notify>>,
@@ -3194,6 +3203,8 @@ impl ActorDaemonCoordinator {
             test_completion_log_lock: Mutex::new(()),
             trace_ingest_tx: std::sync::OnceLock::new(),
             telemetry_worker: None,
+            repo_family_store: None,
+            untraced_persistence_blocked: Mutex::new(HashSet::new()),
             stream_worker: None,
             token_usage_worker: None,
             transcript_shutdown_notify: std::sync::OnceLock::new(),
@@ -5545,6 +5556,7 @@ impl ActorDaemonCoordinator {
         self: &Arc<Self>,
         repo_working_dir: Option<String>,
     ) -> Result<UntracedScanSchedule, GitAiError> {
+        let now_secs = crate::utils::unix_timestamp_now();
         let mut targets = Vec::new();
         match repo_working_dir {
             Some(dir) => {
@@ -5564,8 +5576,30 @@ impl ActorDaemonCoordinator {
                 }
             }
             None => {
-                for family in self.coordinator.family_keys().await {
-                    for (git_dir, worktree) in worktrees_for_common_dir(Path::new(&family)) {
+                // Families this process has heard from, plus those remembered
+                // from earlier daemon lifetimes.
+                let mut families = self.coordinator.family_keys().await;
+                let remembered = self
+                    .with_repo_family_store(move |store| {
+                        store.prune(now_secs)?;
+                        store.known_families()
+                    })
+                    .await?
+                    .unwrap_or_default();
+                families.extend(remembered);
+                families.sort();
+                families.dedup();
+                for family in families {
+                    let common_dir = Path::new(&family);
+                    if !common_dir.is_dir() {
+                        let family = family.clone();
+                        self.with_repo_family_store(move |store| {
+                            store.record_family_missing(&family, now_secs)
+                        })
+                        .await?;
+                        continue;
+                    }
+                    for (git_dir, worktree) in self.family_worktrees(&family).await? {
                         targets.push((family.clone(), git_dir, worktree));
                     }
                 }
@@ -5578,13 +5612,21 @@ impl ActorDaemonCoordinator {
                 continue;
             }
             let max_offset = head_reflog_len(&git_dir);
+            // A completed pass records the family and its cursor; scheduling
+            // only reads the persisted cursor a cold actor should resume from.
+            let seed = {
+                let git_dir_key = git_dir.to_string_lossy().to_string();
+                self.with_repo_family_store(move |store| store.cursor(&git_dir_key))
+                    .await?
+                    .flatten()
+            };
             self.append_family_sequencer_entry(
                 &family,
                 now_unix_nanos(),
                 FamilySequencerEntry::UntracedCommitScan {
                     git_dir,
                     worktree,
-                    seed: None,
+                    seed,
                     max_offset,
                 },
             )?;
@@ -5619,6 +5661,66 @@ impl ActorDaemonCoordinator {
                 )
             })
         }))
+    }
+
+    fn untraced_persistence_blocked(&self, git_dir_key: &str) -> Result<bool, GitAiError> {
+        Ok(self
+            .lock_untraced_persistence_blocked()?
+            .contains(git_dir_key))
+    }
+
+    fn lock_untraced_persistence_blocked(
+        &self,
+    ) -> Result<std::sync::MutexGuard<'_, HashSet<String>>, GitAiError> {
+        self.untraced_persistence_blocked.lock().map_err(|_| {
+            GitAiError::Generic("untraced persistence block set lock poisoned".to_string())
+        })
+    }
+
+    /// A family's worktrees: what the filesystem shows under its common dir,
+    /// plus worktrees remembered from earlier passes (the only way back to a
+    /// `--separate-git-dir` main worktree) that still exist.
+    async fn family_worktrees(&self, family: &str) -> Result<Vec<(PathBuf, PathBuf)>, GitAiError> {
+        let mut worktrees = worktrees_for_common_dir(Path::new(family));
+        let common_dir = family.to_string();
+        // A store problem must not take the whole tick down: the filesystem
+        // enumeration still covers every worktree the filesystem can lead to.
+        let remembered = self
+            .with_repo_family_store(move |store| store.known_worktrees(&common_dir))
+            .await
+            .unwrap_or_else(|error| {
+                tracing::warn!(%error, %family, "could not read remembered worktrees");
+                None
+            })
+            .unwrap_or_default();
+        for (git_dir, worktree) in remembered {
+            let (git_dir, worktree) = (PathBuf::from(git_dir), PathBuf::from(worktree));
+            // Either path may have been reused by an unrelated repository since;
+            // the worktree must still resolve to this git dir.
+            if worktree_belongs_to_git_dir(&worktree, &git_dir)
+                && !worktrees.iter().any(|(known, _)| *known == git_dir)
+            {
+                worktrees.push((git_dir, worktree));
+            }
+        }
+        Ok(worktrees)
+    }
+
+    /// Runs a store operation off the async runtime; `Ok(None)` when no store
+    /// is open.
+    async fn with_repo_family_store<T, F>(&self, operation: F) -> Result<Option<T>, GitAiError>
+    where
+        T: Send + 'static,
+        F: FnOnce(&crate::daemon::repo_family_store::RepoFamilyStore) -> Result<T, GitAiError>
+            + Send
+            + 'static,
+    {
+        let Some(store) = self.repo_family_store.clone() else {
+            return Ok(None);
+        };
+        crate::tokio_runtime::spawn_blocking_result(move || operation(&store))
+            .await
+            .map(Some)
     }
 
     fn side_effect_exec_lock(&self, family: &str) -> Result<Arc<AsyncMutex<()>>, GitAiError> {
@@ -5851,12 +5953,39 @@ impl ActorDaemonCoordinator {
                         .map_err(|_| {
                             GitAiError::Generic("command side-effect semaphore closed".to_string())
                         })?;
-                    if let Err(error) = self
+                    let git_dir_key = git_dir.to_string_lossy().to_string();
+                    let worktree_key = worktree.to_string_lossy().to_string();
+                    let scan = self
                         .run_untraced_commit_scan(
                             family, git_dir, worktree, seed, max_offset, order,
                         )
-                        .await
-                    {
+                        .await;
+                    let persisted = match scan {
+                        Ok(Some(cursor)) if !self.untraced_persistence_blocked(&git_dir_key)? => {
+                            let family = family.to_string();
+                            self.with_repo_family_store(move |store| {
+                                store.record_pass_completed(
+                                    &family,
+                                    &git_dir_key,
+                                    &worktree_key,
+                                    &cursor,
+                                    crate::utils::unix_timestamp_now(),
+                                )
+                            })
+                            .await
+                            .map(|_| ())
+                        }
+                        // A side effect failed in this or an earlier pass: the
+                        // durable cursor stays behind that commit for the rest
+                        // of this daemon lifetime, so the next one retries it
+                        // (commits that did get their note are skipped then).
+                        Ok(Some(_)) => Ok(()),
+                        Ok(None) => self.lock_untraced_persistence_blocked().map(|mut blocked| {
+                            blocked.insert(git_dir_key);
+                        }),
+                        Err(error) => Err(error),
+                    };
+                    if let Err(error) = persisted {
                         self.untraced_scan_errors.fetch_add(1, Ordering::Relaxed);
                         let _ = self.record_side_effect_error(family, order, &error);
                         tracing::error!(%error, %family, order, "untraced commit scan failed");
@@ -10221,6 +10350,16 @@ pub(crate) async fn run_daemon(config: DaemonConfig) -> Result<DaemonExitAction,
     let telemetry_handle = crate::daemon::telemetry_worker::spawn_telemetry_worker();
     crate::daemon::telemetry_worker::set_daemon_internal_telemetry(telemetry_handle.clone());
     coordinator_inner.telemetry_worker = Some(telemetry_handle.clone());
+
+    let repo_family_store_path = config.internal_dir.join("repo-families-db");
+    match crate::daemon::repo_family_store::RepoFamilyStore::open(&repo_family_store_path) {
+        Ok(store) => coordinator_inner.repo_family_store = Some(Arc::new(store)),
+        Err(error) => tracing::error!(
+            %error,
+            path = %repo_family_store_path.display(),
+            "failed to open repo-families database; untraced commit fixup will not survive restarts"
+        ),
+    }
 
     // With the token-usage flag off, previously collected data is deleted
     // regardless of the streaming gate below (the spec's "no collected data

--- a/src/daemon/repo_family_store.rs
+++ b/src/daemon/repo_family_store.rs
@@ -1,0 +1,633 @@
+//! Persistent registry of the repository families this daemon has seen, with
+//! each worktree's untraced-commit fixup cursor. In memory the daemon only
+//! knows families it has heard from since it started; this store is what lets
+//! it find and attribute commits made while it was off.
+//!
+//! Written only by the fixup pass (`fixup.scan` and the periodic worker) —
+//! never on the trace ingestion or checkpoint paths.
+
+use crate::daemon::ref_cursor::{ReflogAnchor, UntracedReflogCursor};
+use crate::error::GitAiError;
+use rusqlite::{Connection, OptionalExtension, params};
+use std::path::Path;
+use std::sync::{Arc, Mutex, MutexGuard};
+
+/// A family whose common dir has been missing this long is forgotten.
+pub const MISSING_RETENTION_SECS: u64 = 7 * 24 * 60 * 60;
+/// A family not seen for this long is forgotten (it may live on a detached
+/// volume; if it comes back it is a first sighting again).
+pub const UNSEEN_RETENTION_SECS: u64 = 90 * 24 * 60 * 60;
+/// Hard cap on remembered families; the least recently seen go first.
+pub const MAX_FAMILIES: usize = 1000;
+
+const MIGRATIONS: &[&str] = &[
+    r#"
+CREATE TABLE schema_version (version INTEGER PRIMARY KEY);
+CREATE TABLE repo_families (
+    common_dir TEXT PRIMARY KEY,
+    first_seen_at INTEGER NOT NULL,
+    last_seen_at INTEGER NOT NULL,
+    missing_since INTEGER
+);
+CREATE TABLE worktree_fixup_cursors (
+    git_dir TEXT PRIMARY KEY,
+    common_dir TEXT NOT NULL,
+    reflog_offset INTEGER NOT NULL,
+    anchor_old TEXT,
+    anchor_new TEXT,
+    anchor_message TEXT,
+    updated_at INTEGER NOT NULL
+);
+CREATE INDEX idx_worktree_fixup_cursors_common_dir ON worktree_fixup_cursors(common_dir);
+INSERT INTO schema_version (version) VALUES (1);
+"#,
+    // v2: remember each cursor's worktree path (the only way back to a
+    // `--separate-git-dir` main worktree). Rows from v1 carry an empty path
+    // and are simply not used as remembered worktrees.
+    r#"
+ALTER TABLE worktree_fixup_cursors ADD COLUMN worktree TEXT NOT NULL DEFAULT '';
+INSERT INTO schema_version (version) VALUES (2);
+"#,
+];
+
+pub struct RepoFamilyStore {
+    conn: Arc<Mutex<Connection>>,
+}
+
+impl RepoFamilyStore {
+    pub fn open(path: &Path) -> Result<Self, GitAiError> {
+        let conn = crate::sqlite::open_with_memory_limits(path)?;
+        conn.pragma_update(None, "journal_mode", "WAL")?;
+        conn.pragma_update(None, "synchronous", "NORMAL")?;
+        conn.pragma_update(None, "temp_store", "MEMORY")?;
+        let store = Self {
+            conn: Arc::new(Mutex::new(conn)),
+        };
+        store.migrate()?;
+        Ok(store)
+    }
+
+    fn lock(&self) -> MutexGuard<'_, Connection> {
+        self.conn
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    fn migrate(&self) -> Result<(), GitAiError> {
+        let conn = self.lock();
+        let table_exists: bool = conn.query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='schema_version'",
+            [],
+            |row| Ok(row.get::<_, i64>(0)? > 0),
+        )?;
+        let current_version: u32 = if table_exists {
+            conn.query_row(
+                "SELECT version FROM schema_version ORDER BY version DESC LIMIT 1",
+                [],
+                |row| row.get(0),
+            )
+            .optional()?
+            .unwrap_or(0)
+        } else {
+            0
+        };
+        if current_version > MIGRATIONS.len() as u32 {
+            return Err(GitAiError::Generic(format!(
+                "repo-families database schema v{current_version} is newer than this binary \
+                 (supports up to v{}); upgrade git-ai or delete the database",
+                MIGRATIONS.len()
+            )));
+        }
+        for (version, migration_sql) in MIGRATIONS.iter().enumerate() {
+            if current_version < (version + 1) as u32 {
+                let tx = conn.unchecked_transaction()?;
+                tx.execute_batch(migration_sql)?;
+                tx.commit()?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Remembers that `common_dir` exists on this machine right now.
+    pub fn record_family_seen(&self, common_dir: &str, now_secs: u64) -> Result<(), GitAiError> {
+        Self::record_family_seen_in(&self.lock(), common_dir, now_secs)
+    }
+
+    fn record_family_seen_in(
+        conn: &Connection,
+        common_dir: &str,
+        now_secs: u64,
+    ) -> Result<(), GitAiError> {
+        conn.execute(
+            "INSERT INTO repo_families (common_dir, first_seen_at, last_seen_at, missing_since)
+             VALUES (?1, ?2, ?2, NULL)
+             ON CONFLICT(common_dir) DO UPDATE SET
+                 last_seen_at = excluded.last_seen_at,
+                 missing_since = NULL",
+            params![common_dir, now_secs as i64],
+        )?;
+        Ok(())
+    }
+
+    /// Refreshes `last_seen_at` (and clears `missing_since`) for a family the
+    /// store already remembers. Unlike a completed pass this never inserts, so
+    /// a remembered family always has the cursor its first pass saved.
+    pub fn refresh_family_seen(&self, common_dir: &str, now_secs: u64) -> Result<(), GitAiError> {
+        self.lock().execute(
+            "UPDATE repo_families SET last_seen_at = ?2, missing_since = NULL
+             WHERE common_dir = ?1",
+            params![common_dir, now_secs as i64],
+        )?;
+        Ok(())
+    }
+
+    /// Records that `common_dir` is gone (kept for `MISSING_RETENTION_SECS`
+    /// in case a volume comes back); a family already marked keeps its
+    /// original `missing_since`.
+    pub fn record_family_missing(&self, common_dir: &str, now_secs: u64) -> Result<(), GitAiError> {
+        self.lock().execute(
+            "UPDATE repo_families SET missing_since = COALESCE(missing_since, ?2)
+             WHERE common_dir = ?1",
+            params![common_dir, now_secs as i64],
+        )?;
+        Ok(())
+    }
+
+    /// Every remembered family, most recently seen first.
+    pub fn known_families(&self) -> Result<Vec<String>, GitAiError> {
+        let conn = self.lock();
+        let mut statement =
+            conn.prepare("SELECT common_dir FROM repo_families ORDER BY last_seen_at DESC")?;
+        let families = statement
+            .query_map([], |row| row.get::<_, String>(0))?
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(families)
+    }
+
+    pub fn family_count(&self) -> Result<usize, GitAiError> {
+        let count: i64 =
+            self.lock()
+                .query_row("SELECT COUNT(*) FROM repo_families", [], |row| row.get(0))?;
+        Ok(count as usize)
+    }
+
+    pub fn cursor(&self, git_dir: &str) -> Result<Option<UntracedReflogCursor>, GitAiError> {
+        let cursor = self
+            .lock()
+            .query_row(
+                "SELECT reflog_offset, anchor_old, anchor_new, anchor_message
+                 FROM worktree_fixup_cursors WHERE git_dir = ?1",
+                params![git_dir],
+                |row| {
+                    let offset: i64 = row.get(0)?;
+                    let anchor = match (
+                        row.get::<_, Option<String>>(1)?,
+                        row.get::<_, Option<String>>(2)?,
+                        row.get::<_, Option<String>>(3)?,
+                    ) {
+                        (Some(old), Some(new), Some(message)) => Some(ReflogAnchor {
+                            old,
+                            new,
+                            message,
+                            end_offset: offset as u64,
+                        }),
+                        _ => None,
+                    };
+                    Ok(UntracedReflogCursor {
+                        offset: offset as u64,
+                        anchor,
+                    })
+                },
+            )
+            .optional()?;
+        Ok(cursor)
+    }
+
+    pub fn save_cursor(
+        &self,
+        common_dir: &str,
+        git_dir: &str,
+        worktree: &str,
+        cursor: &UntracedReflogCursor,
+        now_secs: u64,
+    ) -> Result<(), GitAiError> {
+        Self::save_cursor_in(
+            &self.lock(),
+            common_dir,
+            git_dir,
+            worktree,
+            cursor,
+            now_secs,
+        )
+    }
+
+    fn save_cursor_in(
+        conn: &Connection,
+        common_dir: &str,
+        git_dir: &str,
+        worktree: &str,
+        cursor: &UntracedReflogCursor,
+        now_secs: u64,
+    ) -> Result<(), GitAiError> {
+        let anchor = cursor.anchor.as_ref();
+        conn.execute(
+            "INSERT INTO worktree_fixup_cursors
+                 (git_dir, common_dir, worktree, reflog_offset, anchor_old, anchor_new, anchor_message, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+             ON CONFLICT(git_dir) DO UPDATE SET
+                 common_dir = excluded.common_dir,
+                 worktree = excluded.worktree,
+                 reflog_offset = excluded.reflog_offset,
+                 anchor_old = excluded.anchor_old,
+                 anchor_new = excluded.anchor_new,
+                 anchor_message = excluded.anchor_message,
+                 updated_at = excluded.updated_at",
+            params![
+                git_dir,
+                common_dir,
+                worktree,
+                cursor.offset as i64,
+                anchor.map(|anchor| anchor.old.as_str()),
+                anchor.map(|anchor| anchor.new.as_str()),
+                anchor.map(|anchor| anchor.message.as_str()),
+                now_secs as i64,
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// What a completed fixup pass leaves behind, in one transaction: the
+    /// family is seen now and this worktree's cursor is settled here. A crash
+    /// can never leave a remembered family whose cursor is missing (which a
+    /// cold actor would read as "first sighting" and skip its history).
+    pub fn record_pass_completed(
+        &self,
+        common_dir: &str,
+        git_dir: &str,
+        worktree: &str,
+        cursor: &UntracedReflogCursor,
+        now_secs: u64,
+    ) -> Result<(), GitAiError> {
+        let conn = self.lock();
+        let tx = conn.unchecked_transaction()?;
+        Self::record_family_seen_in(&tx, common_dir, now_secs)?;
+        Self::save_cursor_in(&tx, common_dir, git_dir, worktree, cursor, now_secs)?;
+        tx.commit()?;
+        Ok(())
+    }
+
+    /// The worktrees a family has been scanned in, as `(git_dir, worktree)`
+    /// pairs. This is how a main worktree that the filesystem cannot lead to
+    /// (`git init --separate-git-dir`: the git dir holds no pointer back) is
+    /// still found after a restart; callers drop pairs whose paths are gone.
+    pub fn known_worktrees(&self, common_dir: &str) -> Result<Vec<(String, String)>, GitAiError> {
+        let conn = self.lock();
+        let mut statement = conn.prepare(
+            "SELECT git_dir, worktree FROM worktree_fixup_cursors
+             WHERE common_dir = ?1 ORDER BY git_dir",
+        )?;
+        let worktrees = statement
+            .query_map(params![common_dir], |row| Ok((row.get(0)?, row.get(1)?)))?
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(worktrees)
+    }
+
+    /// Forgets families missing or unseen for too long, then the least
+    /// recently seen beyond `MAX_FAMILIES`, with their cursors. Returns how
+    /// many families were removed.
+    pub fn prune(&self, now_secs: u64) -> Result<usize, GitAiError> {
+        let conn = self.lock();
+        let tx = conn.unchecked_transaction()?;
+        let mut removed = tx.execute(
+            "DELETE FROM repo_families
+             WHERE (missing_since IS NOT NULL AND missing_since <= ?1)
+                OR last_seen_at <= ?2",
+            params![
+                now_secs.saturating_sub(MISSING_RETENTION_SECS) as i64,
+                now_secs.saturating_sub(UNSEEN_RETENTION_SECS) as i64,
+            ],
+        )?;
+        removed += tx.execute(
+            "DELETE FROM repo_families WHERE common_dir IN (
+                 SELECT common_dir FROM repo_families
+                 ORDER BY last_seen_at DESC, common_dir
+                 LIMIT -1 OFFSET ?1
+             )",
+            params![MAX_FAMILIES as i64],
+        )?;
+        tx.execute(
+            "DELETE FROM worktree_fixup_cursors
+             WHERE common_dir NOT IN (SELECT common_dir FROM repo_families)",
+            [],
+        )?;
+        tx.commit()?;
+        Ok(removed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const A: &str = "1111111111111111111111111111111111111111";
+    const B: &str = "2222222222222222222222222222222222222222";
+    const NOW: u64 = 1_800_000_000;
+
+    fn store() -> (tempfile::TempDir, RepoFamilyStore) {
+        let temp = tempfile::tempdir().unwrap();
+        let store = RepoFamilyStore::open(&temp.path().join("repo-families-db")).unwrap();
+        (temp, store)
+    }
+
+    fn cursor_with_anchor(offset: u64) -> UntracedReflogCursor {
+        UntracedReflogCursor {
+            offset,
+            anchor: Some(ReflogAnchor {
+                old: A.to_string(),
+                new: B.to_string(),
+                message: "commit: anchored".to_string(),
+                end_offset: offset,
+            }),
+        }
+    }
+
+    #[test]
+    fn open_migrates_once_and_reopens_idempotently() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("repo-families-db");
+        RepoFamilyStore::open(&path).unwrap();
+        let reopened = RepoFamilyStore::open(&path).unwrap();
+        let version: u32 = reopened
+            .lock()
+            .query_row("SELECT MAX(version) FROM schema_version", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(version, MIGRATIONS.len() as u32);
+        assert_eq!(reopened.family_count().unwrap(), 0);
+    }
+
+    #[test]
+    fn a_v1_store_is_migrated_in_place_and_keeps_its_rows() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("repo-families-db");
+        {
+            let conn = crate::sqlite::open_with_memory_limits(&path).unwrap();
+            conn.execute_batch(MIGRATIONS[0]).unwrap();
+            conn.execute(
+                "INSERT INTO repo_families (common_dir, first_seen_at, last_seen_at) VALUES (?1, ?2, ?2)",
+                params!["/repos/old/.git", NOW as i64],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO worktree_fixup_cursors
+                     (git_dir, common_dir, reflog_offset, updated_at)
+                 VALUES (?1, ?1, 42, ?2)",
+                params!["/repos/old/.git", NOW as i64],
+            )
+            .unwrap();
+        }
+
+        let store = RepoFamilyStore::open(&path).unwrap();
+
+        let version: u32 = store
+            .lock()
+            .query_row("SELECT MAX(version) FROM schema_version", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(version, MIGRATIONS.len() as u32);
+        assert_eq!(
+            store.known_families().unwrap(),
+            vec!["/repos/old/.git".to_string()]
+        );
+        assert_eq!(
+            store.cursor("/repos/old/.git").unwrap().map(|c| c.offset),
+            Some(42)
+        );
+        assert_eq!(
+            store.known_worktrees("/repos/old/.git").unwrap(),
+            vec![("/repos/old/.git".to_string(), String::new())],
+            "a v1 row has no remembered worktree path"
+        );
+    }
+
+    #[test]
+    fn newer_schema_fails_closed() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("repo-families-db");
+        {
+            let store = RepoFamilyStore::open(&path).unwrap();
+            store
+                .lock()
+                .execute("INSERT INTO schema_version (version) VALUES (99)", [])
+                .unwrap();
+        }
+        let error = RepoFamilyStore::open(&path)
+            .err()
+            .expect("newer schema must fail");
+        assert!(
+            error.to_string().contains("newer than this binary"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn refresh_family_seen_only_touches_remembered_families() {
+        let (_temp, store) = store();
+        store.record_family_seen("/repos/a/.git", NOW).unwrap();
+        store
+            .record_family_missing("/repos/a/.git", NOW + 10)
+            .unwrap();
+
+        store
+            .refresh_family_seen("/repos/a/.git", NOW + 20)
+            .unwrap();
+        store
+            .refresh_family_seen("/repos/never-scanned/.git", NOW + 20)
+            .unwrap();
+
+        assert_eq!(
+            store.family_count().unwrap(),
+            1,
+            "a refresh must not remember a family that has no cursor yet"
+        );
+        let (last, missing): (i64, Option<i64>) = store
+            .lock()
+            .query_row(
+                "SELECT last_seen_at, missing_since FROM repo_families
+                 WHERE common_dir = '/repos/a/.git'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!((last, missing), ((NOW + 20) as i64, None));
+    }
+
+    #[test]
+    fn record_family_seen_keeps_first_seen_and_clears_missing() {
+        let (_temp, store) = store();
+        store.record_family_seen("/repos/a/.git", NOW).unwrap();
+        store
+            .record_family_missing("/repos/a/.git", NOW + 10)
+            .unwrap();
+        store.record_family_seen("/repos/a/.git", NOW + 20).unwrap();
+        store.record_family_seen("/repos/b/.git", NOW + 5).unwrap();
+
+        let (first, last, missing): (i64, i64, Option<i64>) = store
+            .lock()
+            .query_row(
+                "SELECT first_seen_at, last_seen_at, missing_since FROM repo_families
+                 WHERE common_dir = '/repos/a/.git'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(
+            (first, last, missing),
+            (NOW as i64, (NOW + 20) as i64, None)
+        );
+        assert_eq!(
+            store.known_families().unwrap(),
+            vec!["/repos/a/.git".to_string(), "/repos/b/.git".to_string()],
+            "most recently seen first"
+        );
+        assert_eq!(store.family_count().unwrap(), 2);
+    }
+
+    #[test]
+    fn record_family_missing_keeps_the_first_missing_timestamp() {
+        let (_temp, store) = store();
+        store.record_family_seen("/repos/a/.git", NOW).unwrap();
+        store
+            .record_family_missing("/repos/a/.git", NOW + 10)
+            .unwrap();
+        store
+            .record_family_missing("/repos/a/.git", NOW + 20)
+            .unwrap();
+        let missing: i64 = store
+            .lock()
+            .query_row(
+                "SELECT missing_since FROM repo_families WHERE common_dir = '/repos/a/.git'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(missing, (NOW + 10) as i64);
+    }
+
+    #[test]
+    fn cursor_roundtrips_with_and_without_anchor() {
+        let (_temp, store) = store();
+        store.record_family_seen("/repos/a/.git", NOW).unwrap();
+        assert_eq!(store.cursor("/repos/a/.git").unwrap(), None);
+
+        let anchored = cursor_with_anchor(4_096);
+        store
+            .save_cursor("/repos/a/.git", "/repos/a/.git", "/repos/a", &anchored, NOW)
+            .unwrap();
+        assert_eq!(store.cursor("/repos/a/.git").unwrap(), Some(anchored));
+
+        let bare = UntracedReflogCursor {
+            offset: 0,
+            anchor: None,
+        };
+        store
+            .save_cursor("/repos/a/.git", "/repos/a/.git", "/repos/a", &bare, NOW + 1)
+            .unwrap();
+        assert_eq!(store.cursor("/repos/a/.git").unwrap(), Some(bare));
+    }
+
+    #[test]
+    fn record_pass_completed_writes_family_and_cursor_together() {
+        let (_temp, store) = store();
+        let cursor = cursor_with_anchor(2_048);
+        store
+            .record_pass_completed("/repos/a/.git", "/repos/a/.git", "/repos/a", &cursor, NOW)
+            .unwrap();
+        store
+            .record_pass_completed(
+                "/repos/a/.git",
+                "/repos/a/.git/worktrees/wt",
+                "/repos/a-wt",
+                &cursor,
+                NOW,
+            )
+            .unwrap();
+
+        assert_eq!(
+            store.known_families().unwrap(),
+            vec!["/repos/a/.git".to_string()]
+        );
+        assert_eq!(store.cursor("/repos/a/.git").unwrap(), Some(cursor));
+        assert_eq!(
+            store.known_worktrees("/repos/a/.git").unwrap(),
+            vec![
+                ("/repos/a/.git".to_string(), "/repos/a".to_string()),
+                (
+                    "/repos/a/.git/worktrees/wt".to_string(),
+                    "/repos/a-wt".to_string()
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn prune_forgets_missing_and_unseen_families_with_their_cursors() {
+        let (_temp, store) = store();
+        store.record_family_seen("/repos/gone/.git", NOW).unwrap();
+        store
+            .save_cursor(
+                "/repos/gone/.git",
+                "/repos/gone/.git",
+                "/repos/gone",
+                &cursor_with_anchor(1),
+                NOW,
+            )
+            .unwrap();
+        store
+            .record_family_missing("/repos/gone/.git", NOW)
+            .unwrap();
+        store
+            .record_family_seen("/repos/stale/.git", NOW - UNSEEN_RETENTION_SECS - 1)
+            .unwrap();
+        store.record_family_seen("/repos/fresh/.git", NOW).unwrap();
+        store
+            .record_family_seen("/repos/recently-missing/.git", NOW)
+            .unwrap();
+        store
+            .record_family_missing("/repos/recently-missing/.git", NOW + 3600)
+            .unwrap();
+
+        let removed = store.prune(NOW + MISSING_RETENTION_SECS + 1).unwrap();
+
+        assert_eq!(removed, 2);
+        assert_eq!(
+            store.known_families().unwrap(),
+            vec![
+                "/repos/fresh/.git".to_string(),
+                "/repos/recently-missing/.git".to_string()
+            ]
+        );
+        assert_eq!(store.cursor("/repos/gone/.git").unwrap(), None);
+    }
+
+    #[test]
+    fn prune_caps_the_number_of_families_by_recency() {
+        let (_temp, store) = store();
+        for index in 0..(MAX_FAMILIES + 5) {
+            store
+                .record_family_seen(&format!("/repos/{index}/.git"), NOW + index as u64)
+                .unwrap();
+        }
+
+        let removed = store.prune(NOW + MAX_FAMILIES as u64 + 10).unwrap();
+
+        assert_eq!(removed, 5);
+        assert_eq!(store.family_count().unwrap(), MAX_FAMILIES);
+        let families = store.known_families().unwrap();
+        assert!(!families.contains(&"/repos/0/.git".to_string()));
+        assert!(!families.contains(&"/repos/4/.git".to_string()));
+        assert!(families.contains(&"/repos/5/.git".to_string()));
+    }
+}

--- a/src/git/repo_state.rs
+++ b/src/git/repo_state.rs
@@ -114,6 +114,15 @@ pub fn worktrees_for_common_dir(common_dir: &Path) -> Vec<(PathBuf, PathBuf)> {
     out
 }
 
+/// Whether `worktree` is still the worktree whose git dir is `git_dir`: a
+/// remembered pair may be stale once either path has been reused by an
+/// unrelated repository.
+pub fn worktree_belongs_to_git_dir(worktree: &Path, git_dir: &Path) -> bool {
+    let canonical = |path: &Path| path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    git_dir_for_worktree(worktree)
+        .is_some_and(|resolved| canonical(&resolved) == canonical(git_dir))
+}
+
 fn main_worktree_for_common_dir(common_dir: &Path) -> Option<PathBuf> {
     // The ordinary layout needs no config read (the daemon asks about every
     // known family on every tick).
@@ -227,6 +236,38 @@ mod tests {
             worktrees_for_common_dir(&common_dir),
             vec![(common_dir.clone(), main), (linked_git_dir, linked)]
         );
+    }
+
+    #[test]
+    fn worktree_belongs_to_git_dir_rejects_reused_paths() {
+        let temp = tempfile::tempdir().unwrap();
+        let main = temp.path().join("repo");
+        let common_dir = main.join(".git");
+        write_file(&common_dir.join("HEAD"), "ref: refs/heads/main\n");
+        assert!(worktree_belongs_to_git_dir(&main, &common_dir));
+
+        // A linked worktree whose `.git` file points at this repository...
+        let linked = temp.path().join("feature");
+        let linked_git_dir = common_dir.join("worktrees").join("feature");
+        write_file(&linked_git_dir.join("HEAD"), "ref: refs/heads/feature\n");
+        write_file(
+            &linked.join(".git"),
+            &format!("gitdir: {}\n", linked_git_dir.display()),
+        );
+        assert!(worktree_belongs_to_git_dir(&linked, &linked_git_dir));
+
+        // ...and the same path later reused by an unrelated repository.
+        let other = temp.path().join("other/.git");
+        write_file(&other.join("HEAD"), "ref: refs/heads/main\n");
+        write_file(
+            &linked.join(".git"),
+            &format!("gitdir: {}\n", other.display()),
+        );
+        assert!(!worktree_belongs_to_git_dir(&linked, &linked_git_dir));
+        assert!(!worktree_belongs_to_git_dir(
+            &temp.path().join("missing"),
+            &common_dir
+        ));
     }
 
     #[test]

--- a/tests/integration/repos/test_repo.rs
+++ b/tests/integration/repos/test_repo.rs
@@ -1797,6 +1797,21 @@ impl TestRepo {
         response.data.unwrap_or(serde_json::Value::Null)
     }
 
+    /// Runs one untraced-commit fixup pass over every family the daemon knows
+    /// (in memory or remembered from earlier lifetimes) and waits for it.
+    pub(crate) fn request_untraced_fixup_scan_all(&self) -> serde_json::Value {
+        let response = send_control_request(
+            &self.daemon_control_socket_path(),
+            &ControlRequest::UntracedFixupScan {
+                repo_working_dir: None,
+            },
+        )
+        .expect("fixup.scan should reach the daemon");
+        assert!(response.ok, "fixup.scan failed: {:?}", response.error);
+        self.sync_daemon_force();
+        response.data.unwrap_or(serde_json::Value::Null)
+    }
+
     /// The daemon's health snapshot (`status.daemon`).
     pub(crate) fn daemon_status(&self) -> serde_json::Value {
         let response = send_control_request(
@@ -1884,10 +1899,17 @@ impl TestRepo {
         &mut self,
         daemon_env: &[(&str, &str)],
     ) {
+        self.shutdown_dedicated_daemon_for_test();
+        self.start_dedicated_daemon_with_env_for_test(daemon_env);
+    }
+
+    /// Stops this repo's dedicated daemon; git run afterwards is invisible to
+    /// git-ai until `start_dedicated_daemon_with_env_for_test`.
+    pub(crate) fn shutdown_dedicated_daemon_for_test(&mut self) {
         assert_eq!(
             self.daemon_scope,
             DaemonTestScope::Dedicated,
-            "daemon restart requires a dedicated daemon repo"
+            "daemon shutdown requires a dedicated daemon repo"
         );
         let family_key = self.daemon_family_key();
         let pending_summary = {
@@ -1898,13 +1920,21 @@ impl TestRepo {
         };
         assert!(
             pending_summary.is_none(),
-            "cannot restart dedicated daemon with pending daemon sync work for family {}: {}",
+            "cannot stop dedicated daemon with pending daemon sync work for family {}: {}",
             family_key,
             pending_summary.unwrap_or_default()
         );
         if let Some(daemon) = self.daemon_process.take() {
             daemon.shutdown();
         }
+    }
+
+    pub(crate) fn start_dedicated_daemon_with_env_for_test(&mut self, daemon_env: &[(&str, &str)]) {
+        assert!(
+            self.daemon_process.is_none(),
+            "test repo already has an active daemon"
+        );
+        self.daemon_scope = DaemonTestScope::Dedicated;
         let daemon = Arc::new(DaemonProcess::start_with_env(
             &self.path,
             &self.test_home,

--- a/tests/integration/untraced_commit_fixup.rs
+++ b/tests/integration/untraced_commit_fixup.rs
@@ -9,6 +9,7 @@ use crate::test_utils::{
     codex_checkpoint, committed_metric_for_commit, committed_metrics_for_commit,
     isolated_metrics_db_path,
 };
+use git_ai::authorship::authorship_log_serialization::AuthorshipLog;
 use git_ai::metrics::events::committed_pos;
 use serde_json::Value;
 use std::fs;
@@ -20,14 +21,19 @@ const TRACE2_DISABLED_ENV: [(&str, &str); 3] = [
     ("GIT_TRACE2_PERF", "0"),
 ];
 
-/// A repository with a dedicated daemon whose fixup pass claims records
-/// immediately (no minimum age) and persists metrics to an isolated db.
+/// Daemon environment for these tests: the fixup pass claims records
+/// immediately (no minimum age) and metrics land in an isolated db.
+fn fixup_daemon_env(metrics_db_path: &str) -> Vec<(&str, &str)> {
+    vec![
+        ("GIT_AI_TEST_METRICS_DB_PATH", metrics_db_path),
+        ("GIT_AI_DAEMON_UNTRACED_FIXUP_MIN_AGE_MS", "0"),
+    ]
+}
+
+/// A repository with a dedicated daemon running under `fixup_daemon_env`.
 fn fixup_repo() -> (tempfile::TempDir, String, TestRepo) {
     let (metrics_dir, metrics_db_path) = isolated_metrics_db_path();
-    let repo = TestRepo::new_with_daemon_env(&[
-        ("GIT_AI_TEST_METRICS_DB_PATH", metrics_db_path.as_str()),
-        ("GIT_AI_DAEMON_UNTRACED_FIXUP_MIN_AGE_MS", "0"),
-    ]);
+    let repo = TestRepo::new_with_daemon_env(&fixup_daemon_env(&metrics_db_path));
     (metrics_dir, metrics_db_path, repo)
 }
 
@@ -424,6 +430,140 @@ fn fixup_scan_for_one_repository_covers_every_worktree_of_its_family() {
         scheduled.get("worktrees").and_then(Value::as_u64),
         Some(2),
         "a request naming one worktree scans the whole family"
+    );
+    let _ = fs::remove_dir_all(&linked);
+}
+
+#[test]
+fn commit_made_while_the_daemon_was_off_is_attributed_after_restart() {
+    let (_metrics_dir, metrics_db_path, mut repo) = fixup_repo();
+    write_file(&repo, "agent.txt", "base\n");
+    let base = repo
+        .stage_all_and_commit("traced base")
+        .expect("traced base commit")
+        .commit_sha;
+    // The daemon has seen this repository: it is a known family.
+    repo.request_untraced_fixup_scan();
+    codex_edit(&repo, "agent.txt", "base\nai line\n", "tool-use-1");
+    repo.sync_daemon();
+
+    repo.shutdown_dedicated_daemon_for_test();
+    let while_off = raw_commit_all(&repo, "committed while the daemon was down");
+    assert!(working_log_dir(&repo, &base).is_dir());
+    repo.start_dedicated_daemon_with_env_for_test(&fixup_daemon_env(&metrics_db_path));
+
+    // A fresh daemon knows this repository only through the persisted store.
+    let scheduled = repo.request_untraced_fixup_scan_all();
+    assert_eq!(scheduled.get("families").and_then(Value::as_u64), Some(1));
+
+    let mut file = repo.filename("agent.txt");
+    file.assert_committed_lines(lines!["base".unattributed_human(), "ai line".ai()]);
+    assert!(!working_log_dir(&repo, &base).is_dir());
+    assert_eq!(
+        commit_source(&metrics_db_path, &while_off),
+        Some("untraced_fixup")
+    );
+    assert_eq!(health_counter(&repo, "untraced_commits_fixed"), 1);
+}
+
+#[test]
+fn rebase_made_while_the_daemon_was_off_is_not_fixed_up() {
+    let (_metrics_dir, metrics_db_path, mut repo) = fixup_repo();
+    write_file(&repo, "base.txt", "base\n");
+    repo.stage_all_and_commit("traced base")
+        .expect("traced base commit");
+    let main_branch = raw_git(&repo, &["rev-parse", "--abbrev-ref", "HEAD"])
+        .trim()
+        .to_string();
+    repo.git(&["checkout", "-b", "topic"]).unwrap();
+    write_file(&repo, "agent.txt", "");
+    codex_edit(&repo, "agent.txt", "ai line\n", "tool-use-1");
+    let topic_commit = repo
+        .stage_all_and_commit("traced topic commit")
+        .expect("traced topic commit")
+        .commit_sha;
+    repo.git(&["checkout", &main_branch]).unwrap();
+    write_file(&repo, "main.txt", "main moved on\n");
+    repo.stage_all_and_commit("traced main commit")
+        .expect("traced main commit");
+    repo.request_untraced_fixup_scan();
+
+    repo.shutdown_dedicated_daemon_for_test();
+    raw_git(&repo, &["checkout", "topic"]);
+    raw_git(&repo, &["rebase", &main_branch]);
+    let rebased = raw_head(&repo);
+    assert_ne!(rebased, topic_commit);
+    repo.start_dedicated_daemon_with_env_for_test(&fixup_daemon_env(&metrics_db_path));
+
+    repo.request_untraced_fixup_scan_all();
+
+    assert!(repo.read_authorship_note(&rebased).is_none());
+    assert!(repo.read_authorship_note(&topic_commit).is_some());
+    assert!(committed_metrics_for_commit(&metrics_db_path, &rebased).is_empty());
+    assert_eq!(health_counter(&repo, "untraced_commits_fixed"), 0);
+}
+
+#[test]
+fn untraced_commit_in_a_linked_worktree_is_attributed() {
+    let (_metrics_dir, metrics_db_path, repo) = fixup_repo();
+    write_file(&repo, "base.txt", "base\n");
+    repo.stage_all_and_commit("traced base")
+        .expect("traced base commit");
+    let linked = repo.path().parent().expect("temp parent").join(format!(
+        "{}-linked",
+        repo.path().file_name().unwrap().to_string_lossy()
+    ));
+    raw_git(
+        &repo,
+        &[
+            "worktree",
+            "add",
+            "-b",
+            "linked",
+            linked.to_str().expect("utf-8 path"),
+        ],
+    );
+    // Scanning every worktree of the family seeds the linked one too.
+    let scheduled = repo.request_untraced_fixup_scan_all();
+    assert_eq!(scheduled.get("worktrees").and_then(Value::as_u64), Some(2));
+
+    fs::write(linked.join("linked.txt"), "from the linked worktree\n").unwrap();
+    let git_in_linked = |args: &[&str]| {
+        let mut command = std::process::Command::new("git");
+        command.arg("-C").arg(&linked).args(args);
+        for (key, value) in TRACE2_DISABLED_ENV {
+            command.env(key, value);
+        }
+        let output = command.output().expect("git in linked worktree");
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    };
+    git_in_linked(&["add", "-A"]);
+    git_in_linked(&["commit", "-m", "untraced in linked worktree"]);
+    let in_linked = git_in_linked(&["rev-parse", "HEAD"]);
+
+    repo.request_untraced_fixup_scan_all();
+
+    let note = repo
+        .read_authorship_note(&in_linked)
+        .expect("the linked worktree commit has a note");
+    let log = AuthorshipLog::deserialize_from_string(&note).expect("note parses");
+    assert_eq!(log.metadata.base_commit_sha, in_linked);
+    assert!(
+        log.attestations
+            .iter()
+            .flat_map(|attestation| &attestation.entries)
+            .all(|entry| entry.hash == "human" || entry.hash.starts_with("h_")),
+        "a hand-typed line never gets AI attribution: {:?}",
+        log.attestations
+    );
+    assert_eq!(
+        commit_source(&metrics_db_path, &in_linked),
+        Some("untraced_fixup")
     );
     let _ = fs::remove_dir_all(&linked);
 }


### PR DESCRIPTION
## Summary

Persists the repository families this machine's daemon has seen, and each worktree's fixup cursor, so commits made while the daemon was off are attributed after it restarts.

- `src/daemon/repo_family_store.rs`: SQLite at `internal_dir/repo-families-db` (token-usage db pattern; `schema_version` + migrations, fails closed on a newer schema). Tables `repo_families` and `worktree_fixup_cursors` (git dir, worktree path, cursor). Remembered worktree paths are how a `--separate-git-dir` main worktree, which the filesystem gives no pointer to, is still scanned after a restart; a remembered pair is used only while the worktree still resolves to that git dir.
- Written only by the fixup pass: a completed pass records the family and saves its settled cursor in one transaction (a crash can never leave a remembered family without a cursor, which a cold actor would read as a first sighting); `fixup.scan` with no repository scans every family this process knows plus every remembered one, marks families whose common dir is gone, and prunes them after 7 days missing, 90 days unseen, or beyond the 1000 most recently seen.
- A cold actor is seeded from the persisted cursor; the actor's own cursor always wins once it has one.
- After a pass in which a side effect failed, the worktree's durable cursor is no longer advanced for the rest of the daemon lifetime (continuation passes included), so the next lifetime retries from before the failed commit, skipping commits that did get a note.
- Test harness: `shutdown_dedicated_daemon_for_test` / `start_dedicated_daemon_with_env_for_test` split so tests can commit or rebase with the daemon down; `request_untraced_fixup_scan_all`.

## Test plan

- [x] store unit tests: migrate/reopen, newer schema fails closed, seen/missing bookkeeping, refresh-only seen update that never inserts a cursorless family, cursor round-trip with and without anchor, prune by retention and cap
- [x] integration: commit made while the daemon was off is attributed after restart (working log consumed, flagged metric); rebase made while the daemon was off is not fixed up; untraced commit in a linked worktree; `sqlite_connection_policy`
- [x] `task lint`, `task fmt`
