### PR TITLE
feat(daemon): periodic untraced commit fixup worker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,7 @@ Signal forwarding: On Unix, the git proxy installs signal handlers (SIGTERM, SIG
 
 `Config` is a global `OnceLock` singleton accessed via `Config::get()`. It reads from `~/.git-ai/config.json`. In tests, `GIT_AI_TEST_CONFIG_PATCH` env var allows overriding specific config fields without a real config file. Feature flags follow precedence: environment vars (`GIT_AI_*` prefix via `envy`) > config file > defaults.
 
-Feature flags have separate debug/release defaults defined via the `define_feature_flags!` macro in `src/feature_flags.rs`. Currently: `auth_keyring` (false/false), `transcript_streaming` (true/true), `transcript_sweep` (true/true), `checkpoint_debug_log` (false/false), `daemon_log_upload` (true/true).
+Feature flags have separate debug/release defaults defined via the `define_feature_flags!` macro in `src/feature_flags.rs`. Currently: `auth_keyring` (false/false), `transcript_streaming` (true/true), `transcript_sweep` (true/true), `checkpoint_debug_log` (false/false), `daemon_log_upload` (true/true), `untraced_commit_fixup` (true/true).
 
 ### Error handling
 

--- a/docs/daemon-trace2-ingestion-spec.md
+++ b/docs/daemon-trace2-ingestion-spec.md
@@ -188,6 +188,10 @@ so no cursor predates the first traced command.
 - Special case: first traced command whose argv contains sufficient immutable
   OIDs (e.g. `merge --squash <sha>`) is exact even cold.
 
+Commits that never produce a traced command at all (daemon off, JGit/libgit2
+clients, sandboxes) are handled separately, from their reflog records, by the
+untraced commit fixup — see `docs/untraced-commit-fixup-spec.md`.
+
 ## Operation-specific ownership notes
 
 - **commit / amend**: expected HEAD transition with `commit`/`commit (amend):`

--- a/docs/untraced-commit-fixup-spec.md
+++ b/docs/untraced-commit-fixup-spec.md
@@ -1,0 +1,144 @@
+# Untraced Commit Fixup Spec
+
+Status: authoritative spec for how the git-ai daemon attributes commits it never
+saw through trace2. Companion docs:
+
+- `docs/daemon-trace2-ingestion-spec.md` — the traced path this is a fallback to.
+- `docs/rewrite-ops-spec.md` — why rewrites are out of scope here.
+
+## The problem
+
+Attribution runs in the daemon, driven by trace2. Three situations produce
+commits that never reach it:
+
+- the daemon was off (upgrade, crash, reboot);
+- the git client emits no trace2 (JGit / IntelliJ, libgit2-based tools);
+- trace2 is emitted but cannot reach the daemon socket (sandboxes; the daemon
+  also refuses to start inside Cursor/Claude/Codex sandboxes).
+
+Those commits got no authorship note and no `Committed` telemetry, even when
+working logs existed for them. Since the checkpoint CLI exits quietly when the
+daemon is unreachable, daemon-off periods usually have no working logs either;
+attribution recovery (`src/authorship/attribution_recovery.rs`) is then the
+main evidence.
+
+## Ownership model
+
+The per-worktree `HEAD` reflog is written only for operations performed in
+that worktree, with a tool-generated message:
+
+| reflog message prefix | meaning | fixup |
+|---|---|---|
+| `commit:`, `commit (initial):`, `commit (merge):` | a new commit created here | candidate |
+| `commit (amend):` | rewrite | skip |
+| `rebase*`, `pull*`, `cherry-pick:`, `revert:`, `merge *:`, `reset:`, `checkout:`, `am:`, anything else | rewrite, replay, or remote content | skip |
+
+A candidate must be **corroborated by the branch reflog**: the identical
+`old new … message` record in `<common_dir>/logs/refs/heads/<branch>`. Git writes
+both records for a commit on a checked-out branch and only `HEAD`'s for a
+detached commit, including a manual `git commit` inside a stopped rebase. This
+excludes rebase replays structurally; pulled commits never produce `commit:`
+records at all. Detached-HEAD commits are skipped (fail closed).
+
+**Exclusive ownership.** A reflog record has exactly one owner. Records a
+traced command consumed are skipped by the fixup; records the fixup claims are
+consumed the same way, so a late trace2 command cannot claim them again. All
+decisions happen inside the family actor, in sequence
+(`RefCursor::claim_untraced_commits`).
+
+**One cursor owner.** The actor keeps a per-worktree fixup cursor (byte offset
+plus the anchoring record), separate from the traced in-order cursor so that
+settling past records nobody owns (a rebase still open in an editor) never
+hides them from the command that eventually completes. The repo-family store
+persists a snapshot of it and seeds a cold actor.
+
+## No backfill
+
+The cursor starts at the actor's own fixup position, else at the persisted
+seed from an earlier daemon lifetime, else at the traced cursor's observation
+point (its in-order offset, or the newest record it consumed while cold), else
+at the reflog end. A cursor that no longer matches the reflog (offset beyond
+EOF, anchor mismatch after `reflog expire`) is re-seeded at the end. Only
+records appended after a valid cursor are ever considered. "Known repo" means:
+a cursor from before the missed commit exists.
+
+Ownership is decided from what traced commands actually consumed: records
+still in the consumed set, and byte ranges the traced cursor compacted or
+jumped over while consuming. The traced in-order offset alone is not
+ownership — a cold seed from an ingress capture deliberately jumps over prior
+untraced history, which is exactly what the fixup exists to claim.
+
+## Non-interference invariants
+
+1. Nothing is added to trace ingestion, checkpoint admission, or the
+   normalizer. The worker reads two counters and skips its tick while trace
+   frames are still queued, and leaves a family alone while one of its git
+   commands is still running (an open mutating trace root), so a scan never
+   sits fenced at the head of that family's sequencer.
+2. A fixup pass is a family sequencer entry appended at the current time: the
+   causal fence holds it behind older open roots, and the per-family exec lock
+   serializes it with commands and checkpoints.
+3. Records younger than `GIT_AI_DAEMON_UNTRACED_FIXUP_MIN_AGE_MS` (5 s) are left
+   for a later pass.
+4. The fixup never writes the `HEAD` reflog; post-commit writes notes and
+   working logs exactly as the traced path does.
+5. An unchanged reflog costs one `stat` per worktree per tick. No git spawns
+   without a candidate. A pass attributes at most 10 commits and checks their
+   notes in one batch; a tick schedules at most 32 worktrees.
+6. Fail closed: invalid cursor, missing reflog, bare repository, detached HEAD,
+   unknown message shape — skip and settle, never guess.
+
+## What runs
+
+- **Claim** (`src/daemon/ref_cursor.rs`, `src/daemon/family_actor.rs`): claimed
+  records become synthetic `git commit` commands with exact `ref_changes`
+  (HEAD and branch), reduced through the normal reducer so the analyzers emit
+  `CommitCreated` and `FamilyState` stays current.
+- **Pass** (`src/daemon.rs`, `FamilySequencerEntry::UntracedCommitScan`): the
+  normal side-effect dispatch runs for each claimed commit — working logs are
+  consumed and carried forward, recovery fills holes, the note is written, and
+  the `Committed` metric carries `commit_source = untraced_fixup` (position 18;
+  null for traced commits). Commits that already have a note are skipped.
+  Synthetic commits are never `sync_tracked` in the test completion log.
+- **Store** (`src/daemon/repo_family_store.rs`): families and per-worktree
+  cursors, written only by the fixup. Families whose common dir is missing for
+  7 days, unseen for 90 days, or beyond the 1000 most recent are pruned.
+- **Worker** (`src/daemon/untraced_commit_fixup.rs`): every
+  `GIT_AI_DAEMON_UNTRACED_FIXUP_INTERVAL_MS` (10 s; first tick at startup),
+  gated by the `untraced_commit_fixup` feature flag. `fixup.scan` on the control
+  socket runs a round on demand, regardless of the flag.
+- **Health**: `untraced_commits_fixed`, `untraced_commits_skipped`,
+  `untraced_cursor_reseeds`, `untraced_scan_errors`, `known_repo_families` in
+  `status.daemon`, `git-ai bg status`, and the heartbeat.
+
+## Known limitations
+
+- Detached-HEAD commits are never fixed up.
+- libgit2 callers may write arbitrary or empty reflog messages; those are skipped.
+- Rewrites made untraced (amend, rebase, cherry-pick, revert) are never
+  migrated; the replacement commits get no notes.
+- A pass runs later than the commit, so time-window recovery solvers (bash
+  mtime, session events) only apply while the committed files are unchanged
+  in the worktree; commit-metadata and working-log evidence always apply.
+- Checkpoints that reach the daemon between an untraced commit and its fixup
+  pass are keyed by the new HEAD without the `INITIAL` attribution the pass
+  writes later; for a file already checkpointed in that window, leftover
+  uncommitted AI lines are not carried into the next commit. The traced path
+  is not exposed to this because its post-commit runs before later
+  checkpoints; the untraced window is `interval + min age` (about 15 s).
+- Corroboration reads each branch reflog's tail (1 MiB) and falls back to the
+  whole file once per pass, within a 16 MiB budget of branch reflog bytes per
+  pass; a candidate whose corroboration would exceed the budget is skipped,
+  never claimed. A pass walks at most 4 MiB of `HEAD` reflog before handing
+  the rest to a follow-up pass.
+
+## Test obligations
+
+`tests/integration/untraced_commit_fixup.rs` covers: attribution from a
+delivered working log and from recovery alone; daemon-off commit after
+restart; untraced amend, rebase (daemon on and off), pull, and detached commit
+skipped; no backfill on first sighting; exactly-once (one note, one metric,
+traced commits never reclaimed); linked worktrees; the periodic and startup
+scans; the feature flag. Unit tests live in `src/daemon/ref_cursor.rs`
+(claim), `src/daemon/family_actor.rs`, `src/daemon/repo_family_store.rs`, and
+`src/git/repo_state.rs` (worktree enumeration).

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -2,7 +2,10 @@ use crate::authorship::authorship_log_serialization::AuthorshipLog;
 use crate::checkpoint_content_budget::CheckpointContentBudget;
 use crate::config;
 use crate::daemon::git_backend::GitBackend;
-use crate::daemon::ref_cursor::{UntracedClaimRequest, UntracedReflogCursor, is_untraced_root_sid};
+use crate::daemon::ref_cursor::{
+    HeadReflogObservation, UntracedClaimRequest, UntracedReflogCursor, head_reflog_unchanged_since,
+    is_untraced_root_sid, observe_head_reflog,
+};
 use crate::error::GitAiError;
 use crate::git::cli_parser::{
     ParsedGitInvocation, explicit_rebase_branch_arg, parse_git_cli_args, summarize_rebase_args,
@@ -80,6 +83,7 @@ pub mod test_sync;
 pub mod token_usage_worker;
 pub mod trace_normalizer;
 pub mod transcript_redaction;
+pub mod untraced_commit_fixup;
 
 pub use control_api::{
     BashSessionQueryResponse, BashSnapshotQueryResponse, ControlRequest, ControlResponse,
@@ -2739,11 +2743,40 @@ enum FamilySequencerEntry {
     },
 }
 
-/// Worktrees whose fixup pass a `fixup.scan` request scheduled.
-#[derive(Debug, Clone, Serialize)]
-struct UntracedScanSchedule {
+/// What one round of untraced-commit fixup scheduling did.
+#[derive(Debug, Clone, Default, Serialize)]
+pub(crate) struct UntracedScanSchedule {
+    /// Families with at least one pass scheduled.
     families: usize,
+    /// Worktrees a pass was scheduled for.
     worktrees: usize,
+    /// Worktrees whose `HEAD` reflog has not grown since their cursor settled.
+    unchanged: usize,
+    /// Changed worktrees left for the next tick: by the per-tick cap, or
+    /// because a git command of their family was still running.
+    deferred: usize,
+}
+
+/// What the daemon remembers about one worktree between fixup ticks.
+#[derive(Debug, Clone, Default)]
+struct CachedUntracedCursor {
+    /// `None` when the store has no row for the worktree yet.
+    cursor: Option<UntracedReflogCursor>,
+    /// The `HEAD` reflog as it looked when the last pass finished (`None`
+    /// until a pass has run; `Some(None)` when there was no reflog then).
+    reflog_seen: Option<HeadReflogObservation>,
+}
+
+/// Why fixup scans are being scheduled; a tick stats before it schedules,
+/// an explicit request scans regardless.
+#[derive(Debug, Clone, Copy)]
+enum UntracedScanTrigger {
+    Request,
+    Tick {
+        rotation: u64,
+        /// Hourly: prune the store and re-probe families last seen missing.
+        maintenance: bool,
+    },
 }
 
 /// Position of an entry in its family sequencer: the moment its originating
@@ -3020,6 +3053,23 @@ pub struct ActorDaemonCoordinator {
     untraced_commits_skipped: AtomicU64,
     untraced_cursor_reseeds: AtomicU64,
     untraced_scan_errors: AtomicU64,
+    /// Families remembered in the repo-family store, as of the last tick.
+    known_repo_families: AtomicU64,
+    /// Ticks so far; rotates which worktrees a capped tick scans first.
+    untraced_fixup_ticks: AtomicU64,
+    /// When the repo-family store was last pruned and missing families last
+    /// re-probed (unix seconds).
+    untraced_store_last_maintenance_secs: AtomicU64,
+    /// Per worktree git dir, the fixup cursor last read from or written to the
+    /// store and how the `HEAD` reflog looked when the last pass finished, so
+    /// a routine tick never touches SQLite: its cost is one `stat` per worktree.
+    untraced_cursor_cache: Mutex<HashMap<String, CachedUntracedCursor>>,
+    /// Families remembered in the store as of the last maintenance round,
+    /// plus those recorded by passes since; `None` before the first round.
+    untraced_known_families: Mutex<Option<Vec<String>>>,
+    /// Families whose common dir was found missing since the last maintenance
+    /// round; routine ticks neither probe nor record them again.
+    untraced_missing_families: Mutex<HashSet<String>>,
     /// Fired when a root clears or is released: fenced drains and waits
     /// re-evaluate. Distinct from the per-frame ingest progress notify so a
     /// fenced family does not wake on every trace frame the daemon sees.
@@ -3062,6 +3112,7 @@ pub struct ActorDaemonCoordinator {
     // Separate from the transcript worker's Notify: notify_one wakes exactly
     // one waiter, so each worker needs its own.
     token_usage_shutdown_notify: std::sync::OnceLock<Arc<tokio::sync::Notify>>,
+    untraced_fixup_shutdown_notify: std::sync::OnceLock<Arc<tokio::sync::Notify>>,
     streams_db: Option<Arc<crate::streams::db::StreamsDatabase>>,
     next_trace_ingest_seq: AtomicUsize,
     queued_trace_payloads: AtomicUsize,
@@ -3171,6 +3222,12 @@ impl ActorDaemonCoordinator {
             untraced_commits_skipped: AtomicU64::new(0),
             untraced_cursor_reseeds: AtomicU64::new(0),
             untraced_scan_errors: AtomicU64::new(0),
+            known_repo_families: AtomicU64::new(0),
+            untraced_fixup_ticks: AtomicU64::new(0),
+            untraced_store_last_maintenance_secs: AtomicU64::new(0),
+            untraced_cursor_cache: Mutex::new(HashMap::new()),
+            untraced_known_families: Mutex::new(None),
+            untraced_missing_families: Mutex::new(HashSet::new()),
             trace_root_fence_notify: Notify::new(),
             commit_file_timestamp_snapshots_by_root: Mutex::new(HashMap::new()),
             recent_replay_prerequisites_by_family: Mutex::new(HashMap::new()),
@@ -3209,6 +3266,7 @@ impl ActorDaemonCoordinator {
             token_usage_worker: None,
             transcript_shutdown_notify: std::sync::OnceLock::new(),
             token_usage_shutdown_notify: std::sync::OnceLock::new(),
+            untraced_fixup_shutdown_notify: std::sync::OnceLock::new(),
             streams_db: None,
             next_trace_ingest_seq: AtomicUsize::new(0),
             queued_trace_payloads: AtomicUsize::new(0),
@@ -3527,6 +3585,9 @@ impl ActorDaemonCoordinator {
         }
         if let Some(token_usage_shutdown) = self.token_usage_shutdown_notify.get() {
             token_usage_shutdown.notify_one();
+        }
+        if let Some(untraced_fixup_shutdown) = self.untraced_fixup_shutdown_notify.get() {
+            untraced_fixup_shutdown.notify_one();
         }
         // Hold the condvar mutex so notify_all cannot race with the
         // check-then-wait sequence in daemon_update_check_loop.
@@ -4210,6 +4271,22 @@ impl ActorDaemonCoordinator {
         .ok()
         .flatten()
         .is_some()
+    }
+
+    /// Whether a trace root that may still change `family`'s refs is open: one
+    /// of its git commands is in flight (or a root not yet attributed to any
+    /// family, which fails closed). Routine fixup ticks leave such a family
+    /// for a later tick, so a scan never waits at the causal fence at the head
+    /// of the family's sequencer with the command's own entries queued behind.
+    fn family_has_open_mutating_root(&self, family: &str) -> Result<bool, GitAiError> {
+        let ingress = self
+            .trace_ingress_state
+            .lock()
+            .map_err(|_| GitAiError::Generic("trace ingress state lock poisoned".to_string()))?;
+        Ok(ingress
+            .root_open_connections
+            .keys()
+            .any(|root_sid| Self::open_root_may_mutate_family(&ingress, root_sid, Some(family))))
     }
 
     /// Whether a sequencer entry positioned at `started_at_ns`, ready for
@@ -5550,11 +5627,61 @@ impl ActorDaemonCoordinator {
         Ok(all_side_effects_succeeded.then_some(outcome.cursor))
     }
 
+    /// One periodic fixup tick: every known worktree whose `HEAD` reflog grew
+    /// since its cursor settled gets a pass, at most
+    /// `UNTRACED_FIXUP_MAX_SCANS_PER_TICK` of them (rotating). Skipped
+    /// entirely while trace frames are still queued, so a pass never runs
+    /// ahead of the commands those frames describe.
+    pub(crate) async fn run_untraced_fixup_tick(
+        self: &Arc<Self>,
+    ) -> Result<UntracedScanSchedule, GitAiError> {
+        let ingest_lag = self
+            .next_trace_ingest_seq
+            .load(Ordering::Acquire)
+            .saturating_sub(self.processed_trace_ingest_seq.load(Ordering::Acquire));
+        if self.queued_trace_payloads.load(Ordering::Acquire) > 0 || ingest_lag > 0 {
+            return Ok(UntracedScanSchedule::default());
+        }
+        let tick = self.untraced_fixup_ticks.fetch_add(1, Ordering::Relaxed);
+        let now_secs = crate::utils::unix_timestamp_now();
+        let last_maintenance = self
+            .untraced_store_last_maintenance_secs
+            .load(Ordering::Relaxed);
+        let maintenance = now_secs.saturating_sub(last_maintenance)
+            >= UNTRACED_STORE_MAINTENANCE_INTERVAL.as_secs();
+        if maintenance {
+            self.untraced_store_last_maintenance_secs
+                .store(now_secs, Ordering::Relaxed);
+        }
+        let schedule = self
+            .schedule_untraced_commit_scans(
+                None,
+                UntracedScanTrigger::Tick {
+                    rotation: tick,
+                    maintenance,
+                },
+            )
+            .await?;
+        if maintenance
+            && let Some(count) = self
+                .with_repo_family_store(move |store| {
+                    store.prune(now_secs)?;
+                    store.family_count()
+                })
+                .await?
+        {
+            self.known_repo_families
+                .store(count as u64, Ordering::Relaxed);
+        }
+        Ok(schedule)
+    }
+
     /// Schedules one fixup pass per worktree of the given repository (or of
     /// every family this daemon knows) and returns how many were scheduled.
     async fn schedule_untraced_commit_scans(
         self: &Arc<Self>,
         repo_working_dir: Option<String>,
+        trigger: UntracedScanTrigger,
     ) -> Result<UntracedScanSchedule, GitAiError> {
         let now_secs = crate::utils::unix_timestamp_now();
         let mut targets = Vec::new();
@@ -5577,27 +5704,68 @@ impl ActorDaemonCoordinator {
             }
             None => {
                 // Families this process has heard from, plus those remembered
-                // from earlier daemon lifetimes.
+                // from earlier daemon lifetimes. Routine ticks work from an
+                // in-memory copy of the remembered list and skip families
+                // already found missing; a maintenance round (hourly, and any
+                // explicit request) re-reads the store, re-probes missing
+                // families and refreshes `last_seen_at` for the present ones so
+                // an idle-but-present repository is never pruned as unseen.
+                let maintenance = !matches!(
+                    trigger,
+                    UntracedScanTrigger::Tick {
+                        maintenance: false,
+                        ..
+                    }
+                );
                 let mut families = self.coordinator.family_keys().await;
-                let remembered = self
-                    .with_repo_family_store(move |store| {
-                        store.prune(now_secs)?;
-                        store.known_families()
-                    })
-                    .await?
-                    .unwrap_or_default();
-                families.extend(remembered);
+                families.extend(self.remembered_families(maintenance).await?);
                 families.sort();
                 families.dedup();
+                if let UntracedScanTrigger::Tick {
+                    rotation,
+                    maintenance: false,
+                } = trigger
+                    && families.len() > UNTRACED_FIXUP_MAX_FAMILIES_PER_TICK
+                {
+                    // A routine tick looks at a rotating window of families so
+                    // its filesystem work stays bounded however many the daemon
+                    // has heard of; every family comes up within a few ticks. A
+                    // maintenance round (hourly) looks at all of them, so every
+                    // present family is marked seen before pruning runs.
+                    let start =
+                        (rotation as usize * UNTRACED_FIXUP_MAX_FAMILIES_PER_TICK) % families.len();
+                    families.rotate_left(start);
+                    families.truncate(UNTRACED_FIXUP_MAX_FAMILIES_PER_TICK);
+                }
+                let known_missing = if maintenance {
+                    self.lock_untraced_missing_families()?.clear();
+                    HashSet::new()
+                } else {
+                    self.lock_untraced_missing_families()?.clone()
+                };
                 for family in families {
+                    if known_missing.contains(&family) {
+                        continue;
+                    }
                     let common_dir = Path::new(&family);
                     if !common_dir.is_dir() {
-                        let family = family.clone();
+                        self.lock_untraced_missing_families()?
+                            .insert(family.clone());
                         self.with_repo_family_store(move |store| {
                             store.record_family_missing(&family, now_secs)
                         })
                         .await?;
                         continue;
+                    }
+                    // Present families the store already remembers stay
+                    // fresh; a family is first remembered only by a completed
+                    // pass, together with its cursor.
+                    if maintenance {
+                        let family = family.clone();
+                        self.with_repo_family_store(move |store| {
+                            store.refresh_family_seen(&family, now_secs)
+                        })
+                        .await?;
                     }
                     for (git_dir, worktree) in self.family_worktrees(&family).await? {
                         targets.push((family.clone(), git_dir, worktree));
@@ -5605,21 +5773,54 @@ impl ActorDaemonCoordinator {
                 }
             }
         }
+        if let UntracedScanTrigger::Tick { rotation, .. } = trigger
+            && !targets.is_empty()
+        {
+            // Later worktrees are not starved when more than a tick's worth
+            // of them changed at once.
+            let len = targets.len();
+            targets.rotate_left((rotation as usize) % len);
+        }
+        let mut schedule = UntracedScanSchedule::default();
         let mut families = HashSet::new();
-        let mut worktrees = 0;
         for (family, git_dir, worktree) in targets {
             if self.family_has_pending_untraced_scan(&family, &git_dir)? {
                 continue;
             }
             let max_offset = head_reflog_len(&git_dir);
-            // A completed pass records the family and its cursor; scheduling
-            // only reads the persisted cursor a cold actor should resume from.
-            let seed = {
-                let git_dir_key = git_dir.to_string_lossy().to_string();
-                self.with_repo_family_store(move |store| store.cursor(&git_dir_key))
-                    .await?
-                    .flatten()
+            // A pass that runs records the family and its cursor when it
+            // completes; ticks only read, and only the first time they see a
+            // worktree (the cache mirrors every later write).
+            let git_dir_key = git_dir.to_string_lossy().to_string();
+            let cached = match self.cached_untraced_cursor(&git_dir_key) {
+                Some(cached) => cached,
+                None => {
+                    let key = git_dir_key.clone();
+                    let cached = CachedUntracedCursor {
+                        cursor: self
+                            .with_repo_family_store(move |store| store.cursor(&key))
+                            .await?
+                            .flatten(),
+                        reflog_seen: None,
+                    };
+                    self.cache_untraced_cursor(&git_dir_key, cached.clone());
+                    cached
+                }
             };
+            let seed = cached.cursor;
+            if matches!(trigger, UntracedScanTrigger::Tick { .. }) {
+                if head_reflog_unchanged_since(&git_dir, seed.as_ref(), cached.reflog_seen.as_ref())
+                {
+                    schedule.unchanged += 1;
+                    continue;
+                }
+                if schedule.worktrees >= UNTRACED_FIXUP_MAX_SCANS_PER_TICK
+                    || self.family_has_open_mutating_root(&family)?
+                {
+                    schedule.deferred += 1;
+                    continue;
+                }
+            }
             self.append_family_sequencer_entry(
                 &family,
                 now_unix_nanos(),
@@ -5630,15 +5831,59 @@ impl ActorDaemonCoordinator {
                     max_offset,
                 },
             )?;
-            worktrees += 1;
+            schedule.worktrees += 1;
             if families.insert(family.clone()) {
                 self.schedule_family_drain(family);
             }
         }
-        Ok(UntracedScanSchedule {
-            families: families.len(),
-            worktrees,
-        })
+        schedule.families = families.len();
+        Ok(schedule)
+    }
+
+    /// Families remembered in the store: re-read on a maintenance round (and
+    /// then including families last seen missing), otherwise the copy taken at
+    /// the last round plus every family a pass has recorded since.
+    async fn remembered_families(&self, maintenance: bool) -> Result<Vec<String>, GitAiError> {
+        if !maintenance && let Some(cached) = self.lock_untraced_known_families()?.clone() {
+            return Ok(cached);
+        }
+        let remembered = self
+            .with_repo_family_store(move |store| store.known_families(maintenance))
+            .await?
+            .unwrap_or_default();
+        *self.lock_untraced_known_families()? = Some(remembered.clone());
+        Ok(remembered)
+    }
+
+    fn lock_untraced_known_families(
+        &self,
+    ) -> Result<std::sync::MutexGuard<'_, Option<Vec<String>>>, GitAiError> {
+        self.untraced_known_families
+            .lock()
+            .map_err(|_| GitAiError::Generic("untraced known families lock poisoned".to_string()))
+    }
+
+    fn lock_untraced_missing_families(
+        &self,
+    ) -> Result<std::sync::MutexGuard<'_, HashSet<String>>, GitAiError> {
+        self.untraced_missing_families
+            .lock()
+            .map_err(|_| GitAiError::Generic("untraced missing families lock poisoned".to_string()))
+    }
+
+    /// `Some` when this worktree's persisted cursor has been read or written
+    /// since the daemon started.
+    fn cached_untraced_cursor(&self, git_dir_key: &str) -> Option<CachedUntracedCursor> {
+        self.untraced_cursor_cache
+            .lock()
+            .ok()
+            .and_then(|cache| cache.get(git_dir_key).cloned())
+    }
+
+    fn cache_untraced_cursor(&self, git_dir_key: &str, cached: CachedUntracedCursor) {
+        if let Ok(mut cache) = self.untraced_cursor_cache.lock() {
+            cache.insert(git_dir_key.to_string(), cached);
+        }
     }
 
     /// Whether a fixup pass for this worktree is already queued (a pass held
@@ -5963,23 +6208,54 @@ impl ActorDaemonCoordinator {
                     let persisted = match scan {
                         Ok(Some(cursor)) if !self.untraced_persistence_blocked(&git_dir_key)? => {
                             let family = family.to_string();
-                            self.with_repo_family_store(move |store| {
-                                store.record_pass_completed(
-                                    &family,
-                                    &git_dir_key,
-                                    &worktree_key,
-                                    &cursor,
-                                    crate::utils::unix_timestamp_now(),
-                                )
+                            self.cache_untraced_cursor(
+                                &git_dir_key,
+                                CachedUntracedCursor {
+                                    cursor: Some(cursor.clone()),
+                                    reflog_seen: Some(observe_head_reflog(Path::new(&git_dir_key))),
+                                },
+                            );
+                            if let Ok(mut known) = self.untraced_known_families.lock()
+                                && let Some(known) = known.as_mut()
+                                && !known.contains(&family)
+                            {
+                                known.push(family.clone());
+                            }
+                            let known = self
+                                .with_repo_family_store(move |store| {
+                                    store.record_pass_completed(
+                                        &family,
+                                        &git_dir_key,
+                                        &worktree_key,
+                                        &cursor,
+                                        crate::utils::unix_timestamp_now(),
+                                    )?;
+                                    store.family_count()
+                                })
+                                .await;
+                            known.map(|count| {
+                                if let Some(count) = count {
+                                    self.known_repo_families
+                                        .store(count as u64, Ordering::Relaxed);
+                                }
                             })
-                            .await
-                            .map(|_| ())
                         }
                         // A side effect failed in this or an earlier pass: the
                         // durable cursor stays behind that commit for the rest
                         // of this daemon lifetime, so the next one retries it
                         // (commits that did get their note are skipped then).
-                        Ok(Some(_)) => Ok(()),
+                        // The in-memory position still moves so ticks keep
+                        // gating on it.
+                        Ok(Some(cursor)) => {
+                            self.cache_untraced_cursor(
+                                &git_dir_key,
+                                CachedUntracedCursor {
+                                    cursor: Some(cursor),
+                                    reflog_seen: Some(observe_head_reflog(Path::new(&git_dir_key))),
+                                },
+                            );
+                            Ok(())
+                        }
                         Ok(None) => self.lock_untraced_persistence_blocked().map(|mut blocked| {
                             blocked.insert(git_dir_key);
                         }),
@@ -8299,7 +8575,7 @@ impl ActorDaemonCoordinator {
                 .map(|v| ControlResponse::ok(None, Some(v)))
                 .map_err(GitAiError::from),
             ControlRequest::UntracedFixupScan { repo_working_dir } => self
-                .schedule_untraced_commit_scans(repo_working_dir)
+                .schedule_untraced_commit_scans(repo_working_dir, UntracedScanTrigger::Request)
                 .await
                 .and_then(|scheduled| {
                     serde_json::to_value(scheduled)
@@ -9726,6 +10002,25 @@ const UNTRACED_FIXUP_MIN_AGE: Duration = Duration::from_secs(5);
 /// family; the rest wait for the next pass.
 const UNTRACED_FIXUP_MAX_COMMITS_PER_PASS: usize = 10;
 
+/// Worktrees one periodic tick schedules passes for; more change than this
+/// only during a burst, and the rest follow next tick.
+const UNTRACED_FIXUP_MAX_SCANS_PER_TICK: usize = 32;
+
+/// Families one periodic tick examines (a directory listing and a `stat` per
+/// worktree each); with more, ticks rotate through them.
+const UNTRACED_FIXUP_MAX_FAMILIES_PER_TICK: usize = 256;
+
+/// How often a tick prunes the repo-family store and re-probes families whose
+/// common dir was missing (retention is measured in days, so hourly is plenty).
+const UNTRACED_STORE_MAINTENANCE_INTERVAL: Duration = Duration::from_secs(60 * 60);
+
+fn untraced_fixup_interval() -> Duration {
+    env_duration_ms(
+        "GIT_AI_DAEMON_UNTRACED_FIXUP_INTERVAL_MS",
+        crate::daemon::untraced_commit_fixup::DEFAULT_INTERVAL,
+    )
+}
+
 fn untraced_fixup_min_age() -> Duration {
     // Zero is meaningful here (tests claim records at once), unlike the
     // positive-only overrides `env_duration_ms` accepts.
@@ -10449,6 +10744,20 @@ pub(crate) async fn run_daemon(config: DaemonConfig) -> Result<DaemonExitAction,
     }));
     coordinator.start_trace_ingest_worker()?;
     coordinator.start_checkpoint_ingress_worker()?;
+    if config::Config::get()
+        .get_feature_flags()
+        .untraced_commit_fixup
+    {
+        let untraced_fixup_shutdown_notify = Arc::new(tokio::sync::Notify::new());
+        let _ = coordinator
+            .untraced_fixup_shutdown_notify
+            .set(untraced_fixup_shutdown_notify.clone());
+        crate::daemon::untraced_commit_fixup::spawn_untraced_fixup_worker(
+            Arc::downgrade(&coordinator),
+            untraced_fixup_interval(),
+            untraced_fixup_shutdown_notify,
+        );
+    }
     if let Some(limit_mb) = config::Config::get().daemon_memory_limit_mb()
         && let Some(limit_bytes) = limit_mb.checked_mul(config::MEBIBYTE_BYTES)
     {
@@ -12489,6 +12798,56 @@ mod tests {
         )
         .await
         .expect("own family fence should pass once the worker has processed the root's close");
+    }
+
+    #[tokio::test]
+    async fn untraced_fixup_tick_leaves_a_family_alone_while_its_git_command_is_in_flight() {
+        let coord = Arc::new(ActorDaemonCoordinator::new());
+        // Outside the OS temp dir, which the fixup ignores by default.
+        let scratch = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("target")
+            .join("untraced-tick-tests");
+        std::fs::create_dir_all(&scratch).unwrap();
+        let temp = tempfile::tempdir_in(&scratch).unwrap();
+        let repo = temp.path().join("repo");
+        std::fs::create_dir_all(repo.join(".git")).unwrap();
+        std::fs::write(repo.join(".git").join("HEAD"), "ref: refs/heads/main\n").unwrap();
+        coord
+            .status_for_family(repo.to_string_lossy().to_string())
+            .await
+            .unwrap();
+        let family = coord.backend.resolve_family(&repo).unwrap().0;
+        // Not a maintenance round (those re-read the config).
+        coord
+            .untraced_store_last_maintenance_secs
+            .store(crate::utils::unix_timestamp_now(), Ordering::Relaxed);
+
+        // A `git commit` of this family is still running.
+        let sid = "20260411T120000.000000-Psid1";
+        {
+            let mut ingress = coord.trace_ingress_state.lock().unwrap();
+            ingress.root_open_connections.insert(sid.to_string(), 1);
+            ingress.root_mutating.insert(sid.to_string(), true);
+            ingress
+                .root_families
+                .insert(sid.to_string(), family.clone());
+        }
+        let busy = coord.run_untraced_fixup_tick().await.unwrap();
+        assert_eq!(
+            (busy.worktrees, busy.deferred),
+            (0, 1),
+            "a scan must not queue behind an in-flight command: {busy:?}"
+        );
+
+        // Once the command is gone the next tick scans the worktree.
+        {
+            let mut ingress = coord.trace_ingress_state.lock().unwrap();
+            ingress.root_open_connections.remove(sid);
+            ingress.root_mutating.remove(sid);
+            ingress.root_families.remove(sid);
+        }
+        let quiet = coord.run_untraced_fixup_tick().await.unwrap();
+        assert_eq!((quiet.worktrees, quiet.deferred), (1, 0), "{quiet:?}");
     }
 
     #[tokio::test]

--- a/src/daemon/health.rs
+++ b/src/daemon/health.rs
@@ -111,6 +111,8 @@ pub(crate) struct DaemonHealthSnapshot {
     /// Fixup cursors that no longer matched their reflog and restarted at its end.
     pub untraced_cursor_reseeds: u64,
     pub untraced_scan_errors: u64,
+    /// Repository families remembered across restarts (as of the last tick).
+    pub known_repo_families: u64,
     #[serde(flatten)]
     pub losses: IngestLossSnapshot,
     pub families: Vec<FamilyHealth>,
@@ -343,6 +345,7 @@ impl DaemonHealthSnapshot {
             untraced_commits_skipped: coordinator.untraced_commits_skipped.load(Ordering::Relaxed),
             untraced_cursor_reseeds: coordinator.untraced_cursor_reseeds.load(Ordering::Relaxed),
             untraced_scan_errors: coordinator.untraced_scan_errors.load(Ordering::Relaxed),
+            known_repo_families: coordinator.known_repo_families.load(Ordering::Relaxed),
             losses: IngestLossSnapshot::capture(coordinator),
             families,
         }
@@ -520,6 +523,7 @@ mod tests {
             untraced_commits_skipped: 0,
             untraced_cursor_reseeds: 0,
             untraced_scan_errors: 0,
+            known_repo_families: 0,
             losses: IngestLossSnapshot::default(),
             families,
         }

--- a/src/daemon/ref_cursor.rs
+++ b/src/daemon/ref_cursor.rs
@@ -186,6 +186,41 @@ pub fn is_untraced_root_sid(root_sid: &str) -> bool {
     root_sid.starts_with(UNTRACED_ROOT_SID_PREFIX)
 }
 
+/// What one `stat` of a worktree `HEAD` reflog showed: its length and
+/// modification time, or `None` when the worktree kept no reflog then.
+pub type HeadReflogObservation = Option<(u64, std::time::SystemTime)>;
+
+pub fn observe_head_reflog(git_dir: &Path) -> HeadReflogObservation {
+    let metadata = fs::metadata(git_dir.join("logs").join("HEAD")).ok()?;
+    // A filesystem without modification times still yields a length-based
+    // observation; it must never look like "no reflog".
+    Some((
+        metadata.len(),
+        metadata
+            .modified()
+            .unwrap_or(std::time::SystemTime::UNIX_EPOCH),
+    ))
+}
+
+/// Whether a worktree `HEAD` reflog is exactly as a fixup pass last left it:
+/// one `stat`, no read. The file must look as it did at `last_seen` (still
+/// absent, or same length and modification time) and its length must still be
+/// the settled cursor, so a rewrite that happens to keep the length (an
+/// expire followed by new records) is not mistaken for "nothing new". Without
+/// a cursor, or without a previous observation, nothing is known and the
+/// worktree is not "unchanged".
+pub fn head_reflog_unchanged_since(
+    git_dir: &Path,
+    cursor: Option<&UntracedReflogCursor>,
+    last_seen: Option<&HeadReflogObservation>,
+) -> bool {
+    let (Some(cursor), Some(last_seen)) = (cursor, last_seen) else {
+        return false;
+    };
+    let now = observe_head_reflog(git_dir);
+    now == *last_seen && now.is_none_or(|(len, _)| len == cursor.offset)
+}
+
 const CHERRY_PICK_REFLOG_PREFIXES: &[&str] = &["cherry-pick:", "commit (cherry-pick):"];
 
 enum ColdSeedMatchSpec {
@@ -7407,6 +7442,67 @@ mod tests {
             head_ref_changes(&second.commands),
             vec![(C.to_string(), D.to_string())]
         );
+    }
+
+    #[test]
+    fn head_reflog_unchanged_since_needs_the_same_observation_and_settled_length() {
+        let temp = tempfile::tempdir().unwrap();
+        let worktree = temp.path().join("repo");
+        let git_dir = create_git_dir(&worktree);
+        let empty = UntracedReflogCursor {
+            offset: 0,
+            anchor: None,
+        };
+        assert!(!head_reflog_unchanged_since(&git_dir, None, None));
+        assert!(
+            !head_reflog_unchanged_since(&git_dir, Some(&empty), None),
+            "without a previous observation nothing is known"
+        );
+        let seen_missing = observe_head_reflog(&git_dir);
+        assert!(seen_missing.is_none());
+        assert!(
+            head_reflog_unchanged_since(&git_dir, Some(&empty), Some(&seen_missing)),
+            "a worktree still without a reflog has nothing new"
+        );
+
+        extend_branch_commit(&git_dir, "refs/heads/main", A, B, 10, "commit: base");
+        assert!(!head_reflog_unchanged_since(
+            &git_dir,
+            Some(&empty),
+            Some(&seen_missing)
+        ));
+        let mut cursor = RefCursor::new(FamilyKey::new(git_dir.to_string_lossy().to_string()));
+        let settled = cursor
+            .claim_untraced_commits(&untraced_request(&git_dir, &worktree))
+            .unwrap()
+            .cursor;
+        let seen = observe_head_reflog(&git_dir);
+        assert!(head_reflog_unchanged_since(
+            &git_dir,
+            Some(&settled),
+            Some(&seen)
+        ));
+
+        // Same length, different content: an expire that rewrote the log.
+        let path = git_dir.join("logs/HEAD");
+        let original = fs::read_to_string(&path).unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        fs::write(&path, original.replace(A, C)).unwrap();
+        assert_eq!(fs::metadata(&path).unwrap().len(), settled.offset);
+        if observe_head_reflog(&git_dir) != seen {
+            assert!(!head_reflog_unchanged_since(
+                &git_dir,
+                Some(&settled),
+                Some(&seen)
+            ));
+        }
+
+        extend_branch_commit(&git_dir, "refs/heads/main", B, C, 20, "commit: more");
+        assert!(!head_reflog_unchanged_since(
+            &git_dir,
+            Some(&settled),
+            Some(&seen)
+        ));
     }
 
     #[test]

--- a/src/daemon/repo_family_store.rs
+++ b/src/daemon/repo_family_store.rs
@@ -153,13 +153,18 @@ impl RepoFamilyStore {
         Ok(())
     }
 
-    /// Every remembered family, most recently seen first.
-    pub fn known_families(&self) -> Result<Vec<String>, GitAiError> {
+    /// Every remembered family, most recently seen first; without
+    /// `include_missing`, families whose common dir was last seen missing are
+    /// left out (a routine tick does not re-probe them).
+    pub fn known_families(&self, include_missing: bool) -> Result<Vec<String>, GitAiError> {
         let conn = self.lock();
-        let mut statement =
-            conn.prepare("SELECT common_dir FROM repo_families ORDER BY last_seen_at DESC")?;
+        let mut statement = conn.prepare(
+            "SELECT common_dir FROM repo_families
+             WHERE ?1 OR missing_since IS NULL
+             ORDER BY last_seen_at DESC",
+        )?;
         let families = statement
-            .query_map([], |row| row.get::<_, String>(0))?
+            .query_map(params![include_missing], |row| row.get::<_, String>(0))?
             .collect::<Result<Vec<_>, _>>()?;
         Ok(families)
     }
@@ -398,7 +403,7 @@ mod tests {
             .unwrap();
         assert_eq!(version, MIGRATIONS.len() as u32);
         assert_eq!(
-            store.known_families().unwrap(),
+            store.known_families(true).unwrap(),
             vec!["/repos/old/.git".to_string()]
         );
         assert_eq!(
@@ -488,7 +493,7 @@ mod tests {
             (NOW as i64, (NOW + 20) as i64, None)
         );
         assert_eq!(
-            store.known_families().unwrap(),
+            store.known_families(true).unwrap(),
             vec!["/repos/a/.git".to_string(), "/repos/b/.git".to_string()],
             "most recently seen first"
         );
@@ -514,6 +519,15 @@ mod tests {
             )
             .unwrap();
         assert_eq!(missing, (NOW + 10) as i64);
+        assert_eq!(
+            store.known_families(false).unwrap(),
+            Vec::<String>::new(),
+            "a missing family is not re-probed by routine ticks"
+        );
+        assert_eq!(
+            store.known_families(true).unwrap(),
+            vec!["/repos/a/.git".to_string()]
+        );
     }
 
     #[test]
@@ -556,7 +570,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            store.known_families().unwrap(),
+            store.known_families(false).unwrap(),
             vec!["/repos/a/.git".to_string()]
         );
         assert_eq!(store.cursor("/repos/a/.git").unwrap(), Some(cursor));
@@ -603,7 +617,7 @@ mod tests {
 
         assert_eq!(removed, 2);
         assert_eq!(
-            store.known_families().unwrap(),
+            store.known_families(true).unwrap(),
             vec![
                 "/repos/fresh/.git".to_string(),
                 "/repos/recently-missing/.git".to_string()
@@ -625,7 +639,7 @@ mod tests {
 
         assert_eq!(removed, 5);
         assert_eq!(store.family_count().unwrap(), MAX_FAMILIES);
-        let families = store.known_families().unwrap();
+        let families = store.known_families(true).unwrap();
         assert!(!families.contains(&"/repos/0/.git".to_string()));
         assert!(!families.contains(&"/repos/4/.git".to_string()));
         assert!(families.contains(&"/repos/5/.git".to_string()));

--- a/src/daemon/untraced_commit_fixup.rs
+++ b/src/daemon/untraced_commit_fixup.rs
@@ -1,0 +1,52 @@
+//! Periodic driver of the untraced-commit fixup: every interval, stat the
+//! `HEAD` reflog of each known worktree and schedule a fixup pass (see
+//! `RefCursor::claim_untraced_commits`) for the ones that grew. Commits made
+//! by clients that emit no trace2, from sandboxes, or while the daemon was
+//! off are attributed within roughly one interval plus the minimum record
+//! age. The first tick runs at startup so a restart catches up at once.
+//!
+//! The worker touches nothing on the trace ingestion path: it reads two
+//! counters to stay out of the way while frames are still being ingested,
+//! and every pass it schedules runs through the family sequencer like a
+//! command.
+
+use crate::daemon::ActorDaemonCoordinator;
+use std::sync::{Arc, Weak};
+use std::time::Duration;
+use tokio::sync::Notify;
+use tokio::time::{MissedTickBehavior, interval};
+
+/// Default time between scans. With the default 5 s minimum record age, an
+/// untraced commit is attributed within about 15 s.
+pub const DEFAULT_INTERVAL: Duration = Duration::from_secs(10);
+
+pub fn spawn_untraced_fixup_worker(
+    coordinator: Weak<ActorDaemonCoordinator>,
+    period: Duration,
+    shutdown_notify: Arc<Notify>,
+) {
+    tokio::spawn(async move {
+        tracing::info!(
+            interval_ms = period.as_millis() as u64,
+            "untraced fixup worker started"
+        );
+        let mut ticker = interval(period);
+        // After suspend/resume one scan covers everything; do not replay
+        // every missed tick.
+        ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
+        loop {
+            tokio::select! {
+                _ = shutdown_notify.notified() => break,
+                _ = ticker.tick() => {
+                    let Some(coordinator) = coordinator.upgrade() else {
+                        break;
+                    };
+                    if let Err(error) = coordinator.run_untraced_fixup_tick().await {
+                        tracing::warn!(%error, "untraced fixup tick failed");
+                    }
+                }
+            }
+        }
+        tracing::info!("untraced fixup worker shutdown complete");
+    });
+}

--- a/src/feature_flags.rs
+++ b/src/feature_flags.rs
@@ -87,6 +87,7 @@ define_feature_flags!(
     daemon_log_upload: daemon_log_upload, debug = true, release = true,
     rewrite_metrics_events: rewrite_metrics_events, debug = true, release = false,
     token_usage_metrics: token_usage_metrics, debug = true, release = false,
+    untraced_commit_fixup: untraced_commit_fixup, debug = true, release = true,
 );
 
 impl FeatureFlags {
@@ -145,6 +146,7 @@ mod tests {
             assert!(flags.daemon_log_upload);
             assert!(flags.rewrite_metrics_events);
             assert!(flags.token_usage_metrics);
+            assert!(flags.untraced_commit_fixup);
         }
         #[cfg(not(debug_assertions))]
         {
@@ -157,6 +159,7 @@ mod tests {
             assert!(flags.daemon_log_upload);
             assert!(!flags.rewrite_metrics_events);
             assert!(!flags.token_usage_metrics);
+            assert!(flags.untraced_commit_fixup);
         }
     }
 
@@ -279,6 +282,7 @@ mod tests {
             daemon_log_upload: true,
             rewrite_metrics_events: true,
             token_usage_metrics: true,
+            untraced_commit_fixup: true,
         };
 
         let serialized = serde_json::to_string(&flags).unwrap();
@@ -291,6 +295,7 @@ mod tests {
         assert!(serialized.contains("daemon_log_upload"));
         assert!(serialized.contains("rewrite_metrics_events"));
         assert!(serialized.contains("token_usage_metrics"));
+        assert!(serialized.contains("untraced_commit_fixup"));
     }
 
     #[test]
@@ -305,6 +310,7 @@ mod tests {
             daemon_log_upload: true,
             rewrite_metrics_events: true,
             token_usage_metrics: true,
+            untraced_commit_fixup: false,
         };
         let cloned = flags.clone();
         assert_eq!(cloned.lite_mode, flags.lite_mode);
@@ -316,6 +322,7 @@ mod tests {
         assert_eq!(cloned.daemon_log_upload, flags.daemon_log_upload);
         assert_eq!(cloned.rewrite_metrics_events, flags.rewrite_metrics_events);
         assert_eq!(cloned.token_usage_metrics, flags.token_usage_metrics);
+        assert_eq!(cloned.untraced_commit_fixup, flags.untraced_commit_fixup);
     }
 
     #[test]

--- a/tests/integration/performance.rs
+++ b/tests/integration/performance.rs
@@ -24,6 +24,7 @@ fn setup() {
         daemon_log_upload: true,
         rewrite_metrics_events: false,
         token_usage_metrics: false,
+        untraced_commit_fixup: false,
     };
 
     git_ai::config::Config::set_test_feature_flags(test_flags.clone());

--- a/tests/integration/repos/test_repo.rs
+++ b/tests/integration/repos/test_repo.rs
@@ -223,6 +223,16 @@ impl DaemonProcess {
                 .env("GIT_AI_DAEMON_HOME", test_home)
                 .env("GIT_AI_DAEMON_CONTROL_SOCKET", &control_socket_path)
                 .env("GIT_AI_DAEMON_TRACE_SOCKET", &trace_socket_path)
+                // The untraced-commit fixup timer only fires in tests that opt
+                // in with a short interval; everything else drives it with
+                // `fixup.scan` so untraced git stays deterministic. A stress
+                // run can turn the timer on for every test daemon through
+                // GIT_AI_TEST_UNTRACED_FIXUP_INTERVAL_MS.
+                .env(
+                    "GIT_AI_DAEMON_UNTRACED_FIXUP_INTERVAL_MS",
+                    std::env::var("GIT_AI_TEST_UNTRACED_FIXUP_INTERVAL_MS")
+                        .unwrap_or_else(|_| "3600000".to_string()),
+                )
                 .stdout(Stdio::null())
                 .stderr(
                     stderr_log

--- a/tests/integration/untraced_commit_fixup.rs
+++ b/tests/integration/untraced_commit_fixup.rs
@@ -14,6 +14,7 @@ use git_ai::metrics::events::committed_pos;
 use serde_json::Value;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
 
 const TRACE2_DISABLED_ENV: [(&str, &str); 3] = [
     ("GIT_TRACE2", "0"),
@@ -566,4 +567,104 @@ fn untraced_commit_in_a_linked_worktree_is_attributed() {
         Some("untraced_fixup")
     );
     let _ = fs::remove_dir_all(&linked);
+}
+
+/// Polls until `commit_sha` has an authorship note or `timeout` passes.
+fn wait_for_note(repo: &TestRepo, commit_sha: &str, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if repo.read_authorship_note(commit_sha).is_some() {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    false
+}
+
+#[test]
+fn periodic_scan_attributes_an_untraced_commit_without_a_request() {
+    let (_metrics_dir, metrics_db_path) = isolated_metrics_db_path();
+    let mut env = fixup_daemon_env(&metrics_db_path);
+    env.push(("GIT_AI_DAEMON_UNTRACED_FIXUP_INTERVAL_MS", "200"));
+    let repo = TestRepo::new_with_daemon_env(&env);
+    write_file(&repo, "agent.txt", "base\n");
+    // A traced commit makes the family known; no fixup.scan is ever sent.
+    repo.stage_all_and_commit("traced base")
+        .expect("traced base commit");
+    codex_edit(&repo, "agent.txt", "base\nai line\n", "tool-use-1");
+    repo.sync_daemon();
+
+    let untraced = raw_commit_all(&repo, "sandboxed agent commit");
+
+    assert!(
+        wait_for_note(&repo, &untraced, Duration::from_secs(20)),
+        "the periodic scan should attribute the commit within interval + min age"
+    );
+    repo.sync_daemon();
+    let mut file = repo.filename("agent.txt");
+    file.assert_committed_lines(lines!["base".unattributed_human(), "ai line".ai()]);
+    assert_eq!(
+        commit_source(&metrics_db_path, &untraced),
+        Some("untraced_fixup")
+    );
+    assert!(health_counter(&repo, "known_repo_families") >= 1);
+}
+
+#[test]
+fn startup_scan_attributes_a_commit_made_while_the_daemon_was_off() {
+    let (_metrics_dir, metrics_db_path, mut repo) = fixup_repo();
+    write_file(&repo, "plain.txt", "base\n");
+    repo.stage_all_and_commit("traced base")
+        .expect("traced base commit");
+    repo.request_untraced_fixup_scan();
+
+    repo.shutdown_dedicated_daemon_for_test();
+    write_file(&repo, "plain.txt", "base\nwhile off\n");
+    let while_off = raw_commit_all(&repo, "while the daemon was off");
+    repo.start_dedicated_daemon_with_env_for_test(&fixup_daemon_env(&metrics_db_path));
+
+    // The worker's first tick runs at startup; the hour-long test interval
+    // never fires again, so this is the startup scan alone.
+    assert!(
+        wait_for_note(&repo, &while_off, Duration::from_secs(20)),
+        "a restarted daemon catches up on known families at once"
+    );
+    repo.sync_daemon();
+    let mut file = repo.filename("plain.txt");
+    file.assert_committed_lines(lines![
+        "base".unattributed_human(),
+        "while off".unattributed_human()
+    ]);
+    assert_eq!(
+        commit_source(&metrics_db_path, &while_off),
+        Some("untraced_fixup")
+    );
+}
+
+#[test]
+fn feature_flag_disables_the_periodic_scan_but_not_explicit_requests() {
+    let (_metrics_dir, metrics_db_path) = isolated_metrics_db_path();
+    let mut env = fixup_daemon_env(&metrics_db_path);
+    env.push(("GIT_AI_DAEMON_UNTRACED_FIXUP_INTERVAL_MS", "200"));
+    env.push(("GIT_AI_UNTRACED_COMMIT_FIXUP", "false"));
+    let repo = TestRepo::new_with_daemon_env(&env);
+    write_file(&repo, "plain.txt", "base\n");
+    repo.stage_all_and_commit("traced base")
+        .expect("traced base commit");
+    repo.request_untraced_fixup_scan();
+
+    write_file(&repo, "plain.txt", "base\nuntraced\n");
+    let untraced = raw_commit_all(&repo, "untraced with the flag off");
+
+    assert!(
+        !wait_for_note(&repo, &untraced, Duration::from_secs(2)),
+        "no timer runs with the flag off"
+    );
+    repo.request_untraced_fixup_scan();
+    assert!(repo.read_authorship_note(&untraced).is_some());
+    let mut file = repo.filename("plain.txt");
+    file.assert_committed_lines(lines![
+        "base".unattributed_human(),
+        "untraced".unattributed_human()
+    ]);
 }


### PR DESCRIPTION
## Summary

Runs the untraced-commit fixup on a timer so commits from JGit/libgit2 clients, sandboxes, or a daemon-off period are attributed without anyone asking.

- `src/daemon/untraced_commit_fixup.rs`: every `GIT_AI_DAEMON_UNTRACED_FIXUP_INTERVAL_MS` (10 s; first tick at startup so a restart catches up at once) the worker stats each known worktree's `HEAD` reflog and schedules a pass only where it grew, at most 32 worktrees per tick (rotating). A tick is skipped while trace frames are still queued, so a pass never runs ahead of the commands those frames describe. With the 5 s minimum record age an untraced commit is attributed within about 15 s.
- The per-worktree gate compares the reflog observation `(length, mtime)`, or its absence, with what the last pass saw, so an equal-length rewrite is rescanned and a repository without a reflog yet is not rescanned every tick. A routine tick examines at most 256 families (rotating), so its filesystem work is bounded however many families the daemon has heard of; the hourly maintenance round examines all of them, so every present family is marked seen before pruning runs. A routine tick also leaves a family alone while one of its git commands is still in flight (an open mutating trace root), so a scan never sits fenced at the head of that family's sequencer with the command's own entries queued behind it. Routine ticks are read-only: the remembered family list and persisted cursors are cached in memory and store writes happen only when a pass completes or a family is first found missing (recorded once). The hourly maintenance round re-reads the store, prunes, re-probes missing families and refreshes `last_seen_at` for present ones (`refresh_family_seen`, an update that never inserts, so only a completed pass ever remembers a family and it always comes with its cursor) so an idle repository is never pruned as unseen.
- Gated by the new `untraced_commit_fixup` feature flag (on in debug and release); `fixup.scan` keeps working regardless. `status.daemon` and the heartbeat report `known_repo_families`.
- Test daemons default the interval to an hour so only opt-in tests see the timer (`GIT_AI_TEST_UNTRACED_FIXUP_INTERVAL_MS` turns it on everywhere for stress runs).
- Design and limitations documented in `docs/untraced-commit-fixup-spec.md`; pointer from the ingestion spec; flag listed in CLAUDE.md.

## Perf (hands-on, debug build via `task dev`)

Isolated daemon (own home/sockets, other workers disabled), 200 known families of which 150 deleted after registration, one family with 20 linked worktrees, 60 s idle:

| | worker off | worker on |
|---|---|---|
| statx + openat | 821 | 3,397 (≈ 430 per tick, ≈ 1.5 ms) |
| execve | 19 | 19 |
| CPU seconds | 2 | 1 |

- 100k-record `HEAD`/branch reflogs + 500 branches: one untraced commit attributed 6.7 s after the commit (tail read only, one branch-log walk).
- Burst of 200 untraced commits with traced commits interleaved: all 200 attributed in 20 s, no duplicates, `untraced_scan_errors = 0`.
- Full suite with `GIT_AI_TEST_UNTRACED_FIXUP_INTERVAL_MS=1000` (timer firing every second in every test daemon): see checklist.

## Real clients (hands-on, this branch installed via `task dev`)

Verified against real non-trace2 clients, in repositories outside the ignored temp roots:

- **libgit2 0.19** (scratch program on the `git2` crate): commit → `commit: …` in both HEAD and branch reflogs, attributed by the next tick; commit after delivered `mock_ai` checkpoints → working log consumed, blame shows the AI lines; rebase via the libgit2 API writes `rebase: …` / `rebase finished: …` records → skipped, the replayed commit gets no note, the original keeps its note, `untraced_commits_fixed` unchanged.
- **JGit 7.7.1** (`org.eclipse.jgit.pgm`): commit → attributed in 10.3 s; `commit --amend` → `commit (amend): …` skipped, no note; commits across `checkout`s on two branches both attributed. JGit's CLI has no rebase command.

## Test plan

- [x] flag defaults/serialization/clone tests; `head_reflog_unchanged_since` unit test
- [x] integration: periodic scan attributes an untraced commit with no request; startup scan attributes a commit made while the daemon was off; flag off disables the timer but not `fixup.scan`
- [x] `daemon_mode`, `cold_trace2_repo` suites; `task lint`, `task fmt`; full `task test`
