### PR TITLE
feat: add CodeArts Agent attribution support

### DIFF
--- a/.github/workflows/opencode-type-check.yml
+++ b/.github/workflows/opencode-type-check.yml
@@ -38,3 +38,6 @@ jobs:
       - name: Run type check
         run: npm run type-check
 
+      - name: Test OpenCode and CodeArts hooks
+        run: npm test
+

--- a/.github/workflows/opencode-type-check.yml
+++ b/.github/workflows/opencode-type-check.yml
@@ -14,7 +14,10 @@ on:
 
 jobs:
   type-check:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     defaults:
       run:
         working-directory: agent-support/opencode

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ powershell -NoProfile -ExecutionPolicy Bypass -Command "irm https://usegitai.com
 </tr>
 </table>
 
+Huawei Cloud [CodeArts Agent](docs/codearts.md) is also supported through its IDE, editor extension, and CLI tool hooks.
+
 
 ## Our Choices
 

--- a/agent-support/opencode/git-ai.test.mjs
+++ b/agent-support/opencode/git-ai.test.mjs
@@ -65,6 +65,53 @@ for (const agent of ["codearts", "opencode"]) {
     assert.deepEqual(calls[1].input.tool_input.file_paths, [args.filePath])
     assert.equal(calls[0].options.windowsHide, true)
   })
+
+  test(`${agent}: deleting a session clears its model without changing a pending call`, async (t) => {
+    const { hooks, calls } = await pluginFixture(t, agent)
+    await hooks["chat.params"]({ sessionID: "deleted", model: { id: "deleted-model" } }, {})
+    await hooks["chat.params"]({ sessionID: "retained", model: { id: "retained-model" } }, {})
+    const input = invocation("bash", "deleted")
+    await hooks["tool.execute.before"](input, { args: { command: "true" } })
+    await hooks.event({ event: { type: "session.deleted", properties: { info: { id: "deleted" } } } })
+    await hooks["tool.execute.after"](input, {})
+    assert.equal(calls.at(-1).input.model, "deleted-model")
+    await hooks["tool.execute.before"](invocation("bash", "deleted", "next-call"), { args: { command: "true" } })
+    assert.equal(calls.at(-1).input.model, undefined)
+    await hooks["tool.execute.before"](invocation("bash", "retained"), { args: { command: "true" } })
+    assert.equal(calls.at(-1).input.model, "retained-model")
+  })
+
+  test(`${agent}: model cache is bounded and retains recently used sessions`, async (t) => {
+    const { hooks, calls } = await pluginFixture(t, agent)
+    for (let index = 0; index < 256; index++) {
+      await hooks["chat.params"]({ sessionID: `session-${index}`, model: { id: `model-${index}` } }, {})
+    }
+    const recent = invocation("bash", "session-0")
+    await hooks["tool.execute.before"](recent, { args: { command: "true" } })
+    await hooks["tool.execute.after"](recent, {})
+    await hooks["chat.params"]({ sessionID: "session-256", model: { id: "new-model" } }, {})
+
+    await hooks["tool.execute.before"](invocation("bash", "session-1"), { args: { command: "true" } })
+    assert.equal(calls.at(-1).input.model, undefined)
+    await hooks["tool.execute.before"](recent, { args: { command: "true" } })
+    assert.equal(calls.at(-1).input.model, "model-0")
+    await hooks["tool.execute.before"](invocation("bash", "session-256"), { args: { command: "true" } })
+    assert.equal(calls.at(-1).input.model, "new-model")
+  })
+
+  test(`${agent}: evicting a session model preserves the pending call snapshot`, async (t) => {
+    const { hooks, calls } = await pluginFixture(t, agent)
+    await hooks["chat.params"]({ sessionID: "pending", model: { id: "original-model" } }, {})
+    const input = invocation("bash", "pending")
+    await hooks["tool.execute.before"](input, { args: { command: "true" } })
+    for (let index = 0; index < 256; index++) {
+      await hooks["chat.params"]({ sessionID: `session-${index}`, model: { id: `model-${index}` } }, {})
+    }
+    await hooks["tool.execute.after"](input, {})
+    assert.equal(calls.at(-1).input.model, "original-model")
+    await hooks["tool.execute.before"](input, { args: { command: "true" } })
+    assert.equal(calls.at(-1).input.model, undefined)
+  })
 }
 
 test("codearts: model is scoped to each session and shell call", async (t) => {

--- a/agent-support/opencode/git-ai.test.mjs
+++ b/agent-support/opencode/git-ai.test.mjs
@@ -1,0 +1,164 @@
+import assert from "node:assert/strict"
+import { EventEmitter } from "node:events"
+import { mkdtemp, mkdir, rm } from "node:fs/promises"
+import { readFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { createRequire } from "node:module"
+import { PassThrough } from "node:stream"
+import { test } from "node:test"
+import { runInNewContext } from "node:vm"
+import ts from "typescript"
+
+const require = createRequire(import.meta.url)
+
+async function pluginFixture(t, agent = "codearts", exitCode = 0, subdirectory = "") {
+  const directory = await mkdtemp(join(tmpdir(), "git-ai-plugin-"))
+  await mkdir(join(directory, ".git"))
+  t.after(() => rm(directory, { recursive: true, force: true }))
+  const calls = []
+  const source = readFileSync(new URL("./git-ai.ts", import.meta.url), "utf8")
+    .replace('const AGENT_NAME = "opencode"', `const AGENT_NAME = "${agent}"`)
+  const compiled = ts.transpileModule(source, {
+    compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2022 },
+  }).outputText
+  const exports = {}
+  runInNewContext(compiled, {
+    exports, process, console, Buffer, setTimeout, clearTimeout,
+    require: (name) => name === "child_process" ? {
+      spawn(binary, args, options) {
+        const child = new EventEmitter()
+        child.stderr = new PassThrough()
+        child.stdin = new PassThrough()
+        let stdin = ""
+        child.stdin.on("data", (data) => { stdin += data })
+        child.stdin.on("finish", () => {
+          calls.push({ binary, args: Array.from(args), options, input: JSON.parse(stdin) })
+          queueMicrotask(() => child.emit("close", exitCode))
+        })
+        child.kill = () => true
+        return child
+      },
+    } : require(name),
+  })
+  const activeDirectory = join(directory, subdirectory)
+  await mkdir(activeDirectory, { recursive: true })
+  const hooks = await exports.GitAiPlugin({ directory: activeDirectory, worktree: directory })
+  return { directory, calls, hooks }
+}
+
+const invocation = (tool, sessionID = "session-1", callID = "call-1") => ({ tool, sessionID, callID })
+
+for (const agent of ["codearts", "opencode"]) {
+  test(`${agent}: edit checkpoints preserve call identity and scoped file paths`, async (t) => {
+    const { directory, hooks, calls } = await pluginFixture(t, agent)
+    const input = invocation("write")
+    const args = { filePath: join(directory, "new.ts"), content: "hello" }
+    await hooks["tool.execute.before"](input, { args })
+    await hooks["tool.execute.after"]({ ...input, args }, { metadata: {} })
+    assert.equal(calls.length, 2)
+    assert.deepEqual(calls[0].args, ["checkpoint", agent, "--hook-input", "stdin"])
+    assert.equal(calls[0].input.hook_event_name, "PreToolUse")
+    assert.equal(calls[1].input.hook_event_name, "PostToolUse")
+    assert.equal(calls[1].input.tool_use_id, "call-1")
+    assert.equal(calls[1].input.session_id, "session-1")
+    assert.deepEqual(calls[1].input.tool_input.file_paths, [args.filePath])
+    assert.equal(calls[0].options.windowsHide, true)
+  })
+}
+
+test("codearts: model is scoped to each session and shell call", async (t) => {
+  const { hooks, calls } = await pluginFixture(t)
+  await hooks["chat.params"]({ sessionID: "session-1", model: { id: "deepseek-v3" } }, {})
+  await hooks["chat.params"]({ sessionID: "session-2", model: { id: "other-model" } }, {})
+  const input = invocation("bash")
+  await hooks["tool.execute.before"](input, { args: { command: "echo hello > new.txt" } })
+  await hooks["chat.params"]({ sessionID: "session-1", model: { id: "next-model" } }, {})
+  await hooks["tool.execute.after"](input, {})
+  assert.equal(calls[1].input.model, "deepseek-v3")
+  assert.equal(calls[1].input.tool_input.command, "echo hello > new.txt")
+})
+
+test("codearts: title generation does not replace the coding model", async (t) => {
+  const { hooks, calls } = await pluginFixture(t)
+  await hooks["chat.params"]({ sessionID: "session-1", model: { id: "coding-model" } }, {})
+  await hooks["chat.params"]({ sessionID: "session-1", model: { id: "title-model" }, isEnsureTitle: true }, {})
+  await hooks["chat.params"]({ sessionID: "session-1", model: { id: "cli-title-model" }, agent: "title" }, {})
+  await hooks["tool.execute.before"](invocation("bash"), { args: { command: "true" } })
+  assert.equal(calls[0].input.model, "coding-model")
+})
+
+test("codearts: relative edit paths resolve against tool workdir before checkpointing", async (t) => {
+  const { directory, hooks, calls } = await pluginFixture(t)
+  await mkdir(join(directory, "src"))
+  const input = invocation("edit")
+  const args = { workdir: "src", filePath: "main.ts" }
+  await hooks["tool.execute.before"](input, { args })
+  await hooks["tool.execute.after"]({ ...input, args }, { metadata: { files: [{ filePath: "extra.ts" }] } })
+  assert.deepEqual(calls[0].input.tool_input.file_paths, [join(directory, "src", "main.ts")])
+  assert.deepEqual(calls[1].input.tool_input.file_paths, [
+    join(directory, "src", "main.ts"), join(directory, "src", "extra.ts"),
+  ])
+})
+
+test("codearts: relative edits use the active directory inside a worktree", async (t) => {
+  const { directory, hooks, calls } = await pluginFixture(t, "codearts", 0, "src")
+  await hooks["tool.execute.before"](invocation("write"), { args: { filePath: "main.ts" } })
+  assert.deepEqual(calls[0].input.tool_input.file_paths, [join(directory, "src", "main.ts")])
+})
+
+test("codearts: shell checkpoint cwd preserves the command workdir", async (t) => {
+  const { directory, hooks, calls } = await pluginFixture(t)
+  await mkdir(join(directory, "src"))
+  const input = invocation("bash")
+  await hooks["tool.execute.before"](input, { args: { workdir: "src", command: "echo hello > main.ts" } })
+  await hooks["tool.execute.after"](input, {})
+  assert.equal(calls[0].input.cwd, join(directory, "src"))
+  assert.equal(calls[1].input.cwd, join(directory, "src"))
+})
+
+test("codearts: patch examples inside file content are not treated as edited paths", async (t) => {
+  const { directory, hooks, calls } = await pluginFixture(t)
+  await hooks["tool.execute.before"](invocation("write"), { args: {
+    filePath: "README.md", content: "*** Update File: unrelated.ts\nfile:///another.ts",
+  } })
+  assert.deepEqual(calls[0].input.tool_input.file_paths, [join(directory, "README.md")])
+})
+
+test("codearts: deleteFile is tracked and read-only tools are skipped", async (t) => {
+  const { directory, hooks, calls } = await pluginFixture(t)
+  const args = { filePath: join(directory, "old.ts") }
+  await hooks["tool.execute.before"](invocation("read"), { args })
+  assert.equal(calls.length, 0)
+  await hooks["tool.execute.before"](invocation("deleteFile"), { args })
+  await hooks["tool.execute.after"](invocation("deleteFile"), {})
+  assert.equal(calls.length, 2)
+})
+
+test("codearts: missing identifiers and unmatched post events do not checkpoint", async (t) => {
+  const { hooks, calls } = await pluginFixture(t)
+  await hooks["tool.execute.before"](invocation("bash", "", ""), { args: { command: "true" } })
+  await hooks["tool.execute.after"](invocation("bash", "", ""), {})
+  await hooks["tool.execute.after"](invocation("bash"), {})
+  assert.equal(calls.length, 0)
+})
+
+test("codearts: identical call IDs in different sessions stay separate", async (t) => {
+  const { hooks, calls } = await pluginFixture(t)
+  const first = invocation("bash", "session-1")
+  const second = invocation("bash", "session-2")
+  await hooks["tool.execute.before"](first, { args: { command: "first" } })
+  await hooks["tool.execute.before"](second, { args: { command: "second" } })
+  await hooks["tool.execute.after"](first, {})
+  await hooks["tool.execute.after"](second, {})
+  assert.deepEqual(calls.slice(2).map((call) => [call.input.session_id, call.input.tool_input.command]), [
+    ["session-1", "first"], ["session-2", "second"],
+  ])
+})
+
+test("codearts: checkpoint failures leave tool execution usable", async (t) => {
+  const { hooks } = await pluginFixture(t, "codearts", 1)
+  const input = invocation("bash")
+  await assert.doesNotReject(() => hooks["tool.execute.before"](input, { args: { command: "true" } }))
+  await assert.doesNotReject(() => hooks["tool.execute.after"](input, {}))
+})

--- a/agent-support/opencode/git-ai.test.mjs
+++ b/agent-support/opencode/git-ai.test.mjs
@@ -4,6 +4,7 @@ import { mkdtemp, mkdir, rm } from "node:fs/promises"
 import { readFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import { pathToFileURL } from "node:url"
 import { createRequire } from "node:module"
 import { PassThrough } from "node:stream"
 import { test } from "node:test"
@@ -32,9 +33,10 @@ async function pluginFixture(t, agent = "codearts", exitCode = 0, subdirectory =
         child.stdin = new PassThrough()
         let stdin = ""
         child.stdin.on("data", (data) => { stdin += data })
-        child.stdin.on("finish", () => {
+        child.stdin.on("finish", async () => {
           calls.push({ binary, args: Array.from(args), options, input: JSON.parse(stdin) })
-          queueMicrotask(() => child.emit("close", exitCode))
+          const code = typeof exitCode === "function" ? await exitCode() : exitCode
+          queueMicrotask(() => child.emit("close", code))
         })
         child.kill = () => true
         return child
@@ -64,6 +66,115 @@ for (const agent of ["codearts", "opencode"]) {
     assert.equal(calls[1].input.session_id, "session-1")
     assert.deepEqual(calls[1].input.tool_input.file_paths, [args.filePath])
     assert.equal(calls[0].options.windowsHide, true)
+  })
+
+  test(`${agent}: post-only metadata cannot expand the pre-checkpoint scope`, async (t) => {
+    const { directory, hooks, calls } = await pluginFixture(t, agent)
+    await mkdir(join(directory, "src"))
+    const input = invocation("edit")
+    const args = { workdir: "src", filePath: "main.ts" }
+    await hooks["tool.execute.before"](input, { args })
+    await hooks["tool.execute.after"]({ ...input, args }, {
+      metadata: { files: [{ filePath: "main.ts" }, { filePath: "untracked.ts" }] },
+    })
+    assert.equal(calls.length, 2)
+    assert.deepEqual(calls[0].input.tool_input.file_paths, [join(directory, "src", "main.ts")])
+    assert.deepEqual(calls[1].input.tool_input, calls[0].input.tool_input)
+  })
+
+  test(`${agent}: file URI edit paths decode spaces and Unicode`, async (t) => {
+    const { directory, hooks, calls } = await pluginFixture(t, agent)
+    const filePath = join(directory, "space 中文.ts")
+    const input = invocation("edit")
+    const uri = pathToFileURL(filePath).href
+    for (const fileUri of [uri, uri.replace("file://", "file://localhost")]) {
+      await hooks["tool.execute.before"](input, { args: { filePath: fileUri } })
+      await hooks["tool.execute.after"](input, {})
+      assert.deepEqual(calls.at(-2).input.tool_input.file_paths, [filePath])
+      assert.deepEqual(calls.at(-1).input.tool_input, calls.at(-2).input.tool_input)
+    }
+    assert.equal(calls.length, 4)
+  })
+
+  test(`${agent}: tools without CodeArts drive conversion preserve rooted paths`, async (t) => {
+    const { hooks, calls } = await pluginFixture(t, agent)
+    const tools = agent === "opencode" || process.platform !== "win32" ? ["write", "edit"] : ["write"]
+    for (const tool of tools) {
+      const input = invocation(tool)
+      await hooks["tool.execute.before"](input, { args: { filePath: "/d/example.ts" } })
+      await hooks["tool.execute.after"](input, {})
+      assert.deepEqual(calls.at(-1).input.tool_input.file_paths, ["/d/example.ts"])
+    }
+  })
+
+  test(`${agent}: invalid file URIs do not create a checkpoint`, async (t) => {
+    const { hooks, calls } = await pluginFixture(t, agent)
+    const input = invocation("edit")
+    await hooks["tool.execute.before"](input, { args: { filePath: "file:///%ZZ" } })
+    await hooks["tool.execute.after"](input, {})
+    assert.equal(calls.length, 0)
+  })
+
+  test(`${agent}: edits without pre-tool paths never checkpoint the whole repository`, async (t) => {
+    const { hooks, calls } = await pluginFixture(t, agent)
+    const input = invocation("patch")
+    await hooks["tool.execute.before"](input, { args: { patch: "unrecognized patch format" } })
+    await hooks["tool.execute.after"](input, { metadata: { files: [{ filePath: "untracked.ts" }] } })
+    assert.equal(calls.length, 0)
+  })
+
+  test(`${agent}: failed tool events clear only the matching pending call`, async (t) => {
+    const { hooks, calls } = await pluginFixture(t, agent)
+    const failed = invocation("bash", "failed")
+    const retained = invocation("bash", "retained")
+    await hooks["tool.execute.before"](failed, { args: { command: "failed" } })
+    await hooks["tool.execute.before"](retained, { args: { command: "retained" } })
+    await hooks.event({ event: { type: "message.part.updated", properties: { part: {
+      type: "tool", sessionID: "failed", callID: "call-1", tool: "bash", state: { status: "error" },
+    } } } })
+    await hooks["tool.execute.after"](failed, {})
+    assert.equal(calls.length, 2)
+    await hooks["tool.execute.after"](retained, {})
+    assert.equal(calls.length, 3)
+    assert.equal(calls.at(-1).input.session_id, "retained")
+  })
+
+  test(`${agent}: completed tool events preserve the pending post-checkpoint`, async (t) => {
+    const { hooks, calls } = await pluginFixture(t, agent)
+    const input = invocation("bash")
+    await hooks["tool.execute.before"](input, { args: { command: "true" } })
+    await hooks.event({ event: { type: "message.part.updated", properties: { part: {
+      type: "tool", sessionID: input.sessionID, callID: input.callID, state: { status: "completed" },
+    } } } })
+    await hooks["tool.execute.after"](input, {})
+    assert.equal(calls.length, 2)
+  })
+
+  test(`${agent}: cancellation during a pre-checkpoint cannot resurrect a pending call`, async (t) => {
+    const input = invocation("bash")
+    const { hooks, calls } = await pluginFixture(t, agent, async () => {
+      await hooks.event({ event: { type: "message.part.updated", properties: { part: {
+        type: "tool", sessionID: input.sessionID, callID: input.callID, state: { status: "error" },
+      } } } })
+      return 0
+    })
+    await hooks["tool.execute.before"](input, { args: { command: "true" } })
+    await hooks["tool.execute.after"](input, {})
+    assert.equal(calls.length, 1)
+  })
+
+  test(`${agent}: missing terminal events cannot retain pending calls indefinitely`, async (t) => {
+    const { hooks, calls } = await pluginFixture(t, agent)
+    for (let index = 0; index <= 1024; index++) {
+      await hooks["tool.execute.before"](invocation("bash", "session-1", `call-${index}`), {
+        args: { command: `command-${index}` },
+      })
+    }
+    await hooks["tool.execute.after"](invocation("bash", "session-1", "call-0"), {})
+    assert.equal(calls.length, 1025)
+    await hooks["tool.execute.after"](invocation("bash", "session-1", "call-1024"), {})
+    assert.equal(calls.length, 1026)
+    assert.equal(calls.at(-1).input.tool_input.command, "command-1024")
   })
 
   test(`${agent}: deleting a session clears its model without changing a pending call`, async (t) => {
@@ -114,6 +225,21 @@ for (const agent of ["codearts", "opencode"]) {
   })
 }
 
+test("codearts: Windows edit and deleteFile follow the client's drive-path transformation", {
+  skip: process.platform !== "win32",
+}, async (t) => {
+  const { directory, hooks, calls } = await pluginFixture(t)
+  const filePath = join(directory, "file.ts")
+  const posixDrivePath = filePath.replace(/\\/g, "/").replace(/^([a-zA-Z]):\//, "/$1/")
+  for (const tool of ["edit", "deleteFile"]) {
+    const input = invocation(tool, "session-1", tool)
+    const args = tool === "deleteFile" ? { file_paths: [posixDrivePath] } : { filePath: posixDrivePath }
+    await hooks["tool.execute.before"](input, { args })
+    await hooks["tool.execute.after"](input, {})
+    assert.deepEqual(calls.at(-1).input.tool_input.file_paths, [filePath.replace(/\\/g, "/")])
+  }
+})
+
 test("codearts: model is scoped to each session and shell call", async (t) => {
   const { hooks, calls } = await pluginFixture(t)
   await hooks["chat.params"]({ sessionID: "session-1", model: { id: "deepseek-v3" } }, {})
@@ -133,19 +259,6 @@ test("codearts: title generation does not replace the coding model", async (t) =
   await hooks["chat.params"]({ sessionID: "session-1", model: { id: "cli-title-model" }, agent: "title" }, {})
   await hooks["tool.execute.before"](invocation("bash"), { args: { command: "true" } })
   assert.equal(calls[0].input.model, "coding-model")
-})
-
-test("codearts: relative edit paths resolve against tool workdir before checkpointing", async (t) => {
-  const { directory, hooks, calls } = await pluginFixture(t)
-  await mkdir(join(directory, "src"))
-  const input = invocation("edit")
-  const args = { workdir: "src", filePath: "main.ts" }
-  await hooks["tool.execute.before"](input, { args })
-  await hooks["tool.execute.after"]({ ...input, args }, { metadata: { files: [{ filePath: "extra.ts" }] } })
-  assert.deepEqual(calls[0].input.tool_input.file_paths, [join(directory, "src", "main.ts")])
-  assert.deepEqual(calls[1].input.tool_input.file_paths, [
-    join(directory, "src", "main.ts"), join(directory, "src", "extra.ts"),
-  ])
 })
 
 test("codearts: relative edits use the active directory inside a worktree", async (t) => {
@@ -204,8 +317,9 @@ test("codearts: identical call IDs in different sessions stay separate", async (
 })
 
 test("codearts: checkpoint failures leave tool execution usable", async (t) => {
-  const { hooks } = await pluginFixture(t, "codearts", 1)
+  const { hooks, calls } = await pluginFixture(t, "codearts", 1)
   const input = invocation("bash")
   await assert.doesNotReject(() => hooks["tool.execute.before"](input, { args: { command: "true" } }))
   await assert.doesNotReject(() => hooks["tool.execute.after"](input, {}))
+  assert.equal(calls.length, 1)
 })

--- a/agent-support/opencode/git-ai.test.mjs
+++ b/agent-support/opencode/git-ai.test.mjs
@@ -2,7 +2,7 @@ import assert from "node:assert/strict"
 import { EventEmitter } from "node:events"
 import { mkdtemp, mkdir, rm } from "node:fs/promises"
 import { readFileSync } from "node:fs"
-import { tmpdir } from "node:os"
+import { homedir, tmpdir } from "node:os"
 import { join } from "node:path"
 import { pathToFileURL } from "node:url"
 import { createRequire } from "node:module"
@@ -13,7 +13,7 @@ import ts from "typescript"
 
 const require = createRequire(import.meta.url)
 
-async function pluginFixture(t, agent = "codearts", exitCode = 0, subdirectory = "") {
+async function pluginFixture(t, agent = "codearts", exitCode = 0, subdirectory = "", runtime = {}) {
   const directory = await mkdtemp(join(tmpdir(), "git-ai-plugin-"))
   await mkdir(join(directory, ".git"))
   t.after(() => rm(directory, { recursive: true, force: true }))
@@ -25,7 +25,8 @@ async function pluginFixture(t, agent = "codearts", exitCode = 0, subdirectory =
   }).outputText
   const exports = {}
   runInNewContext(compiled, {
-    exports, process, console, Buffer, setTimeout, clearTimeout,
+    exports, console, Buffer, setTimeout, clearTimeout,
+    process: { env: { ...runtime.env }, platform: process.platform, cwd: () => runtime.cwd ?? directory },
     require: (name) => name === "child_process" ? {
       spawn(binary, args, options) {
         const child = new EventEmitter()
@@ -41,7 +42,7 @@ async function pluginFixture(t, agent = "codearts", exitCode = 0, subdirectory =
         child.kill = () => true
         return child
       },
-    } : require(name),
+    } : name === "os" ? { ...require(name), homedir: () => runtime.home ?? homedir() } : require(name),
   })
   const activeDirectory = join(directory, subdirectory)
   await mkdir(activeDirectory, { recursive: true })
@@ -50,6 +51,176 @@ async function pluginFixture(t, agent = "codearts", exitCode = 0, subdirectory =
 }
 
 const invocation = (tool, sessionID = "session-1", callID = "call-1") => ({ tool, sessionID, callID })
+
+const transcriptRoot = join(tmpdir(), "git-ai-codearts-transcript")
+const transcriptHome = join(transcriptRoot, "home")
+const transcriptCwd = join(transcriptRoot, "kernel-process")
+for (const { name, env, expected } of [
+  {
+    name: "kernel data overrides XDG and ignores the runtime channel",
+    env: { KERNEL_DATA_DIR: join(transcriptRoot, "kernel"), XDG_DATA_HOME: join(transcriptRoot, "xdg"), SCENARIO: "codeartsdoer", OPENCODE_CHANNEL: "development" },
+    expected: join(transcriptRoot, "kernel", "opencode.db"),
+  },
+  {
+    name: "absolute database override",
+    env: { KERNEL_DATA_DIR: join(transcriptRoot, "kernel"), OPENCODE_DB: join(transcriptRoot, "custom.db") },
+    expected: join(transcriptRoot, "custom.db"),
+  },
+  {
+    name: "relative database override under kernel data",
+    env: { KERNEL_DATA_DIR: join(transcriptRoot, "kernel"), OPENCODE_DB: "nested/custom.db" },
+    expected: join(transcriptRoot, "kernel", "nested", "custom.db"),
+  },
+  {
+    name: "relative kernel data resolves against the kernel process cwd",
+    env: { KERNEL_DATA_DIR: "relative-data", OPENCODE_DB: "custom.db" },
+    expected: join(transcriptCwd, "relative-data", "custom.db"),
+  },
+  {
+    name: "XDG data and scenario fallback",
+    env: { XDG_DATA_HOME: join(transcriptRoot, "xdg"), SCENARIO: "codeartsdoer" },
+    expected: join(transcriptRoot, "xdg", "codeartsdoer", "opencode.db"),
+  },
+  {
+    name: "XDG data with the kernel's default scenario",
+    env: { XDG_DATA_HOME: join(transcriptRoot, "xdg") },
+    expected: join(transcriptRoot, "xdg", "opencode", "opencode.db"),
+  },
+  {
+    name: "home data fallback for an explicit scenario",
+    env: { KERNEL_DATA_DIR: "", XDG_DATA_HOME: "", SCENARIO: "codeartsdoer", OPENCODE_DB: "" },
+    expected: join(transcriptHome, ".local", "share", "codeartsdoer", "opencode.db"),
+  },
+  {
+    name: "home data and default scenario fallback",
+    env: {},
+    expected: join(transcriptHome, ".local", "share", "opencode", "opencode.db"),
+  },
+  {
+    name: "in-memory database skips transcript collection",
+    env: { KERNEL_DATA_DIR: join(transcriptRoot, "kernel"), OPENCODE_DB: ":memory:" },
+    expected: undefined,
+  },
+]) {
+  test(`codearts: transcript path uses ${name} for file and shell checkpoints`, async (t) => {
+    const { hooks, calls } = await pluginFixture(t, "codearts", 0, "src", {
+      env, home: transcriptHome, cwd: transcriptCwd,
+    })
+    for (const tool of ["write", "bash"]) {
+      const input = invocation(tool)
+      const args = tool === "write" ? { filePath: "main.ts" } : { command: "echo hello > main.ts" }
+      await hooks["tool.execute.before"](input, { args })
+      await hooks["tool.execute.after"](input, {})
+      assert.equal(calls.at(-2).input.hook_event_name, "PreToolUse")
+      assert.equal(Object.hasOwn(calls.at(-2).input, "transcript_path"), false)
+      assert.equal(calls.at(-1).input.hook_event_name, "PostToolUse")
+      assert.equal(calls.at(-1).input.transcript_path, expected)
+      assert.equal(Object.hasOwn(calls.at(-1).input, "transcript_path"), expected !== undefined)
+      assert.deepEqual(calls.at(-1).input.tool_input, calls.at(-2).input.tool_input)
+    }
+    assert.equal(calls.length, 4)
+  })
+}
+
+test("opencode: CodeArts transcript environment does not change checkpoint payloads", async (t) => {
+  const { hooks, calls } = await pluginFixture(t, "opencode", 0, "", {
+    env: { KERNEL_DATA_DIR: transcriptRoot, OPENCODE_DB: "custom.db" },
+  })
+  for (const tool of ["write", "bash"]) {
+    const input = invocation(tool)
+    const args = tool === "write" ? { filePath: "main.ts" } : { command: "echo hello > main.ts" }
+    await hooks["tool.execute.before"](input, { args })
+    await hooks["tool.execute.after"](input, {})
+  }
+  assert.equal(calls.length, 4)
+  assert.ok(calls.every(({ input }) => !Object.hasOwn(input, "transcript_path")))
+})
+
+const messageUpdated = (sessionID, properties = {}) => ({ event: {
+  type: "message.updated",
+  properties: { info: {
+    id: `message-${sessionID}`, sessionID, role: "assistant", time: { created: 1, completed: 2 },
+    ...properties,
+  } },
+} })
+
+test("codearts: completed messages refresh transcripts for their own sessions without edit payloads", async (t) => {
+  const { directory, hooks, calls } = await pluginFixture(t, "codearts", 0, "src", {
+    env: { KERNEL_DATA_DIR: transcriptRoot },
+  })
+  await Promise.all([
+    hooks.event(messageUpdated("session-1")),
+    hooks.event(messageUpdated("session-2", { error: { name: "AbortedError", data: { message: "Aborted" } } })),
+  ])
+  assert.equal(calls.length, 2)
+  assert.deepEqual(calls.map(({ input }) => input.session_id).sort(), ["session-1", "session-2"])
+  for (const { args, input } of calls) {
+    assert.deepEqual(args, ["checkpoint", "codearts", "--hook-input", "stdin"])
+    assert.deepEqual(input, {
+      hook_event_name: "SessionUpdate",
+      session_id: input.session_id,
+      cwd: directory,
+      transcript_path: join(transcriptRoot, "opencode.db"),
+    })
+  }
+})
+
+test("codearts: session refresh ignores unfinished messages, user messages, idle events and empty IDs", async (t) => {
+  const { hooks, calls } = await pluginFixture(t)
+  for (const event of [
+    messageUpdated("session-1", { time: { created: 1 } }),
+    messageUpdated("session-1", { role: "user" }),
+    messageUpdated(""),
+    messageUpdated("   "),
+    { event: { type: "session.idle", properties: { sessionID: "session-1" } } },
+    { event: { type: "session.status", properties: { sessionID: "session-1", status: { type: "idle" } } } },
+  ]) {
+    await hooks.event(event)
+  }
+  assert.equal(calls.length, 0)
+})
+
+test("codearts: session refresh leaves pending file and shell checkpoint scopes intact", async (t) => {
+  const { hooks, calls } = await pluginFixture(t)
+  for (const tool of ["write", "bash"]) {
+    const input = invocation(tool)
+    const args = tool === "write" ? { filePath: "main.ts" } : { command: "echo hello > main.ts" }
+    await hooks["tool.execute.before"](input, { args })
+    await hooks.event(messageUpdated("other-session"))
+    await hooks["tool.execute.after"](input, {})
+    assert.deepEqual(calls.slice(-3).map(({ input }) => input.hook_event_name), ["PreToolUse", "SessionUpdate", "PostToolUse"])
+    assert.deepEqual(calls.at(-1).input.tool_input, calls.at(-3).input.tool_input)
+    assert.equal(calls.at(-1).input.session_id, input.sessionID)
+    assert.equal(calls.at(-1).input.tool_use_id, input.callID)
+  }
+})
+
+for (const agent of ["codearts", "opencode"]) {
+  test(`${agent}: session refresh skips unsupported or in-memory transcripts`, async (t) => {
+    const { hooks, calls } = await pluginFixture(t, agent, 0, "", {
+      env: { KERNEL_DATA_DIR: transcriptRoot, OPENCODE_DB: agent === "codearts" ? ":memory:" : "custom.db" },
+    })
+    await hooks.event(messageUpdated("session-1"))
+    assert.equal(calls.length, 0)
+  })
+}
+
+test("codearts: session refresh outside a git repository is skipped", async (t) => {
+  const { directory, hooks, calls } = await pluginFixture(t)
+  await rm(join(directory, ".git"), { recursive: true })
+  await hooks.event(messageUpdated("session-1"))
+  assert.equal(calls.length, 0)
+})
+
+test("codearts: a failed session refresh does not interrupt subsequent tool hooks", async (t) => {
+  let attempts = 0
+  const { hooks, calls } = await pluginFixture(t, "codearts", () => attempts++ === 0 ? 1 : 0)
+  await assert.doesNotReject(() => hooks.event(messageUpdated("session-1")))
+  const input = invocation("write")
+  await hooks["tool.execute.before"](input, { args: { filePath: "main.ts" } })
+  await hooks["tool.execute.after"](input, {})
+  assert.deepEqual(calls.map(({ input }) => input.hook_event_name), ["SessionUpdate", "PreToolUse", "PostToolUse"])
+})
 
 for (const agent of ["codearts", "opencode"]) {
   test(`${agent}: edit checkpoints preserve call identity and scoped file paths`, async (t) => {

--- a/agent-support/opencode/git-ai.ts
+++ b/agent-support/opencode/git-ai.ts
@@ -22,10 +22,12 @@ import { spawn } from "child_process"
 import { readFile, stat } from "fs/promises"
 import { dirname, isAbsolute, join, resolve } from "path"
 
+// Also embedded by the CodeArts installer, which substitutes this agent name.
+const AGENT_NAME = "opencode"
 // Absolute path to git-ai binary, replaced at install time by `git-ai install-hooks`
 const GIT_AI_BIN = "__GIT_AI_BINARY_PATH__"
 const CHECKPOINT_TIMEOUT_MS = 10_000
-const CHECKPOINT_ARGS = ["checkpoint", "opencode", "--hook-input", "stdin"]
+const CHECKPOINT_ARGS = ["checkpoint", AGENT_NAME, "--hook-input", "stdin"]
 
 // Tools that modify files and should be tracked
 const FILE_EDIT_TOOLS = new Set([
@@ -44,7 +46,9 @@ const APPLY_PATCH_FILE_PREFIXES = [
   "*** Move to: ",
 ]
 
-const isEditTool = (toolName: string): boolean => FILE_EDIT_TOOLS.has(toolName.toLowerCase())
+const isEditTool = (toolName: string): boolean =>
+  FILE_EDIT_TOOLS.has(toolName.toLowerCase()) ||
+  (AGENT_NAME.toString() === "codearts" && toolName.toLowerCase() === "deletefile")
 
 const isBashTool = (toolName: string): boolean => {
   const name = toolName.toLowerCase()
@@ -107,6 +111,10 @@ const collectToolPaths = (value: unknown, out: Set<string>): void => {
 
   for (const [key, val] of Object.entries(value)) {
     const keyLower = key.toLowerCase()
+    // Source text may itself contain file URIs or examples of apply_patch input.
+    if (["content", "oldstring", "newstring", "oldtext", "newtext", "old_text", "new_text"].includes(keyLower)) {
+      continue
+    }
     const isSinglePathKey = keyLower === "file_path" || keyLower === "filepath" || keyLower === "path" || keyLower === "fspath"
     const isMultiPathKey = keyLower === "files" || keyLower === "filepaths" || keyLower === "file_paths"
 
@@ -167,7 +175,7 @@ const extractToolCwd = (args: Record<string, unknown> | undefined): string | und
 }
 
 const debugEnabled = (): boolean => {
-  const value = process.env.GIT_AI_OPENCODE_DEBUG ?? process.env.GIT_AI_DEBUG
+  const value = process.env[`GIT_AI_${AGENT_NAME.toUpperCase()}_DEBUG`] ?? process.env.GIT_AI_DEBUG
   return value === "1" || value?.toLowerCase() === "true"
 }
 
@@ -182,7 +190,7 @@ const debugLog = (message: string, error?: unknown): void => {
       : error === undefined
         ? ""
         : String(error)
-    console.error(`[git-ai opencode] ${message}${detail ? `: ${detail}` : ""}`)
+    console.error(`[git-ai ${AGENT_NAME}] ${message}${detail ? `: ${detail}` : ""}`)
   } catch {
     // Debug logging must never be the reason a hook fails.
   }
@@ -223,6 +231,7 @@ const runCheckpoint = (hookInput: string): Promise<void> => {
 
     const child = spawn(GIT_AI_BIN, CHECKPOINT_ARGS, {
       stdio: ["pipe", "ignore", "pipe"],
+      windowsHide: true,
     })
 
     timeout = setTimeout(() => {
@@ -231,7 +240,7 @@ const runCheckpoint = (hookInput: string): Promise<void> => {
       } catch (error) {
         debugLog("failed to kill timed-out checkpoint command", error)
       }
-      finish(new Error(`git-ai checkpoint opencode timed out after ${CHECKPOINT_TIMEOUT_MS}ms`))
+      finish(new Error(`git-ai checkpoint ${AGENT_NAME} timed out after ${CHECKPOINT_TIMEOUT_MS}ms`))
     }, CHECKPOINT_TIMEOUT_MS)
 
     const stderr: Buffer[] = []
@@ -251,7 +260,7 @@ const runCheckpoint = (hookInput: string): Promise<void> => {
       }
 
       const stderrText = Buffer.concat(stderr).toString().trim()
-      finish(new Error(`git-ai checkpoint opencode exited with ${code}${stderrText ? `: ${stderrText}` : ""}`))
+      finish(new Error(`git-ai checkpoint ${AGENT_NAME} exited with ${code}${stderrText ? `: ${stderrText}` : ""}`))
     })
 
     child.stdin.end(hookInput)
@@ -269,10 +278,12 @@ export const GitAiPlugin: Plugin = async (ctx) => {
 
 const createGitAiPlugin = (ctx: Parameters<Plugin>[0]): Awaited<ReturnType<Plugin>> => {
   const { worktree, directory } = ctx
-  const defaultCwd = worktree || directory || process.cwd()
+  const defaultCwd = directory || worktree || process.cwd()
 
-  // Track pending calls by callID so we can reference them in the after hook
-  const pendingCalls = new Map<string, { repoDir: string; sessionID: string; toolInput: unknown }>()
+  // Call IDs can be reused across sessions. Keep each before/after pair together.
+  const callKey = (sessionID: string, callID: string): string => JSON.stringify([sessionID, callID])
+  const pendingCalls = new Map<string, { cwd: string; toolCwd: string; sessionID: string; toolInput: unknown; model?: string }>()
+  const sessionModels = new Map<string, string>()
 
   const nearestExistingDirectory = async (pathHint: string): Promise<string | null> => {
     let candidate = pathHint
@@ -424,25 +435,18 @@ const createGitAiPlugin = (ctx: Parameters<Plugin>[0]): Awaited<ReturnType<Plugi
     return [...paths]
   }
 
-  const withMetadataFilePaths = (toolInput: unknown, filePaths: string[]): unknown => {
-    if (filePaths.length === 0) {
-      return toolInput
-    }
-
-    if (toolInput && typeof toolInput === "object" && !Array.isArray(toolInput)) {
-      return {
-        ...toolInput,
-        file_paths: filePaths,
-      }
-    }
-
-    return {
-      input: toolInput,
-      file_paths: filePaths,
-    }
-  }
-
   return {
+    "chat.params": swallowHookErrors(
+      "model capture failed",
+      async (input: { sessionID: string; agent?: string; model: { id?: string }; isEnsureTitle?: boolean }) => {
+        if (input.isEnsureTitle || input.agent === "title") return
+        const model = hookString(input.model?.id).trim()
+        if (input.sessionID && model) {
+          sessionModels.set(input.sessionID, model)
+        }
+      },
+    ),
+
     "tool.execute.before": swallowHookErrors(
       "pre-tool checkpoint failed",
       async (input: ToolHookInput, output?: { args?: unknown }) => {
@@ -455,25 +459,34 @@ const createGitAiPlugin = (ctx: Parameters<Plugin>[0]): Awaited<ReturnType<Plugi
 
         const callID = hookString(input.callID)
         const sessionID = hookString(input.sessionID)
+        if (!callID.trim() || !sessionID.trim()) {
+          return
+        }
         const toolInput = output?.args ?? input.args
         const toolCwd = resolveCwd(extractToolCwd(asRecord(toolInput)))
         const filePaths = isTrackedEdit ? extractFilePaths(toolInput, toolCwd) : []
+        // The checkpoint runs at the repo root, while tool paths may be relative
+        // to a subdirectory. Send resolved edit paths, not the original arguments.
+        const checkpointInput = isTrackedEdit ? { file_paths: filePaths } : toolInput
         const repoDir = await resolveRepoDir(filePaths, toolCwd)
         if (!repoDir) {
           return
         }
 
-        pendingCalls.set(callID, { repoDir, sessionID, toolInput })
+        const model = sessionModels.get(sessionID)
+        const cwd = isTrackedBash ? toolCwd : repoDir
 
         const hookInput = JSON.stringify({
           hook_event_name: "PreToolUse",
           session_id: sessionID,
           tool_use_id: callID,
-          cwd: repoDir,
+          cwd,
           tool_name: toolName,
-          tool_input: toolInput,
+          tool_input: checkpointInput,
+          model,
         })
         await runCheckpoint(hookInput)
+        pendingCalls.set(callKey(sessionID, callID), { cwd, toolCwd, sessionID, toolInput: checkpointInput, model })
       },
     ),
 
@@ -486,25 +499,28 @@ const createGitAiPlugin = (ctx: Parameters<Plugin>[0]): Awaited<ReturnType<Plugi
         }
 
         const callID = hookString(input.callID)
-        const callInfo = pendingCalls.get(callID)
-        pendingCalls.delete(callID)
+        const key = callKey(hookString(input.sessionID), callID)
+        const callInfo = pendingCalls.get(key)
+        pendingCalls.delete(key)
 
         if (!callInfo) {
           debugLog(`skipping post-tool checkpoint without matching pre-tool call for ${callID}`)
           return
         }
 
-        const toolCwd = resolveCwd(extractToolCwd(asRecord(input.args)))
-        const metadataFilePaths = extractMetadataFilePaths(output?.metadata, toolCwd)
-        const toolInput = withMetadataFilePaths(callInfo.toolInput, metadataFilePaths)
+        const metadataFilePaths = extractMetadataFilePaths(output?.metadata, callInfo.toolCwd)
+        const toolInput = isEditTool(toolName)
+          ? { file_paths: [...new Set([...extractFilePaths(callInfo.toolInput, callInfo.cwd), ...metadataFilePaths])] }
+          : callInfo.toolInput
 
         const hookInput = JSON.stringify({
           hook_event_name: "PostToolUse",
           session_id: callInfo.sessionID,
           tool_use_id: callID,
-          cwd: callInfo.repoDir,
+          cwd: callInfo.cwd,
           tool_name: toolName,
           tool_input: toolInput,
+          model: callInfo.model,
         })
         await runCheckpoint(hookInput)
       },

--- a/agent-support/opencode/git-ai.ts
+++ b/agent-support/opencode/git-ai.ts
@@ -17,7 +17,7 @@
  * @see https://opencode.ai/docs/plugins/
  */
 
-import type { Plugin } from "@opencode-ai/plugin"
+import type { Hooks, Plugin } from "@opencode-ai/plugin"
 import { spawn } from "child_process"
 import { readFile, stat } from "fs/promises"
 import { dirname, isAbsolute, join, resolve } from "path"
@@ -28,6 +28,7 @@ const AGENT_NAME = "opencode"
 const GIT_AI_BIN = "__GIT_AI_BINARY_PATH__"
 const CHECKPOINT_TIMEOUT_MS = 10_000
 const CHECKPOINT_ARGS = ["checkpoint", AGENT_NAME, "--hook-input", "stdin"]
+const MAX_SESSION_MODELS = 256
 
 // Tools that modify files and should be tracked
 const FILE_EDIT_TOOLS = new Set([
@@ -284,6 +285,15 @@ const createGitAiPlugin = (ctx: Parameters<Plugin>[0]): Awaited<ReturnType<Plugi
   const callKey = (sessionID: string, callID: string): string => JSON.stringify([sessionID, callID])
   const pendingCalls = new Map<string, { cwd: string; toolCwd: string; sessionID: string; toolInput: unknown; model?: string }>()
   const sessionModels = new Map<string, string>()
+  const rememberSessionModel = (sessionID: string, model: string): void => {
+    // Keep recent sessions even when the client never emits session.deleted.
+    sessionModels.delete(sessionID)
+    sessionModels.set(sessionID, model)
+    if (sessionModels.size > MAX_SESSION_MODELS) {
+      const oldestSessionID = sessionModels.keys().next().value
+      if (oldestSessionID !== undefined) sessionModels.delete(oldestSessionID)
+    }
+  }
 
   const nearestExistingDirectory = async (pathHint: string): Promise<string | null> => {
     let candidate = pathHint
@@ -436,13 +446,22 @@ const createGitAiPlugin = (ctx: Parameters<Plugin>[0]): Awaited<ReturnType<Plugi
   }
 
   return {
+    event: swallowHookErrors(
+      "session model cleanup failed",
+      async ({ event }: Parameters<NonNullable<Hooks["event"]>>[0]) => {
+        if (event.type === "session.deleted") {
+          sessionModels.delete(event.properties.info.id)
+        }
+      },
+    ),
+
     "chat.params": swallowHookErrors(
       "model capture failed",
       async (input: { sessionID: string; agent?: string; model: { id?: string }; isEnsureTitle?: boolean }) => {
         if (input.isEnsureTitle || input.agent === "title") return
         const model = hookString(input.model?.id).trim()
         if (input.sessionID && model) {
-          sessionModels.set(input.sessionID, model)
+          rememberSessionModel(input.sessionID, model)
         }
       },
     ),
@@ -474,6 +493,7 @@ const createGitAiPlugin = (ctx: Parameters<Plugin>[0]): Awaited<ReturnType<Plugi
         }
 
         const model = sessionModels.get(sessionID)
+        if (model) rememberSessionModel(sessionID, model)
         const cwd = isTrackedBash ? toolCwd : repoDir
 
         const hookInput = JSON.stringify({

--- a/agent-support/opencode/git-ai.ts
+++ b/agent-support/opencode/git-ai.ts
@@ -20,6 +20,7 @@
 import type { Hooks, Plugin } from "@opencode-ai/plugin"
 import { spawn } from "child_process"
 import { readFile, stat } from "fs/promises"
+import { homedir } from "os"
 import { dirname, isAbsolute, join, resolve } from "path"
 import { fileURLToPath } from "url"
 
@@ -56,6 +57,21 @@ const isEditTool = (toolName: string): boolean =>
 const isBashTool = (toolName: string): boolean => {
   const name = toolName.toLowerCase()
   return name === "bash" || name === "shell"
+}
+
+const codeArtsTranscriptPath = (): string | undefined => {
+  if (AGENT_NAME.toString() !== "codearts") return undefined
+
+  // CodeArts CLI and IDE kernels share OpenCode's SQLite format, but set their
+  // own data directory. Resolve here so the daemon need not inherit their env.
+  const database = process.env.OPENCODE_DB || "opencode.db"
+  if (database === ":memory:") return undefined
+  if (isAbsolute(database)) return resolve(process.cwd(), database)
+  const data = process.env.KERNEL_DATA_DIR || join(
+    process.env.XDG_DATA_HOME || join(homedir(), ".local", "share"),
+    process.env.SCENARIO || "opencode",
+  )
+  return resolve(process.cwd(), join(data, database))
 }
 
 const normalizePath = (rawPath: string, cwd?: string, toolName?: string): string | null => {
@@ -292,6 +308,7 @@ export const GitAiPlugin: Plugin = async (ctx) => {
 const createGitAiPlugin = (ctx: Parameters<Plugin>[0]): Awaited<ReturnType<Plugin>> => {
   const { worktree, directory } = ctx
   const defaultCwd = directory || worktree || process.cwd()
+  const transcriptPath = codeArtsTranscriptPath()
 
   // Call IDs can be reused across sessions. Keep each before/after pair together.
   const callKey = (sessionID: string, callID: string): string => JSON.stringify([sessionID, callID])
@@ -431,7 +448,7 @@ const createGitAiPlugin = (ctx: Parameters<Plugin>[0]): Awaited<ReturnType<Plugi
 
   return {
     event: swallowHookErrors(
-      "tool/session cleanup failed",
+      "tool/session event failed",
       async ({ event }: Parameters<NonNullable<Hooks["event"]>>[0]) => {
         if (event.type === "session.deleted") {
           sessionModels.delete(event.properties.info.id)
@@ -441,6 +458,20 @@ const createGitAiPlugin = (ctx: Parameters<Plugin>[0]): Awaited<ReturnType<Plugi
           if (part.type === "tool" && part.state.status === "error") {
             pendingCalls.delete(callKey(part.sessionID, part.callID))
           }
+        }
+        if (transcriptPath && event.type === "message.updated") {
+          const info = event.properties.info
+          if (info.role !== "assistant" || typeof info.time.completed !== "number" || !info.sessionID.trim()) return
+          const repoDir = await resolveRepoDir([], defaultCwd)
+          if (!repoDir) return
+          // CodeArts persists final tool results and reply parts after the tool
+          // hook. A completed message refreshes only its transcript, not files.
+          await runCheckpoint(JSON.stringify({
+            hook_event_name: "SessionUpdate",
+            session_id: info.sessionID,
+            cwd: repoDir,
+            transcript_path: transcriptPath,
+          }))
         }
       },
     ),
@@ -545,6 +576,7 @@ const createGitAiPlugin = (ctx: Parameters<Plugin>[0]): Awaited<ReturnType<Plugi
           // discovered in post metadata may already contain unrelated edits.
           tool_input: callInfo.toolInput,
           model: callInfo.model,
+          transcript_path: transcriptPath,
         })
         await runCheckpoint(hookInput)
       },

--- a/agent-support/opencode/git-ai.ts
+++ b/agent-support/opencode/git-ai.ts
@@ -21,6 +21,7 @@ import type { Hooks, Plugin } from "@opencode-ai/plugin"
 import { spawn } from "child_process"
 import { readFile, stat } from "fs/promises"
 import { dirname, isAbsolute, join, resolve } from "path"
+import { fileURLToPath } from "url"
 
 // Also embedded by the CodeArts installer, which substitutes this agent name.
 const AGENT_NAME = "opencode"
@@ -29,6 +30,7 @@ const GIT_AI_BIN = "__GIT_AI_BINARY_PATH__"
 const CHECKPOINT_TIMEOUT_MS = 10_000
 const CHECKPOINT_ARGS = ["checkpoint", AGENT_NAME, "--hook-input", "stdin"]
 const MAX_SESSION_MODELS = 256
+const MAX_PENDING_CALLS = 1024
 
 // Tools that modify files and should be tracked
 const FILE_EDIT_TOOLS = new Set([
@@ -56,24 +58,34 @@ const isBashTool = (toolName: string): boolean => {
   return name === "bash" || name === "shell"
 }
 
-const normalizePath = (rawPath: string, cwd?: string): string | null => {
+const normalizePath = (rawPath: string, cwd?: string, toolName?: string): string | null => {
   const trimmed = rawPath.trim().replace(/^['"]|['"]$/g, "")
   if (!trimmed) {
     return null
   }
 
-  const withoutScheme = trimmed
-    .replace(/^file:\/\/localhost/, "")
-    .replace(/^file:\/\//, "")
+  if (trimmed.startsWith("file://")) {
+    try {
+      return fileURLToPath(trimmed)
+    } catch {
+      return null
+    }
+  }
 
-  const isWindowsAbs = /^[a-zA-Z]:[\\/]/.test(withoutScheme)
-  if (isAbsolute(withoutScheme) || isWindowsAbs) {
-    return withoutScheme
+  // CodeArts 26.8.1 rewrites MSYS drive paths before edit/deleteFile execute.
+  // Its write and patch tools do not apply that execution-time transformation.
+  const isCodeArtsDrivePath = AGENT_NAME.toString() === "codearts" && process.platform === "win32"
+    && (toolName?.toLowerCase() === "edit" || toolName?.toLowerCase() === "deletefile")
+  const toolPath = isCodeArtsDrivePath ? trimmed.replace(/^\/([a-zA-Z])\//, "$1:/") : trimmed
+
+  const isWindowsAbs = /^[a-zA-Z]:[\\/]/.test(toolPath)
+  if (isAbsolute(toolPath) || isWindowsAbs) {
+    return toolPath
   }
 
   // Use provided cwd, or fall back to process.cwd() for relative paths
   const resolvedCwd = cwd || process.cwd()
-  return join(resolvedCwd, withoutScheme)
+  return join(resolvedCwd, toolPath)
 }
 
 const collectApplyPatchPaths = (raw: string, out: Set<string>): void => {
@@ -137,13 +149,13 @@ const collectToolPaths = (value: unknown, out: Set<string>): void => {
   }
 }
 
-const extractFilePaths = (args: unknown, cwd?: string): string[] => {
+const extractFilePaths = (args: unknown, cwd?: string, toolName?: string): string[] => {
   const rawPaths = new Set<string>()
   collectToolPaths(args, rawPaths)
 
   const normalizedPaths = new Set<string>()
   for (const rawPath of rawPaths) {
-    const normalized = normalizePath(rawPath, cwd)
+    const normalized = normalizePath(rawPath, cwd, toolName)
     if (normalized) {
       normalizedPaths.add(normalized)
     }
@@ -283,7 +295,7 @@ const createGitAiPlugin = (ctx: Parameters<Plugin>[0]): Awaited<ReturnType<Plugi
 
   // Call IDs can be reused across sessions. Keep each before/after pair together.
   const callKey = (sessionID: string, callID: string): string => JSON.stringify([sessionID, callID])
-  const pendingCalls = new Map<string, { cwd: string; toolCwd: string; sessionID: string; toolInput: unknown; model?: string }>()
+  const pendingCalls = new Map<string, { cwd: string; sessionID: string; toolInput: unknown; model?: string }>()
   const sessionModels = new Map<string, string>()
   const rememberSessionModel = (sessionID: string, model: string): void => {
     // Keep recent sessions even when the client never emits session.deleted.
@@ -417,40 +429,18 @@ const createGitAiPlugin = (ctx: Parameters<Plugin>[0]): Awaited<ReturnType<Plugi
     return null
   }
 
-  const extractMetadataFilePaths = (metadata: unknown, cwd?: string): string[] => {
-    if (!metadata || typeof metadata !== "object") {
-      return []
-    }
-
-    const files = (metadata as { files?: unknown }).files
-    if (!Array.isArray(files)) {
-      return []
-    }
-
-    const paths = new Set<string>()
-    for (const file of files) {
-      if (!file || typeof file !== "object") {
-        continue
-      }
-
-      const filePath = (file as { filePath?: unknown; path?: unknown }).filePath ?? (file as { path?: unknown }).path
-      if (typeof filePath === "string") {
-        const normalized = normalizePath(filePath, cwd ?? defaultCwd)
-        if (normalized) {
-          paths.add(normalized)
-        }
-      }
-    }
-
-    return [...paths]
-  }
-
   return {
     event: swallowHookErrors(
-      "session model cleanup failed",
+      "tool/session cleanup failed",
       async ({ event }: Parameters<NonNullable<Hooks["event"]>>[0]) => {
         if (event.type === "session.deleted") {
           sessionModels.delete(event.properties.info.id)
+        }
+        if (event.type === "message.part.updated") {
+          const part = event.properties.part
+          if (part.type === "tool" && part.state.status === "error") {
+            pendingCalls.delete(callKey(part.sessionID, part.callID))
+          }
         }
       },
     ),
@@ -483,36 +473,53 @@ const createGitAiPlugin = (ctx: Parameters<Plugin>[0]): Awaited<ReturnType<Plugi
         }
         const toolInput = output?.args ?? input.args
         const toolCwd = resolveCwd(extractToolCwd(asRecord(toolInput)))
-        const filePaths = isTrackedEdit ? extractFilePaths(toolInput, toolCwd) : []
+        const filePaths = isTrackedEdit ? extractFilePaths(toolInput, toolCwd, toolName) : []
+        // An empty edit scope can turn into a repository-wide checkpoint.
+        if (isTrackedEdit && filePaths.length === 0) return
         // The checkpoint runs at the repo root, while tool paths may be relative
         // to a subdirectory. Send resolved edit paths, not the original arguments.
         const checkpointInput = isTrackedEdit ? { file_paths: filePaths } : toolInput
-        const repoDir = await resolveRepoDir(filePaths, toolCwd)
-        if (!repoDir) {
-          return
-        }
-
         const model = sessionModels.get(sessionID)
         if (model) rememberSessionModel(sessionID, model)
-        const cwd = isTrackedBash ? toolCwd : repoDir
+        const key = callKey(sessionID, callID)
+        const callInfo = { cwd: toolCwd, sessionID, toolInput: checkpointInput, model }
+        // Register before any asynchronous work so cancellation can remove the
+        // call while repository discovery or the pre-checkpoint is in flight.
+        pendingCalls.delete(key)
+        pendingCalls.set(key, callInfo)
+        // Some clients omit terminal events for cancelled/failed calls. Bound
+        // retained state; an evicted call safely skips its post-checkpoint.
+        if (pendingCalls.size > MAX_PENDING_CALLS) {
+          const oldestKey = pendingCalls.keys().next().value
+          if (oldestKey !== undefined) pendingCalls.delete(oldestKey)
+        }
 
-        const hookInput = JSON.stringify({
-          hook_event_name: "PreToolUse",
-          session_id: sessionID,
-          tool_use_id: callID,
-          cwd,
-          tool_name: toolName,
-          tool_input: checkpointInput,
-          model,
-        })
-        await runCheckpoint(hookInput)
-        pendingCalls.set(callKey(sessionID, callID), { cwd, toolCwd, sessionID, toolInput: checkpointInput, model })
+        let checkpointSucceeded = false
+        try {
+          const repoDir = await resolveRepoDir(filePaths, toolCwd)
+          if (!repoDir || pendingCalls.get(key) !== callInfo) return
+          callInfo.cwd = isTrackedBash ? toolCwd : repoDir
+          await runCheckpoint(JSON.stringify({
+            hook_event_name: "PreToolUse",
+            session_id: sessionID,
+            tool_use_id: callID,
+            cwd: callInfo.cwd,
+            tool_name: toolName,
+            tool_input: checkpointInput,
+            model,
+          }))
+          checkpointSucceeded = true
+        } finally {
+          if (!checkpointSucceeded && pendingCalls.get(key) === callInfo) {
+            pendingCalls.delete(key)
+          }
+        }
       },
     ),
 
     "tool.execute.after": swallowHookErrors(
       "post-tool checkpoint failed",
-      async (input: ToolHookInput, output?: { metadata?: unknown }) => {
+      async (input: ToolHookInput) => {
         const toolName = hookString(input.tool)
         if (!isEditTool(toolName) && !isBashTool(toolName)) {
           return
@@ -528,18 +535,15 @@ const createGitAiPlugin = (ctx: Parameters<Plugin>[0]): Awaited<ReturnType<Plugi
           return
         }
 
-        const metadataFilePaths = extractMetadataFilePaths(output?.metadata, callInfo.toolCwd)
-        const toolInput = isEditTool(toolName)
-          ? { file_paths: [...new Set([...extractFilePaths(callInfo.toolInput, callInfo.cwd), ...metadataFilePaths])] }
-          : callInfo.toolInput
-
         const hookInput = JSON.stringify({
           hook_event_name: "PostToolUse",
           session_id: callInfo.sessionID,
           tool_use_id: callID,
           cwd: callInfo.cwd,
           tool_name: toolName,
-          tool_input: toolInput,
+          // Only attribute paths whose pre-edit state was checkpointed. Files
+          // discovered in post metadata may already contain unrelated edits.
+          tool_input: callInfo.toolInput,
           model: callInfo.model,
         })
         await runCheckpoint(hookInput)

--- a/agent-support/opencode/package.json
+++ b/agent-support/opencode/package.json
@@ -5,6 +5,7 @@
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {
+    "test": "node --test git-ai.test.mjs",
     "type-check": "tsc --noEmit"
   },
   "dependencies": {

--- a/docs/codearts.md
+++ b/docs/codearts.md
@@ -31,7 +31,28 @@ calls are cleared when the client reports a tool error; retained pending calls
 are also capped at 1,024 if terminal events are missing. An evicted call skips
 its post-checkpoint.
 
-This integration does not import stored conversation transcripts. It covers tool edits reported through CodeArts Agent hooks; legacy CodeArts Snap inline completions are not covered by these hooks.
+After a tracked tool call and when an assistant message finishes, Git AI reads
+that session's conversation from the CodeArts SQLite database through its
+existing asynchronous transcript worker. The completion notification collects
+final replies and tool results written after the tool hook, without creating
+another code-attribution checkpoint. Completed conversations without editing
+tools are also collected when the client is running in a Git repository.
+User messages, assistant messages and tool calls retain their native data,
+with the agent recorded as `codearts`. Child sessions retain their parent
+session IDs when CodeArts provides them. Transcript collection follows Git
+AI's existing configuration and secret-redaction rules.
+
+The plugin resolves the database path inside the CodeArts process, using
+`KERNEL_DATA_DIR`, or `XDG_DATA_HOME` and `SCENARIO` with the kernel's defaults.
+The standard database is `opencode.db`; the CLI normally stores it under
+`~/.codeartsdoer/cli-data`. `OPENCODE_DB` can select another absolute path or a
+path relative to the kernel's data directory. An in-memory database
+(`OPENCODE_DB=:memory:`) cannot be collected by Git AI. Missing database files
+do not prevent code attribution. This integration uses the SQLite schema
+verified in CodeArts CLI 26.8.1 and VS Code AgentKernel 26.8.101; custom build
+channels with a different database name should set `OPENCODE_DB` explicitly.
+
+Legacy CodeArts Snap inline completions are not covered by these hooks.
 
 ### Tool coverage
 
@@ -62,8 +83,8 @@ other tools, whose execution uses different path handling.
 
 Read-only tools are skipped. Arbitrarily named custom or MCP file-writing tools
 are not automatically tracked. Subagent edits depend on receiving their own
-tracked tool hooks; this implementation isolates session/call IDs but has not
-live-tested subagent editing or imported parent/child conversation links.
+tracked tool hooks. Parent/child conversation links are covered by integration
+tests; real subagent editing has not yet been verified.
 The shared shell snapshot algorithm detects created and modified files, not
 pure file deletions. Shell deletion attribution is therefore not a guaranteed
 capability of either integration.

--- a/docs/codearts.md
+++ b/docs/codearts.md
@@ -23,6 +23,14 @@ Before a tracked file edit, the plugin captures any existing changes as untracke
 
 The plugin captures the model identifier from CodeArts chat hooks when available. If CodeArts does not provide model information for the session, the model is recorded as `unknown`. Set `GIT_AI_CODEARTS_DEBUG=1` or `GIT_AI_DEBUG=1` before launching CodeArts to log checkpoint failures. Hook failures do not interrupt the agent's tool execution.
 
+File checkpoints use the same paths before and after an edit. Paths first
+reported in post-tool metadata are not added to the attribution scope, because
+their previous untracked changes cannot safely be distinguished from AI edits.
+Edits without any resolvable pre-tool paths are skipped. Failed or cancelled
+calls are cleared when the client reports a tool error; retained pending calls
+are also capped at 1,024 if terminal events are missing. An evicted call skips
+its post-checkpoint.
+
 This integration does not import stored conversation transcripts. It covers tool edits reported through CodeArts Agent hooks; legacy CodeArts Snap inline completions are not covered by these hooks.
 
 ### Tool coverage
@@ -35,8 +43,8 @@ repository's OpenCode plugin, plus CodeArts `deleteFile`:
 | --- | --- | --- |
 | `edit`, `write` | Capture changes to the supplied file paths | Real CodeArts CLI 26.8.1 / MiMo edits, commits, stats and blame verified |
 | `bash`, `shell` | Reuse OpenCode's shell snapshot attribution | Real `bash` edits verified; `shell` alias covered by parser tests |
-| `multiedit` | Extract and deduplicate paths across nested edits | Parser tests; no real CodeArts run yet |
-| `apply_patch` | Extract add, update, delete and move paths from `*** ... File:` / `*** Move to:` headers | Parser tests; no real CodeArts run yet |
+| `multiedit` | Extract and deduplicate paths across nested edits | Parser and `TestRepo` commit/blame tests, including unrelated dirty files; no real CodeArts run yet |
+| `apply_patch` | Extract add, update, delete and move paths from `*** ... File:` / `*** Move to:` headers | Parser and `TestRepo` add/move/delete commit tests; no real CodeArts run yet |
 | `patch`, `applypatch` | Recognize the aliases and use the same path extractor | Implemented; no separate real run yet |
 | `deleteFile` | Capture the explicitly named deletion target | Plugin-hook and parser tests; no real deletion attribution run yet |
 
@@ -46,6 +54,11 @@ supported fields such as `filePath`, `file_path`, `path`, `files`, nested edit
 objects, or the supported patch headers. Recognizing `patch` does not imply
 support for every patch format; a raw unified diff without supported path
 fields or headers is not currently parsed.
+
+The plugin decodes standard `file://` paths, including escaped spaces and
+Windows drive letters. On Windows, `edit` and `deleteFile` also follow CodeArts
+26.8.1's `/d/path` to `d:/path` conversion. That conversion is not applied to
+other tools, whose execution uses different path handling.
 
 Read-only tools are skipped. Arbitrarily named custom or MCP file-writing tools
 are not automatically tracked. Subagent edits depend on receiving their own

--- a/docs/codearts.md
+++ b/docs/codearts.md
@@ -1,0 +1,113 @@
+# CodeArts Agent support
+
+Git AI supports Huawei Cloud CodeArts Agent (华为云码道代码智能体) through its JavaScript/TypeScript tool hooks. The integration uses the same hook lifecycle as OpenCode and records the agent as `codearts`.
+
+## Install
+
+1. Install and start a CodeArts client with hook support: CodeArts Agent IDE, its editor extension, or CodeArts CLI.
+2. Install Git AI, then run:
+
+   ```sh
+   git-ai install-hooks
+   ```
+
+3. Restart the CodeArts IDE, reload the editor hosting the extension, or start a new CodeArts CLI process to load the plugin.
+
+The installer detects the `codearts` command or a `.codeartsdoer` directory in your home directory or current project. It writes the plugin to `~/.codeartsdoer/plugins/git-ai.ts`, which applies to all projects for the current user. On Windows, `~` is `%USERPROFILE%`.
+
+The plugin contains the absolute path to the installed Git AI binary. Running `git-ai install-hooks` again updates it when necessary. You can preview changes with `git-ai install-hooks --dry-run`.
+
+## Attribution
+
+Before a tracked file edit, the plugin captures any existing changes as untracked. After the edit, it attributes the new changes to CodeArts and its session. It also records matching shell tool calls using Git AI's existing shell checkpoint flow. Commit normally; Git AI's trace2 daemon attaches attribution to the commit.
+
+The plugin captures the model identifier from CodeArts chat hooks when available. If CodeArts does not provide model information for the session, the model is recorded as `unknown`. Set `GIT_AI_CODEARTS_DEBUG=1` or `GIT_AI_DEBUG=1` before launching CodeArts to log checkpoint failures. Hook failures do not interrupt the agent's tool execution.
+
+This integration does not import stored conversation transcripts. It covers tool edits reported through CodeArts Agent hooks; legacy CodeArts Snap inline completions are not covered by these hooks.
+
+### Tool coverage
+
+The CodeArts installer embeds the same plugin template as OpenCode. Its tracked
+tool-name set includes every editing and shell tool recognized by this
+repository's OpenCode plugin, plus CodeArts `deleteFile`:
+
+| Tool names | Handling | Verification in this implementation |
+| --- | --- | --- |
+| `edit`, `write` | Capture changes to the supplied file paths | Real CodeArts CLI 26.8.1 / MiMo edits, commits, stats and blame verified |
+| `bash`, `shell` | Reuse OpenCode's shell snapshot attribution | Real `bash` edits verified; `shell` alias covered by parser tests |
+| `multiedit` | Extract and deduplicate paths across nested edits | Parser tests; no real CodeArts run yet |
+| `apply_patch` | Extract add, update, delete and move paths from `*** ... File:` / `*** Move to:` headers | Parser tests; no real CodeArts run yet |
+| `patch`, `applypatch` | Recognize the aliases and use the same path extractor | Implemented; no separate real run yet |
+| `deleteFile` | Capture the explicitly named deletion target | Plugin-hook and parser tests; no real deletion attribution run yet |
+
+These are names the integration accepts, not a promise that every CodeArts
+version or model exposes every tool. File tools must provide paths through
+supported fields such as `filePath`, `file_path`, `path`, `files`, nested edit
+objects, or the supported patch headers. Recognizing `patch` does not imply
+support for every patch format; a raw unified diff without supported path
+fields or headers is not currently parsed.
+
+Read-only tools are skipped. Arbitrarily named custom or MCP file-writing tools
+are not automatically tracked. Subagent edits depend on receiving their own
+tracked tool hooks; this implementation isolates session/call IDs but has not
+live-tested subagent editing or imported parent/child conversation links.
+The shared shell snapshot algorithm detects created and modified files, not
+pure file deletions. Shell deletion attribution is therefore not a guaranteed
+capability of either integration.
+
+To remove only this integration, delete `~/.codeartsdoer/plugins/git-ai.ts` and restart CodeArts. The `git-ai uninstall-hooks` command removes Git AI hooks from all detected agents, including CodeArts.
+
+## Development
+
+The CodeArts installer generates its plugin from `agent-support/opencode/git-ai.ts`. Shared tool handling fixes therefore apply to both clients. Use the repository's standard development commands:
+
+```sh
+task test TEST_FILTER=codearts
+task lint
+task fmt
+task dev
+```
+
+For a real non-interactive CLI check, select an available model explicitly and
+send the prompt through stdin. For example, with MiMo configured:
+
+```powershell
+codearts models
+Get-Content -Raw .\prompt.txt | codearts run --format json --auto --model mimo/mimo-v2.5
+```
+
+This follows the invocation guidance in [Multica PR #6985](https://github.com/multica-ai/multica/pull/6985).
+Use a model listed by your installation. CodeArts CLI 26.8.1 also checks for
+`CODEARTS_CLI_AK` and `CODEARTS_CLI_SK` in the process environment, including when
+an external model provider is selected; configure authentication according to
+your provider and CodeArts setup.
+
+`--auto` controls shell execution. It does not approve native file edits:
+CodeArts automatically rejects permissions configured as `ask` in
+non-interactive `run` mode. Use the normal one-time approval flow in an
+interactive client when testing native `edit` or `write` calls. See the
+[CodeArts permission documentation](https://support.huaweicloud.com/usermanual-cli/codeartsagent_cli_0006.html).
+
+After CodeArts has actually modified files, run the project's checks, commit
+the test changes, and wait for asynchronous attribution before inspecting it:
+
+```sh
+git add <test-files>
+git commit -m "Verify CodeArts attribution"
+git-ai await --timeout 30
+git-ai stats HEAD --json
+git-ai blame <test-file> --json
+git notes --ref=ai show HEAD
+```
+
+Check the tool result and file contents as well as the process exit code.
+Confirm that the authorship note records `codearts`, the selected model, and
+the actual CodeArts session ID. Shell-generated changes and native file-tool
+changes should be verified separately so that shell fallback cannot mask a
+failed native edit.
+
+## Huawei Cloud references
+
+- [CodeArts Agent IDE and extension hooks](https://support.huaweicloud.com/intl/zh-cn/usermanual-codeartsagent/codeartsagent_ug_0036.html): plugin paths, reload requirements, and hook event signatures.
+- [CodeArts CLI hooks](https://support.huaweicloud.com/usermanual-cli/codeartsagent_cli_0018.html): shared plugin paths and lifecycle events.
+- [CodeArts CLI agents and tools](https://support.huaweicloud.com/intl/zh-cn/usermanual-cli/codeartsagent_cli_0031.html): built-in file and shell tools.

--- a/src/commands/checkpoint_agent/bash_tool.rs
+++ b/src/commands/checkpoint_agent/bash_tool.rs
@@ -345,6 +345,12 @@ pub fn classify_tool(agent: Agent, tool_name: &str) -> ToolClass {
             "bash" | "shell" => ToolClass::Bash,
             _ => ToolClass::Skip,
         },
+        Agent::CodeArts => match tool_name.to_ascii_lowercase().as_str() {
+            "edit" | "write" | "patch" | "multiedit" | "apply_patch" | "applypatch"
+            | "deletefile" => ToolClass::FileEdit,
+            "bash" | "shell" => ToolClass::Bash,
+            _ => ToolClass::Skip,
+        },
         Agent::Firebender => match tool_name {
             "Write" | "Edit" | "Delete" | "RenameSymbol" | "DeleteSymbol" => ToolClass::FileEdit,
             "Bash" => ToolClass::Bash,
@@ -399,6 +405,7 @@ pub enum Agent {
     Droid,
     Amp,
     OpenCode,
+    CodeArts,
     Firebender,
     Codex,
     Pi,

--- a/src/commands/checkpoint_agent/orchestrator.rs
+++ b/src/commands/checkpoint_agent/orchestrator.rs
@@ -3,7 +3,7 @@ use crate::authorship::working_log::{AgentId, CheckpointKind};
 use crate::checkpoint_content_budget::CheckpointContentBudget;
 use crate::commands::checkpoint_agent::presets::{
     KnownHumanEdit, ParsedHookEvent, PostBashCall, PostFileEdit, PreBashCall, PreFileEdit,
-    StreamSource, UntrackedEdit,
+    SessionUpdate, StreamSource, UntrackedEdit,
 };
 use crate::config;
 use crate::daemon::checkpoint::PreparedPathRole;
@@ -307,6 +307,7 @@ fn execute_event(
         ParsedHookEvent::PostFileEdit(e) => execute_post_file_edit(e, preset_name),
         ParsedHookEvent::PreBashCall(e) => execute_pre_bash_call(e),
         ParsedHookEvent::PostBashCall(e) => execute_post_bash_call(e),
+        ParsedHookEvent::SessionUpdate(e) => execute_session_update(e),
         ParsedHookEvent::KnownHumanEdit(e) => execute_known_human_edit(e),
         ParsedHookEvent::UntrackedEdit(e) => execute_untracked_edit(e),
     }
@@ -421,6 +422,34 @@ fn execute_untracked_edit(e: UntrackedEdit) -> Result<Vec<CheckpointRequest>, Gi
         None,
         HashMap::new(),
     ))
+}
+
+fn execute_session_update(e: SessionUpdate) -> Result<Vec<CheckpointRequest>, GitAiError> {
+    // Session updates bypass checkpoint submission, so enforce its repository
+    // filters here before notifying the transcript worker.
+    let config = config::Config::get();
+    if config.has_repository_filters() {
+        let repo = discover_repository_in_path_no_git_exec(&e.context.cwd)?;
+        if !config.is_allowed_repository(&Some(repo)) {
+            return Ok(vec![]);
+        }
+    }
+
+    let daemon_config = crate::daemon::DaemonConfig::from_env_or_default_paths()?;
+    let response = crate::daemon::send_control_request_with_timeout(
+        &daemon_config.control_socket_path,
+        &crate::daemon::ControlRequest::TranscriptUpdate {
+            context: e.context,
+            stream_source: e.stream_source,
+        },
+        std::time::Duration::from_millis(500),
+    )?;
+    if !response.ok {
+        return Err(GitAiError::Generic(response.error.unwrap_or_else(|| {
+            "daemon rejected transcript update".to_string()
+        })));
+    }
+    Ok(vec![])
 }
 
 fn execute_pre_bash_call(e: PreBashCall) -> Result<Vec<CheckpointRequest>, GitAiError> {

--- a/src/commands/checkpoint_agent/presets/codearts.rs
+++ b/src/commands/checkpoint_agent/presets/codearts.rs
@@ -2,8 +2,9 @@ use super::opencode::OpenCodePreset;
 use super::parse;
 use super::{
     AgentPreset, ParsedHookEvent, PostBashCall, PostFileEdit, PreBashCall, PreFileEdit,
-    PresetContext,
+    PresetContext, SessionUpdate, StreamFormat, StreamSource,
 };
+use crate::authorship::authorship_log_serialization::generate_session_id;
 use crate::authorship::working_log::AgentId;
 use crate::commands::checkpoint_agent::bash_tool::{self, Agent, ToolClass};
 use crate::error::GitAiError;
@@ -21,6 +22,45 @@ fn required_nonempty<'a>(input: &'a Value, key: &str) -> Result<&'a str, GitAiEr
     Ok(value)
 }
 
+fn resolve_stream_source(input: &Value, session_id: &str) -> Option<StreamSource> {
+    // The plugin resolves the CodeArts kernel's database path. Do not fall back
+    // to OpenCode's default directory or depend on the daemon's environment.
+    let path = PathBuf::from(parse::optional_str(input, "transcript_path")?);
+    if !path.is_absolute() || !path.is_file() {
+        return None;
+    }
+    let parent_id = OpenCodePreset::lookup_parent_session(&path, session_id);
+    Some(StreamSource {
+        path,
+        format: StreamFormat::OpenCodeSqlite,
+        session_id: generate_session_id(session_id, "codearts"),
+        external_session_id: session_id.to_string(),
+        external_parent_session_id: parent_id,
+    })
+}
+
+fn preset_context(input: &Value, trace_id: &str, session_id: &str, cwd: &str) -> PresetContext {
+    let mut metadata = HashMap::from([("session_id".to_string(), session_id.to_string())]);
+    if let Some(tool_name) = parse::optional_str(input, "tool_name") {
+        metadata.insert("tool_name".to_string(), tool_name.to_string());
+    }
+    PresetContext {
+        agent_id: AgentId {
+            tool: "codearts".to_string(),
+            id: session_id.to_string(),
+            model: parse::optional_str(input, "model")
+                .map(str::trim)
+                .filter(|model| !model.is_empty())
+                .unwrap_or("unknown")
+                .to_string(),
+        },
+        external_session_id: session_id.to_string(),
+        trace_id: trace_id.to_string(),
+        cwd: PathBuf::from(cwd),
+        metadata,
+    }
+}
+
 impl AgentPreset for CodeArtsPreset {
     fn parse(&self, hook_input: &str, trace_id: &str) -> Result<Vec<ParsedHookEvent>, GitAiError> {
         let input: Value = serde_json::from_str(hook_input)
@@ -28,6 +68,19 @@ impl AgentPreset for CodeArtsPreset {
         let is_pre = match parse::required_str(&input, "hook_event_name")? {
             "PreToolUse" => true,
             "PostToolUse" => false,
+            "SessionUpdate" => {
+                let session_id = required_nonempty(&input, "session_id")?;
+                let cwd = required_nonempty(&input, "cwd")?;
+                return Ok(resolve_stream_source(&input, session_id)
+                    .map(|stream_source| {
+                        ParsedHookEvent::SessionUpdate(SessionUpdate {
+                            context: preset_context(&input, trace_id, session_id, cwd),
+                            stream_source,
+                        })
+                    })
+                    .into_iter()
+                    .collect());
+            }
             _ => return Ok(Vec::new()),
         };
         let tool_name = parse::required_str(&input, "tool_name")?;
@@ -39,27 +92,8 @@ impl AgentPreset for CodeArtsPreset {
         let session_id = required_nonempty(&input, "session_id")?;
         let cwd = required_nonempty(&input, "cwd")?;
         let tool_use_id = required_nonempty(&input, "tool_use_id")?.to_string();
-        let context = PresetContext {
-            agent_id: AgentId {
-                tool: "codearts".to_string(),
-                id: session_id.to_string(),
-                model: parse::optional_str(&input, "model")
-                    .map(str::trim)
-                    .filter(|model| !model.is_empty())
-                    .unwrap_or("unknown")
-                    .to_string(),
-            },
-            external_session_id: session_id.to_string(),
-            trace_id: trace_id.to_string(),
-            cwd: PathBuf::from(cwd),
-            metadata: HashMap::from([
-                ("session_id".to_string(), session_id.to_string()),
-                ("tool_name".to_string(), tool_name.to_string()),
-            ]),
-        };
+        let context = preset_context(&input, trace_id, session_id, cwd);
 
-        // CodeArts shares the hook protocol, but its transcript storage is not
-        // assumed to be OpenCode's database. Model identity comes from the plugin.
         let event = if tool_class == ToolClass::Bash {
             let command = parse::bash_command_from_hook_input(&input);
             if is_pre {
@@ -73,7 +107,7 @@ impl AgentPreset for CodeArtsPreset {
                     context,
                     tool_use_id,
                     command,
-                    stream_source: None,
+                    stream_source: resolve_stream_source(&input, session_id),
                 })
             }
         } else {
@@ -97,7 +131,7 @@ impl AgentPreset for CodeArtsPreset {
                     context,
                     file_paths,
                     dirty_files: None,
-                    stream_source: None,
+                    stream_source: resolve_stream_source(&input, session_id),
                     tool_use_id: Some(tool_use_id),
                 })
             }

--- a/src/commands/checkpoint_agent/presets/codearts.rs
+++ b/src/commands/checkpoint_agent/presets/codearts.rs
@@ -1,0 +1,107 @@
+use super::opencode::OpenCodePreset;
+use super::parse;
+use super::{
+    AgentPreset, ParsedHookEvent, PostBashCall, PostFileEdit, PreBashCall, PreFileEdit,
+    PresetContext,
+};
+use crate::authorship::working_log::AgentId;
+use crate::commands::checkpoint_agent::bash_tool::{self, Agent, ToolClass};
+use crate::error::GitAiError;
+use serde_json::Value;
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+pub struct CodeArtsPreset;
+
+fn required_nonempty<'a>(input: &'a Value, key: &str) -> Result<&'a str, GitAiError> {
+    let value = parse::required_str(input, key)?;
+    if value.trim().is_empty() {
+        return Err(GitAiError::PresetError(format!("{key} must not be empty")));
+    }
+    Ok(value)
+}
+
+impl AgentPreset for CodeArtsPreset {
+    fn parse(&self, hook_input: &str, trace_id: &str) -> Result<Vec<ParsedHookEvent>, GitAiError> {
+        let input: Value = serde_json::from_str(hook_input)
+            .map_err(|e| GitAiError::PresetError(format!("Invalid CodeArts hook JSON: {e}")))?;
+        let is_pre = match parse::required_str(&input, "hook_event_name")? {
+            "PreToolUse" => true,
+            "PostToolUse" => false,
+            _ => return Ok(Vec::new()),
+        };
+        let tool_name = parse::required_str(&input, "tool_name")?;
+        let tool_class = bash_tool::classify_tool(Agent::CodeArts, tool_name);
+        if tool_class == ToolClass::Skip {
+            return Ok(Vec::new());
+        }
+
+        let session_id = required_nonempty(&input, "session_id")?;
+        let cwd = required_nonempty(&input, "cwd")?;
+        let tool_use_id = required_nonempty(&input, "tool_use_id")?.to_string();
+        let context = PresetContext {
+            agent_id: AgentId {
+                tool: "codearts".to_string(),
+                id: session_id.to_string(),
+                model: parse::optional_str(&input, "model")
+                    .map(str::trim)
+                    .filter(|model| !model.is_empty())
+                    .unwrap_or("unknown")
+                    .to_string(),
+            },
+            external_session_id: session_id.to_string(),
+            trace_id: trace_id.to_string(),
+            cwd: PathBuf::from(cwd),
+            metadata: HashMap::from([
+                ("session_id".to_string(), session_id.to_string()),
+                ("tool_name".to_string(), tool_name.to_string()),
+            ]),
+        };
+
+        // CodeArts shares the hook protocol, but its transcript storage is not
+        // assumed to be OpenCode's database. Model identity comes from the plugin.
+        let event = if tool_class == ToolClass::Bash {
+            let command = parse::bash_command_from_hook_input(&input);
+            if is_pre {
+                ParsedHookEvent::PreBashCall(PreBashCall {
+                    context,
+                    tool_use_id,
+                    command,
+                })
+            } else {
+                ParsedHookEvent::PostBashCall(PostBashCall {
+                    context,
+                    tool_use_id,
+                    command,
+                    stream_source: None,
+                })
+            }
+        } else {
+            let file_paths =
+                OpenCodePreset::extract_filepaths_from_tool_input(input.get("tool_input"), cwd);
+            // Empty edit paths would capture unrelated changes across the repo.
+            if file_paths.is_empty() {
+                return Err(GitAiError::PresetError(
+                    "CodeArts file edit has no file paths in tool_input".to_string(),
+                ));
+            }
+            if is_pre {
+                ParsedHookEvent::PreFileEdit(PreFileEdit {
+                    context,
+                    file_paths,
+                    dirty_files: None,
+                    tool_use_id: Some(tool_use_id),
+                })
+            } else {
+                ParsedHookEvent::PostFileEdit(PostFileEdit {
+                    context,
+                    file_paths,
+                    dirty_files: None,
+                    stream_source: None,
+                    tool_use_id: Some(tool_use_id),
+                })
+            }
+        };
+        Ok(vec![event])
+    }
+}

--- a/src/commands/checkpoint_agent/presets/mod.rs
+++ b/src/commands/checkpoint_agent/presets/mod.rs
@@ -5,6 +5,7 @@ mod ai_tab;
 mod amp;
 mod claude;
 mod cline;
+mod codearts;
 mod codex;
 mod continue_cli;
 mod cursor;
@@ -154,6 +155,7 @@ pub fn resolve_preset(name: &str) -> Result<Box<dyn AgentPreset>, GitAiError> {
     match name {
         "claude" => Ok(Box::new(claude::ClaudePreset)),
         "cline" => Ok(Box::new(cline::ClinePreset)),
+        "codearts" => Ok(Box::new(codearts::CodeArtsPreset)),
         "codex" => Ok(Box::new(codex::CodexPreset)),
         "gemini" => Ok(Box::new(gemini::GeminiPreset)),
         "windsurf" => Ok(Box::new(windsurf::WindsurfPreset)),

--- a/src/commands/checkpoint_agent/presets/mod.rs
+++ b/src/commands/checkpoint_agent/presets/mod.rs
@@ -42,6 +42,7 @@ pub enum ParsedHookEvent {
     PostFileEdit(PostFileEdit),
     PreBashCall(PreBashCall),
     PostBashCall(PostBashCall),
+    SessionUpdate(SessionUpdate),
     KnownHumanEdit(KnownHumanEdit),
     UntrackedEdit(UntrackedEdit),
 }
@@ -96,6 +97,12 @@ pub struct PostBashCall {
     #[serde(default)]
     pub command: Option<String>,
     pub stream_source: Option<StreamSource>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionUpdate {
+    pub context: PresetContext,
+    pub stream_source: StreamSource,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/commands/checkpoint_agent/presets/opencode.rs
+++ b/src/commands/checkpoint_agent/presets/opencode.rs
@@ -53,6 +53,20 @@ impl OpenCodePreset {
             serde_json::Value::Object(map) => {
                 for (key, val) in map {
                     let key_lower = key.to_ascii_lowercase();
+                    // File contents can contain patch examples or file URIs;
+                    // those are source text, not additional edit targets.
+                    if matches!(
+                        key_lower.as_str(),
+                        "content"
+                            | "oldstring"
+                            | "newstring"
+                            | "oldtext"
+                            | "newtext"
+                            | "old_text"
+                            | "new_text"
+                    ) {
+                        continue;
+                    }
                     let is_single_path_key = key_lower == "file_path"
                         || key_lower == "filepath"
                         || key_lower == "path"

--- a/src/commands/checkpoint_agent/presets/opencode.rs
+++ b/src/commands/checkpoint_agent/presets/opencode.rs
@@ -166,7 +166,7 @@ impl OpenCodePreset {
         None
     }
 
-    fn lookup_parent_session(db_path: &Path, session_id: &str) -> Option<String> {
+    pub(super) fn lookup_parent_session(db_path: &Path, session_id: &str) -> Option<String> {
         let conn = crate::streams::agents::opencode::open_sqlite_readonly(db_path).ok()?;
         conn.query_row(
             "SELECT parent_id FROM session WHERE id = ?",

--- a/src/commands/git_ai_handlers.rs
+++ b/src/commands/git_ai_handlers.rs
@@ -324,7 +324,7 @@ fn print_help() {
     eprintln!("Commands:");
     eprintln!("  checkpoint         Checkpoint working changes and attribute author");
     eprintln!(
-        "    Presets: claude, cline, codex, continue-cli, cursor, gemini, github-copilot, amp, windsurf, opencode, pi, ai_tab, firebender, human, mock_ai, mock_known_human, known_human"
+        "    Presets: claude, cline, codearts, codex, continue-cli, cursor, gemini, github-copilot, amp, windsurf, opencode, pi, ai_tab, firebender, human, mock_ai, mock_known_human, known_human"
     );
     eprintln!(
         "    --hook-input <json|stdin>   JSON payload required by presets, or 'stdin' to read from stdin"

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -7811,6 +7811,24 @@ impl ActorDaemonCoordinator {
             ControlRequest::CheckpointRun { .. } => Err(GitAiError::Generic(
                 "checkpoint.run requires the framed checkpoint transport".to_string(),
             )),
+            ControlRequest::TranscriptUpdate {
+                context,
+                stream_source,
+            } => {
+                if let Some(worker) = &self.stream_worker {
+                    worker.notify_checkpoint(
+                        stream_source.session_id,
+                        context.agent_id.tool,
+                        context.trace_id,
+                        None,
+                        stream_source.path,
+                        Some(context.cwd),
+                        stream_source.external_session_id,
+                        stream_source.external_parent_session_id,
+                    );
+                }
+                Ok(ControlResponse::ok(None, None))
+            }
             ControlRequest::SyncFamily { repo_working_dir } => {
                 self.sync_family(repo_working_dir).await.and_then(|status| {
                     serde_json::to_value(status)

--- a/src/daemon/control_api.rs
+++ b/src/daemon/control_api.rs
@@ -1,5 +1,6 @@
 use crate::authorship::working_log::AgentId;
 use crate::commands::checkpoint_agent::bash_tool::StatSnapshot;
+use crate::commands::checkpoint_agent::presets::{PresetContext, StreamSource};
 use crate::metrics::MetricEvent;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -12,6 +13,12 @@ pub enum ControlRequest {
     Ping,
     #[serde(rename = "checkpoint.run")]
     CheckpointRun { body_bytes: u64 },
+    /// Queue transcript processing without creating a file checkpoint.
+    #[serde(rename = "transcript.update")]
+    TranscriptUpdate {
+        context: PresetContext,
+        stream_source: StreamSource,
+    },
     #[serde(rename = "sync.family")]
     SyncFamily { repo_working_dir: String },
     #[serde(rename = "status.family")]

--- a/src/mdm/agents/codearts.rs
+++ b/src/mdm/agents/codearts.rs
@@ -1,0 +1,227 @@
+use crate::error::GitAiError;
+use crate::mdm::hook_installer::{HookCheckResult, HookInstaller, HookInstallerParams};
+use crate::mdm::utils::{binary_exists, generate_diff, home_dir, write_atomic};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+// CodeArts exposes the same tool lifecycle hooks as OpenCode.
+const PLUGIN_CONTENT: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/agent-support/opencode/git-ai.ts"
+));
+
+pub struct CodeArtsInstaller {
+    config_dir: PathBuf,
+}
+
+impl Default for CodeArtsInstaller {
+    fn default() -> Self {
+        Self {
+            config_dir: home_dir().join(".codeartsdoer"),
+        }
+    }
+}
+
+impl CodeArtsInstaller {
+    fn plugin_path(&self) -> PathBuf {
+        self.config_dir.join("plugins").join("git-ai.ts")
+    }
+
+    fn generate_plugin_content(binary_path: &Path) -> String {
+        let path_literal = serde_json::to_string(&binary_path.to_string_lossy())
+            .expect("serializing a binary path string cannot fail");
+        PLUGIN_CONTENT
+            .replace(
+                r#"const AGENT_NAME = "opencode""#,
+                r#"const AGENT_NAME = "codearts""#,
+            )
+            .replace("OpenCode", "CodeArts")
+            .replace(".config/opencode/plugins", ".codeartsdoer/plugins")
+            .replace(".opencode/plugins", ".codeartsdoer/plugins")
+            .replace(
+                "https://opencode.ai/docs/plugins/",
+                "https://support.huaweicloud.com/usermanual-cli/codeartsagent_cli_0018.html",
+            )
+            // Substitute last so template branding cannot rewrite the binary path.
+            .replace(r#""__GIT_AI_BINARY_PATH__""#, &path_literal)
+    }
+}
+
+impl HookInstaller for CodeArtsInstaller {
+    fn name(&self) -> &str {
+        "CodeArts"
+    }
+
+    fn id(&self) -> &str {
+        "codearts"
+    }
+
+    fn process_names(&self) -> Vec<&str> {
+        vec!["codearts"]
+    }
+
+    fn check_hooks(&self, params: &HookInstallerParams) -> Result<HookCheckResult, GitAiError> {
+        let tool_installed = self.config_dir.exists()
+            || Path::new(".codeartsdoer").exists()
+            || binary_exists("codearts");
+        let plugin_path = self.plugin_path();
+        let hooks_installed = tool_installed && plugin_path.is_file();
+        let hooks_up_to_date = hooks_installed
+            && fs::read_to_string(&plugin_path)?.trim()
+                == Self::generate_plugin_content(&params.binary_path).trim();
+
+        Ok(HookCheckResult {
+            tool_installed,
+            hooks_installed,
+            hooks_up_to_date,
+        })
+    }
+
+    fn install_hooks(
+        &self,
+        params: &HookInstallerParams,
+        dry_run: bool,
+    ) -> Result<Option<String>, GitAiError> {
+        let plugin_path = self.plugin_path();
+        let existing_content = if plugin_path.exists() {
+            fs::read_to_string(&plugin_path)?
+        } else {
+            String::new()
+        };
+        let new_content = Self::generate_plugin_content(&params.binary_path);
+        if existing_content.trim() == new_content.trim() {
+            return Ok(None);
+        }
+
+        let diff = generate_diff(&plugin_path, &existing_content, &new_content);
+        if !dry_run {
+            write_atomic(&plugin_path, new_content.as_bytes())?;
+        }
+        Ok(Some(diff))
+    }
+
+    fn uninstall_hooks(
+        &self,
+        _params: &HookInstallerParams,
+        dry_run: bool,
+    ) -> Result<Option<String>, GitAiError> {
+        let plugin_path = self.plugin_path();
+        if !plugin_path.exists() {
+            return Ok(None);
+        }
+
+        let existing_content = fs::read_to_string(&plugin_path)?;
+        let diff = generate_diff(&plugin_path, &existing_content, "");
+        if !dry_run {
+            fs::remove_file(&plugin_path)?;
+        }
+        Ok(Some(diff))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn installer_at(temp: &TempDir) -> CodeArtsInstaller {
+        CodeArtsInstaller {
+            config_dir: temp.path().join(".codeartsdoer"),
+        }
+    }
+
+    fn params() -> HookInstallerParams {
+        HookInstallerParams {
+            binary_path: PathBuf::from("/usr/local/bin/git-ai"),
+        }
+    }
+
+    #[test]
+    fn test_codearts_installer_is_registered_once() {
+        let installers = crate::mdm::agents::get_all_installers();
+        let codearts: Vec<_> = installers
+            .iter()
+            .filter(|item| item.id() == "codearts")
+            .collect();
+        assert_eq!(codearts.len(), 1);
+        assert_eq!(codearts[0].name(), "CodeArts");
+    }
+
+    #[test]
+    fn test_codearts_install_dry_run_has_no_side_effects() {
+        let temp = TempDir::new().unwrap();
+        let installer = installer_at(&temp);
+
+        let diff = installer.install_hooks(&params(), true).unwrap().unwrap();
+
+        assert!(diff.contains("git-ai.ts"));
+        assert!(diff.contains("const AGENT_NAME = \"codearts\""));
+        assert!(!installer.config_dir.exists());
+    }
+
+    #[test]
+    fn test_codearts_install_update_and_uninstall_lifecycle() {
+        let temp = TempDir::new().unwrap();
+        let installer = installer_at(&temp);
+        let params = params();
+        fs::create_dir_all(&installer.config_dir).unwrap();
+
+        let before = installer.check_hooks(&params).unwrap();
+        assert!(before.tool_installed);
+        assert!(!before.hooks_installed);
+        assert!(!before.hooks_up_to_date);
+
+        assert!(installer.install_hooks(&params, false).unwrap().is_some());
+        let plugin_path = installer.config_dir.join("plugins").join("git-ai.ts");
+        let content = fs::read_to_string(&plugin_path).unwrap();
+        assert!(content.contains("const AGENT_NAME = \"codearts\""));
+        assert!(!content.contains("__GIT_AI_BINARY_PATH__"));
+        let installed = installer.check_hooks(&params).unwrap();
+        assert!(installed.tool_installed);
+        assert!(installed.hooks_installed);
+        assert!(installed.hooks_up_to_date);
+        assert!(installer.install_hooks(&params, false).unwrap().is_none());
+
+        fs::write(&plugin_path, "// outdated git-ai plugin").unwrap();
+        let outdated = installer.check_hooks(&params).unwrap();
+        assert!(outdated.hooks_installed);
+        assert!(!outdated.hooks_up_to_date);
+        assert!(installer.install_hooks(&params, false).unwrap().is_some());
+        assert_eq!(fs::read_to_string(&plugin_path).unwrap(), content);
+
+        let other_plugin = plugin_path.with_file_name("custom.ts");
+        fs::write(&other_plugin, "// user plugin").unwrap();
+        assert!(installer.uninstall_hooks(&params, true).unwrap().is_some());
+        assert_eq!(fs::read_to_string(&plugin_path).unwrap(), content);
+        assert!(installer.uninstall_hooks(&params, false).unwrap().is_some());
+        assert!(!plugin_path.exists());
+        assert_eq!(fs::read_to_string(&other_plugin).unwrap(), "// user plugin");
+        assert!(installer.uninstall_hooks(&params, false).unwrap().is_none());
+        let uninstalled = installer.check_hooks(&params).unwrap();
+        assert!(uninstalled.tool_installed);
+        assert!(!uninstalled.hooks_installed);
+        assert!(!uninstalled.hooks_up_to_date);
+    }
+
+    #[test]
+    fn test_codearts_binary_path_is_a_valid_string_literal() {
+        for raw_path in [
+            "C:\\Users\\a\"b\\tools\\git-ai.exe",
+            "C:\\Tools\\OpenCode\\git-ai.exe",
+            "/opt/.config/opencode/plugins/git-ai",
+        ] {
+            let path = PathBuf::from(raw_path);
+            let content = CodeArtsInstaller::generate_plugin_content(&path);
+            let literal = content
+                .lines()
+                .find_map(|line| line.strip_prefix("const GIT_AI_BIN = "))
+                .unwrap();
+
+            assert_eq!(
+                serde_json::from_str::<String>(literal).unwrap(),
+                path.to_string_lossy()
+            );
+            assert!(!content.contains("__GIT_AI_BINARY_PATH__"));
+        }
+    }
+}

--- a/src/mdm/agents/mod.rs
+++ b/src/mdm/agents/mod.rs
@@ -1,6 +1,7 @@
 mod amp;
 mod claude_code;
 mod cline;
+mod codearts;
 mod codex;
 mod cursor;
 mod droid;
@@ -18,6 +19,7 @@ mod windsurf;
 pub use amp::AmpInstaller;
 pub use claude_code::ClaudeCodeInstaller;
 pub use cline::ClineInstaller;
+pub use codearts::CodeArtsInstaller;
 pub use codex::CodexInstaller;
 pub use cursor::CursorInstaller;
 pub use droid::DroidInstaller;
@@ -39,6 +41,7 @@ pub fn get_all_installers() -> Vec<Box<dyn HookInstaller>> {
     let mut installers: Vec<Box<dyn HookInstaller>> = vec![
         Box::new(ClaudeCodeInstaller),
         Box::new(ClineInstaller),
+        Box::new(CodeArtsInstaller::default()),
         Box::new(CodexInstaller),
         Box::new(CursorInstaller),
         Box::new(VSCodeInstaller),

--- a/src/mdm/agents/opencode.rs
+++ b/src/mdm/agents/opencode.rs
@@ -299,7 +299,7 @@ mod tests {
     fn test_opencode_plugin_content_is_valid_typescript() {
         let content = OPENCODE_PLUGIN_CONTENT;
 
-        assert!(content.contains("import type { Plugin }"));
+        assert!(content.contains("import type { Hooks, Plugin }"));
         assert!(content.contains("@opencode-ai/plugin"));
         assert!(content.contains("export const GitAiPlugin: Plugin"));
         assert!(content.contains("export default GitAiPlugin"));

--- a/src/mdm/agents/opencode.rs
+++ b/src/mdm/agents/opencode.rs
@@ -327,7 +327,8 @@ mod tests {
         assert!(content.contains(r#"const GIT_AI_BIN = "/usr/local/bin/git-ai""#));
         // Checkpoint execution uses spawn(), which works in OpenCode CLI and Desktop.
         assert!(content.contains("spawn(GIT_AI_BIN"));
-        assert!(content.contains(r#""checkpoint", "opencode", "--hook-input", "stdin""#));
+        assert!(content.contains(r#"const AGENT_NAME = "opencode""#));
+        assert!(content.contains(r#""checkpoint", AGENT_NAME, "--hook-input", "stdin""#));
         assert!(!content.contains("Bun.$"));
     }
 

--- a/src/streams/agent.rs
+++ b/src/streams/agent.rs
@@ -188,6 +188,7 @@ const ALL_AGENT_TYPES: &[&str] = &[
     "codex",
     "amp",
     "opencode",
+    "codearts",
     "pi",
 ];
 
@@ -208,7 +209,8 @@ pub fn get_agent(agent_type: &str) -> Option<Box<dyn Agent>> {
         "windsurf" => Some(Box::new(super::agents::WindsurfAgent::new())),
         "codex" => Some(Box::new(super::agents::CodexAgent::new())),
         "amp" => Some(Box::new(super::agents::AmpAgent::new())),
-        "opencode" => Some(Box::new(super::agents::OpenCodeAgent::new())),
+        // CodeArts kernels use the same SQLite schema, with separate session identities.
+        "opencode" | "codearts" => Some(Box::new(super::agents::OpenCodeAgent::new())),
         "pi" => Some(Box::new(super::agents::PiAgent::new())),
         _ => None,
     }

--- a/tests/integration/codearts.rs
+++ b/tests/integration/codearts.rs
@@ -330,3 +330,131 @@ fn test_codearts_e2e_shell_edit_attributes_only_new_changes() {
     assert_eq!(session.agent_id.id, "codearts-session");
     assert_eq!(session.agent_id.model, "deepseek-v3.2");
 }
+
+#[test]
+fn test_codearts_e2e_multiedit_excludes_unrelated_dirty_files() {
+    let repo = TestRepo::new();
+    let mut first = repo.filename("first.txt");
+    let mut second = repo.filename("second.txt");
+    let mut outside = repo.filename("outside.txt");
+
+    fs::write(repo.path().join("first.txt"), "First original line\n").unwrap();
+    fs::write(repo.path().join("second.txt"), "Second original line\n").unwrap();
+    fs::write(repo.path().join("outside.txt"), "Outside original line\n").unwrap();
+    repo.stage_all_and_commit("Initial multiedit files")
+        .unwrap();
+    first.assert_committed_lines(lines!["First original line".unattributed_human()]);
+    second.assert_committed_lines(lines!["Second original line".unattributed_human()]);
+    outside.assert_committed_lines(lines!["Outside original line".unattributed_human()]);
+
+    // These edits have no checkpoint and must remain untracked even when they
+    // are committed together with CodeArts changes in other files.
+    fs::write(
+        repo.path().join("outside.txt"),
+        "Outside original line\nUntracked outside line one\nUntracked outside line two\n",
+    )
+    .unwrap();
+    let input = json!({"edits": [
+        {"file_path": "first.txt"},
+        {"filePath": "second.txt"},
+        {"path": "first.txt"},
+    ]});
+    checkpoint(
+        &repo,
+        "PreToolUse",
+        "multiedit",
+        "multiedit-1",
+        input.clone(),
+    );
+    fs::write(
+        repo.path().join("first.txt"),
+        "First original line\nFirst CodeArts addition\n",
+    )
+    .unwrap();
+    fs::write(
+        repo.path().join("second.txt"),
+        "Second original line\nSecond CodeArts addition\n",
+    )
+    .unwrap();
+    checkpoint(&repo, "PostToolUse", "multiedit", "multiedit-1", input);
+    let commit = repo.stage_all_and_commit("CodeArts multiedit").unwrap();
+    first.assert_committed_lines(lines![
+        "First original line".unattributed_human(),
+        "First CodeArts addition".ai(),
+    ]);
+    second.assert_committed_lines(lines![
+        "Second original line".unattributed_human(),
+        "Second CodeArts addition".ai(),
+    ]);
+    outside.assert_committed_lines(lines![
+        "Outside original line".unattributed_human(),
+        "Untracked outside line one".unattributed_human(),
+        "Untracked outside line two".unattributed_human(),
+    ]);
+    let sessions = &commit.authorship_log.metadata.sessions;
+    assert_eq!(sessions.len(), 1);
+    let session = sessions.values().next().unwrap();
+    assert_eq!(session.agent_id.tool, "codearts");
+    assert_eq!(session.agent_id.id, "codearts-session");
+    assert_eq!(session.agent_id.model, "deepseek-v3.2");
+}
+
+#[test]
+fn test_codearts_e2e_apply_patch_adds_and_moves_files() {
+    let repo = TestRepo::new();
+    let mut original = repo.filename("original.txt");
+    let mut renamed = repo.filename("renamed.txt");
+    let mut added = repo.filename("added.txt");
+    let mut deleted = repo.filename("deleted.txt");
+    let original_content = "Original first line\nOriginal second line\nOriginal third line\n";
+
+    fs::write(repo.path().join("original.txt"), original_content).unwrap();
+    fs::write(
+        repo.path().join("deleted.txt"),
+        "Remove this original line\n",
+    )
+    .unwrap();
+    repo.stage_all_and_commit("Initial patch files").unwrap();
+    original.assert_committed_lines(lines![
+        "Original first line".unattributed_human(),
+        "Original second line".unattributed_human(),
+        "Original third line".unattributed_human(),
+    ]);
+    deleted.assert_committed_lines(lines!["Remove this original line".unattributed_human()]);
+
+    let input = json!({"patchText": "*** Begin Patch\n*** Add File: added.txt\n+CodeArts new file\n*** Delete File: deleted.txt\n*** Update File: original.txt\n*** Move to: renamed.txt\n@@\n Original third line\n+CodeArts addition after move\n*** End Patch"});
+    checkpoint(&repo, "PreToolUse", "apply_patch", "patch-1", input.clone());
+    fs::rename(
+        repo.path().join("original.txt"),
+        repo.path().join("renamed.txt"),
+    )
+    .unwrap();
+    fs::write(
+        repo.path().join("renamed.txt"),
+        format!("{original_content}CodeArts addition after move\n"),
+    )
+    .unwrap();
+    fs::write(repo.path().join("added.txt"), "CodeArts new file\n").unwrap();
+    fs::remove_file(repo.path().join("deleted.txt")).unwrap();
+    checkpoint(&repo, "PostToolUse", "apply_patch", "patch-1", input);
+    let commit = repo
+        .stage_all_and_commit("CodeArts patch with a move")
+        .unwrap();
+    renamed.assert_committed_lines(lines![
+        "Original first line".unattributed_human(),
+        "Original second line".unattributed_human(),
+        "Original third line".unattributed_human(),
+        "CodeArts addition after move".ai(),
+    ]);
+    added.assert_committed_lines(lines!["CodeArts new file".ai()]);
+    assert!(!repo.path().join("original.txt").exists());
+    assert!(!repo.path().join("deleted.txt").exists());
+    assert!(repo.git(&["cat-file", "-e", "HEAD:original.txt"]).is_err());
+    assert!(repo.git(&["cat-file", "-e", "HEAD:deleted.txt"]).is_err());
+    let sessions = &commit.authorship_log.metadata.sessions;
+    assert_eq!(sessions.len(), 1);
+    let session = sessions.values().next().unwrap();
+    assert_eq!(session.agent_id.tool, "codearts");
+    assert_eq!(session.agent_id.id, "codearts-session");
+    assert_eq!(session.agent_id.model, "deepseek-v3.2");
+}

--- a/tests/integration/codearts.rs
+++ b/tests/integration/codearts.rs
@@ -1,10 +1,15 @@
 use crate::repos::test_file::ExpectedLineExt;
 use crate::repos::test_repo::TestRepo;
-use git_ai::commands::checkpoint_agent::presets::{ParsedHookEvent, resolve_preset};
+use crate::test_utils::{fixture_path, isolated_metrics_db_path};
+use git_ai::authorship::authorship_log_serialization::generate_session_id;
+use git_ai::commands::checkpoint_agent::presets::{ParsedHookEvent, StreamFormat, resolve_preset};
 use git_ai::error::GitAiError;
+use git_ai::metrics::db::MetricsDatabase;
+use git_ai::metrics::types::MetricEventId;
+use git_ai::metrics::{EventAttributes, PosEncoded, SessionEventValues};
 use serde_json::{Value, json};
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 fn hook_input(event: &str, tool: &str, input: Value) -> Value {
     json!({
@@ -61,6 +66,339 @@ fn test_codearts_post_edit_uses_supplied_model_without_opencode_transcript() {
     assert_eq!(event.file_paths, vec![PathBuf::from("/project/new.rs")]);
     assert_eq!(event.tool_use_id.as_deref(), Some("tool-call-1"));
     assert!(event.stream_source.is_none());
+}
+
+#[test]
+fn test_codearts_post_hooks_resolve_explicit_transcript_and_parent_session() {
+    let storage = tempfile::tempdir().unwrap();
+    // CodeArts uses OpenCode's SQLite schema, but its database may have any name.
+    let database = storage.path().join("codearts.db");
+    fs::copy(fixture_path("opencode-sqlite/opencode.db"), &database).unwrap();
+
+    for tool in ["write", "bash", "shell"] {
+        let mut input = hook_input(
+            "PostToolUse",
+            tool,
+            json!({"filePath": "new.rs", "command": "echo generated > new.rs"}),
+        );
+        input["session_id"] = json!("test-session-123");
+        input["transcript_path"] = json!(database);
+        let events = parse_codearts(&input).unwrap();
+        let source = match &events[0] {
+            ParsedHookEvent::PostFileEdit(event) => &event.stream_source,
+            ParsedHookEvent::PostBashCall(event) => &event.stream_source,
+            _ => panic!("expected a post event for {tool}"),
+        }
+        .as_ref()
+        .expect("CodeArts post hooks must register the supplied transcript");
+        assert_eq!(source.path, database);
+        assert_eq!(source.format, StreamFormat::OpenCodeSqlite);
+        assert_eq!(
+            source.session_id,
+            generate_session_id("test-session-123", "codearts")
+        );
+        assert_eq!(source.external_session_id, "test-session-123");
+        assert_eq!(
+            source.external_parent_session_id.as_deref(),
+            Some("parent-session-456")
+        );
+    }
+}
+
+#[test]
+fn test_codearts_unavailable_transcript_does_not_block_attribution() {
+    let storage = tempfile::tempdir().unwrap();
+    for path in [
+        Value::Null,
+        json!(""),
+        json!("opencode.db"),
+        json!(storage.path()),
+        json!(storage.path().join("missing.db")),
+    ] {
+        let mut input = hook_input("PostToolUse", "edit", json!({"filePath": "main.rs"}));
+        input["transcript_path"] = path;
+        let events = parse_codearts(&input).unwrap();
+        let ParsedHookEvent::PostFileEdit(event) = &events[0] else {
+            panic!("expected a post-edit event");
+        };
+        assert!(event.stream_source.is_none());
+        assert_eq!(event.file_paths, vec![PathBuf::from("/project/main.rs")]);
+    }
+}
+
+#[test]
+fn test_codearts_session_update_respects_repository_filters() {
+    let (_metrics_dir, metrics_path) = isolated_metrics_db_path();
+    let repo = TestRepo::new_with_daemon_env(&[("GIT_AI_TEST_METRICS_DB_PATH", &metrics_path)]);
+    repo.git(&[
+        "remote",
+        "add",
+        "origin",
+        "https://example.com/codearts/project.git",
+    ])
+    .unwrap();
+    let storage = tempfile::tempdir().unwrap();
+    let database = storage.path().join("codearts.db");
+    fs::copy(fixture_path("opencode-sqlite/opencode.db"), &database).unwrap();
+    let update = json!({
+        "hook_event_name": "SessionUpdate",
+        "session_id": "test-session-123",
+        "cwd": repo.canonical_path(),
+        "transcript_path": database,
+    });
+    let config_path = repo.test_home_path().join(".git-ai/config.json");
+    let original: Value = serde_json::from_str(&fs::read_to_string(&config_path).unwrap()).unwrap();
+    let metrics = MetricsDatabase::open_at_path(Path::new(&metrics_path)).unwrap();
+    for (field, pattern) in [
+        ("exclude_repositories", "*"),
+        ("allow_repositories", "not-this-repository/*"),
+    ] {
+        let mut config = original.clone();
+        config[field] = json!([pattern]);
+        fs::write(&config_path, config.to_string()).unwrap();
+        repo.git_ai(&[
+            "checkpoint",
+            "codearts",
+            "--hook-input",
+            &update.to_string(),
+        ])
+        .unwrap();
+        repo.git_ai(&["await", "--timeout", "60"]).unwrap();
+        assert!(
+            metrics
+                .get_metric_history(0, None, &[MetricEventId::SessionEvent as u16])
+                .unwrap()
+                .is_empty(),
+            "{field} must prevent session collection"
+        );
+    }
+    // The same completed conversation is collected once the repository is allowed,
+    // including a session with no editing tool call or attribution checkpoint.
+    fs::write(&config_path, original.to_string()).unwrap();
+    repo.git_ai(&[
+        "checkpoint",
+        "codearts",
+        "--hook-input",
+        &update.to_string(),
+    ])
+    .unwrap();
+    repo.git_ai(&["await", "--timeout", "60"]).unwrap();
+    assert_eq!(
+        metrics
+            .get_metric_history(0, None, &[MetricEventId::SessionEvent as u16])
+            .unwrap()
+            .len(),
+        2
+    );
+}
+
+#[test]
+fn test_codearts_e2e_streams_conversation_with_codearts_identity() {
+    let (_metrics_dir, metrics_path) = isolated_metrics_db_path();
+    let repo = TestRepo::new_with_daemon_env(&[("GIT_AI_TEST_METRICS_DB_PATH", &metrics_path)]);
+    let storage = tempfile::tempdir().unwrap();
+    let database = storage.path().join("codearts.db");
+    fs::copy(fixture_path("opencode-sqlite/opencode.db"), &database).unwrap();
+    let connection = rusqlite::Connection::open(&database).unwrap();
+    connection.execute_batch(
+        "UPDATE part SET data = json_remove(json_set(data, '$.state.status', 'running'), '$.state.output')
+             WHERE id = 'prt-sql-003';
+         UPDATE message SET data = json_remove(data, '$.time.completed')
+             WHERE id = 'msg-assistant-sql-001';"
+    ).unwrap();
+    drop(connection);
+    let file_path = repo.path().join("example.txt");
+    let mut file = repo.filename("example.txt");
+    fs::write(&file_path, "Original line\n").unwrap();
+    repo.stage_all_and_commit("Initial content").unwrap();
+    file.assert_committed_lines(lines!["Original line".unattributed_human()]);
+
+    let mut hook = hook_input("PreToolUse", "edit", json!({"filePath": "example.txt"}));
+    hook["cwd"] = json!(repo.canonical_path());
+    hook["session_id"] = json!("test-session-123");
+    hook["tool_use_id"] = json!("call-sql-001");
+    hook["model"] = json!("mimo-v2.5");
+    hook["transcript_path"] = json!(database);
+    repo.git_ai(&["checkpoint", "codearts", "--hook-input", &hook.to_string()])
+        .unwrap();
+    fs::write(&file_path, "Original line\nCodeArts generated line\n").unwrap();
+    hook["hook_event_name"] = json!("PostToolUse");
+    repo.git_ai(&["checkpoint", "codearts", "--hook-input", &hook.to_string()])
+        .unwrap();
+    let commit = repo.stage_all_and_commit("CodeArts edit").unwrap();
+    file.assert_committed_lines(lines![
+        "Original line".unattributed_human(),
+        "CodeArts generated line".ai(),
+    ]);
+    let session = commit
+        .authorship_log
+        .metadata
+        .sessions
+        .values()
+        .next()
+        .unwrap();
+    assert_eq!(session.agent_id.tool, "codearts");
+    assert_eq!(session.agent_id.id, "test-session-123");
+    assert_eq!(session.agent_id.model, "mimo-v2.5");
+
+    repo.sync_daemon_force();
+    repo.git_ai(&["await", "--timeout", "60"]).unwrap();
+    let metrics = MetricsDatabase::open_at_path(Path::new(&metrics_path)).unwrap();
+    let session_id = generate_session_id("test-session-123", "codearts");
+    let events: Vec<_> = metrics
+        .get_metric_history(0, None, &[MetricEventId::SessionEvent as u16])
+        .unwrap()
+        .into_iter()
+        .map(|record| {
+            (
+                EventAttributes::from_sparse(&record.event.attrs),
+                SessionEventValues::from_sparse(&record.event.values),
+            )
+        })
+        .filter(|(attrs, _)| attrs.session_id == Some(Some(session_id.clone())))
+        .collect();
+    assert_eq!(
+        events.len(),
+        2,
+        "both user and assistant messages must be captured"
+    );
+    for (attrs, _) in &events {
+        assert_eq!(attrs.tool, Some(Some("codearts".to_string())));
+        assert_eq!(
+            attrs.external_session_id,
+            Some(Some("test-session-123".to_string()))
+        );
+        assert_eq!(
+            attrs.external_parent_session_id,
+            Some(Some("parent-session-456".to_string()))
+        );
+        assert_eq!(
+            attrs.parent_session_id,
+            Some(Some(generate_session_id("parent-session-456", "codearts")))
+        );
+    }
+    let user = &events
+        .iter()
+        .find(|(_, event)| event.external_event_id.as_deref() == Some("msg-user-sql-001"))
+        .unwrap()
+        .1;
+    assert_eq!(user.external_parent_event_id, None);
+    assert_eq!(user.external_tool_use_id, None);
+    assert_eq!(
+        user.raw_json["parts"][0]["data"]["text"],
+        "Please update index.ts using sqlite transcript data"
+    );
+    let assistant = &events
+        .iter()
+        .find(|(_, event)| event.external_event_id.as_deref() == Some("msg-assistant-sql-001"))
+        .unwrap()
+        .1;
+    assert_eq!(
+        assistant.external_parent_event_id.as_deref(),
+        Some("msg-user-sql-001")
+    );
+    assert_eq!(
+        assistant.external_tool_use_id.as_deref(),
+        Some("call-sql-001")
+    );
+    assert_eq!(assistant.raw_json["message"]["data"]["modelID"], "gpt-5");
+    assert_eq!(
+        assistant.raw_json["parts"][0]["data"]["text"],
+        "I will make the edit from sqlite."
+    );
+    let tool = &assistant.raw_json["parts"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|part| part["data"]["callID"] == "call-sql-001")
+        .unwrap()["data"];
+    assert_eq!(tool["tool"], "edit");
+    assert_eq!(tool["state"]["status"], "running");
+    assert_eq!(
+        tool["state"]["input"]["filePath"],
+        "/Users/test/project/index.ts"
+    );
+    assert!(tool["state"].get("output").is_none());
+
+    // CodeArts persists its final assistant reply after the last tool hook.
+    // Refreshing that transcript must not checkpoint intervening user edits.
+    fs::write(
+        repo.path().join("unrelated.txt"),
+        "Untracked after the tool\n",
+    )
+    .unwrap();
+    let connection = rusqlite::Connection::open(&database).unwrap();
+    connection.execute_batch(
+        "UPDATE part SET data = json_set(data, '$.state.status', 'completed', '$.state.output', 'Edit applied'),
+             time_updated = 1706459836000 WHERE id = 'prt-sql-003';
+         UPDATE message SET data = json_set(data, '$.time.completed', 1706459836000),
+             time_updated = 1706459836000 WHERE id = 'msg-assistant-sql-001';
+         INSERT INTO message VALUES ('msg-final', 'test-session-123', 1706459837000, 1706459837000,
+            '{\"role\":\"assistant\",\"parentID\":\"msg-user-sql-001\",\"time\":{\"completed\":1706459837000}}');
+         INSERT INTO part VALUES ('part-final', 'msg-final', 'test-session-123', 1706459837000, 1706459837000,
+            '{\"type\":\"text\",\"text\":\"Final reply after the last tool\"}');"
+    ).unwrap();
+    drop(connection);
+    let update = json!({
+        "hook_event_name": "SessionUpdate",
+        "session_id": "test-session-123",
+        "cwd": repo.canonical_path(),
+        "transcript_path": database,
+    });
+    repo.git_ai(&[
+        "checkpoint",
+        "codearts",
+        "--hook-input",
+        &update.to_string(),
+    ])
+    .unwrap();
+    repo.git_ai(&["await", "--timeout", "60"]).unwrap();
+    let refreshed_events: Vec<_> = metrics
+        .get_metric_history(0, None, &[MetricEventId::SessionEvent as u16])
+        .unwrap()
+        .into_iter()
+        .filter(|record| {
+            EventAttributes::from_sparse(&record.event.attrs).session_id
+                == Some(Some(session_id.clone()))
+        })
+        .map(|record| SessionEventValues::from_sparse(&record.event.values))
+        .collect();
+    let updated_assistant = refreshed_events
+        .iter()
+        .find(|event| {
+            event.external_event_id.as_deref() == Some("msg-assistant-sql-001")
+                && event.raw_json["message"]["time_updated"] == 1706459836000_i64
+        })
+        .expect("the previously captured assistant message must be refreshed");
+    let completed_tool = &updated_assistant.raw_json["parts"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|part| part["data"]["callID"] == "call-sql-001")
+        .unwrap()["data"];
+    assert_eq!(completed_tool["state"]["status"], "completed");
+    assert_eq!(completed_tool["state"]["output"], "Edit applied");
+    let final_messages: Vec<_> = refreshed_events
+        .iter()
+        .filter(|event| event.external_event_id.as_deref() == Some("msg-final"))
+        .collect();
+    assert_eq!(
+        final_messages.len(),
+        1,
+        "the final reply must arrive without another editing tool call"
+    );
+    assert_eq!(
+        final_messages[0].raw_json["parts"][0]["data"]["text"],
+        "Final reply after the last tool"
+    );
+    repo.stage_all_and_commit("Untracked edit after CodeArts")
+        .unwrap();
+    file.assert_committed_lines(lines![
+        "Original line".unattributed_human(),
+        "CodeArts generated line".ai(),
+    ]);
+    repo.filename("unrelated.txt")
+        .assert_committed_lines(lines!["Untracked after the tool".unattributed_human()]);
 }
 
 #[test]

--- a/tests/integration/codearts.rs
+++ b/tests/integration/codearts.rs
@@ -1,0 +1,332 @@
+use crate::repos::test_file::ExpectedLineExt;
+use crate::repos::test_repo::TestRepo;
+use git_ai::commands::checkpoint_agent::presets::{ParsedHookEvent, resolve_preset};
+use git_ai::error::GitAiError;
+use serde_json::{Value, json};
+use std::fs;
+use std::path::PathBuf;
+
+fn hook_input(event: &str, tool: &str, input: Value) -> Value {
+    json!({
+        "hook_event_name": event,
+        "session_id": "codearts-session",
+        "cwd": "/project",
+        "tool_name": tool,
+        "tool_use_id": "tool-call-1",
+        "tool_input": input,
+    })
+}
+
+fn parse_codearts(input: &Value) -> Result<Vec<ParsedHookEvent>, GitAiError> {
+    resolve_preset("codearts")?.parse(&input.to_string(), "codearts-trace")
+}
+
+#[test]
+fn test_codearts_pre_edit_preserves_session_and_invocation_identity() {
+    let events = parse_codearts(&hook_input(
+        "PreToolUse",
+        "edit",
+        json!({"filePath": "src/main.rs"}),
+    ))
+    .unwrap();
+    assert_eq!(events.len(), 1);
+    let ParsedHookEvent::PreFileEdit(event) = &events[0] else {
+        panic!("expected a pre-edit event");
+    };
+    assert_eq!(
+        event.file_paths,
+        vec![PathBuf::from("/project/src/main.rs")]
+    );
+    assert_eq!(event.tool_use_id.as_deref(), Some("tool-call-1"));
+    assert_eq!(event.context.agent_id.tool, "codearts");
+    assert_eq!(event.context.agent_id.id, "codearts-session");
+    assert_eq!(event.context.agent_id.model, "unknown");
+    assert_eq!(event.context.external_session_id, "codearts-session");
+    assert_eq!(event.context.trace_id, "codearts-trace");
+    assert_eq!(event.context.cwd, PathBuf::from("/project"));
+    assert_eq!(event.context.metadata["session_id"], "codearts-session");
+}
+
+#[test]
+fn test_codearts_post_edit_uses_supplied_model_without_opencode_transcript() {
+    let mut input = hook_input("PostToolUse", "write", json!({"filePath": "new.rs"}));
+    input["model"] = json!("deepseek-v3.2");
+    let events = parse_codearts(&input).unwrap();
+    assert_eq!(events.len(), 1);
+    let ParsedHookEvent::PostFileEdit(event) = &events[0] else {
+        panic!("expected a post-edit event");
+    };
+    assert_eq!(event.context.agent_id.tool, "codearts");
+    assert_eq!(event.context.agent_id.model, "deepseek-v3.2");
+    assert_eq!(event.file_paths, vec![PathBuf::from("/project/new.rs")]);
+    assert_eq!(event.tool_use_id.as_deref(), Some("tool-call-1"));
+    assert!(event.stream_source.is_none());
+}
+
+#[test]
+fn test_codearts_empty_model_is_unknown() {
+    for model in [Value::Null, json!(""), json!("   ")] {
+        let mut input = hook_input("PostToolUse", "edit", json!({"filePath": "main.rs"}));
+        input["model"] = model;
+        let events = parse_codearts(&input).unwrap();
+        let ParsedHookEvent::PostFileEdit(event) = &events[0] else {
+            panic!("expected a post-edit event");
+        };
+        assert_eq!(event.context.agent_id.model, "unknown");
+    }
+}
+
+#[test]
+fn test_codearts_multiedit_normalizes_and_deduplicates_paths() {
+    let events = parse_codearts(&hook_input(
+        "PostToolUse",
+        "multiedit",
+        json!({"edits": [
+            {"file_path": "src/main.rs"},
+            {"filePath": "src/main.rs"},
+            {"path": "file:///project/src/lib.rs"},
+        ]}),
+    ))
+    .unwrap();
+    let ParsedHookEvent::PostFileEdit(event) = &events[0] else {
+        panic!("expected a post-edit event");
+    };
+    assert_eq!(
+        event.file_paths,
+        vec![
+            PathBuf::from("/project/src/main.rs"),
+            PathBuf::from("/project/src/lib.rs"),
+        ]
+    );
+}
+
+#[test]
+fn test_codearts_file_contents_do_not_expand_checkpoint_scope() {
+    for tool in ["edit", "write"] {
+        let events = parse_codearts(&hook_input(
+            "PostToolUse",
+            tool,
+            json!({
+                "filePath": "target.rs",
+                "content": "*** Update File: unrelated.rs\n+example code\n",
+                "oldString": "file:///other.rs",
+            }),
+        ))
+        .unwrap();
+        let ParsedHookEvent::PostFileEdit(event) = &events[0] else {
+            panic!("expected a post-edit event");
+        };
+        assert_eq!(event.file_paths, vec![PathBuf::from("/project/target.rs")]);
+    }
+}
+
+#[test]
+fn test_codearts_apply_patch_tracks_added_deleted_and_moved_paths() {
+    let events = parse_codearts(&hook_input(
+        "PreToolUse",
+        "apply_patch",
+        json!({"patchText": "*** Begin Patch\n*** Add File: added.rs\n+new\n*** Delete File: deleted.rs\n*** Update File: old.rs\n*** Move to: renamed.rs\n@@\n-old\n+new\n*** End Patch"}),
+    ))
+    .unwrap();
+    let ParsedHookEvent::PreFileEdit(event) = &events[0] else {
+        panic!("expected a pre-edit event");
+    };
+    assert_eq!(
+        event.file_paths,
+        vec![
+            PathBuf::from("/project/added.rs"),
+            PathBuf::from("/project/deleted.rs"),
+            PathBuf::from("/project/old.rs"),
+            PathBuf::from("/project/renamed.rs"),
+        ]
+    );
+}
+
+#[test]
+fn test_codearts_delete_file_tracks_target() {
+    let events = parse_codearts(&hook_input(
+        "PostToolUse",
+        "deleteFile",
+        json!({"filePath": "removed.rs"}),
+    ))
+    .unwrap();
+    let ParsedHookEvent::PostFileEdit(event) = &events[0] else {
+        panic!("expected a post-edit event");
+    };
+    assert_eq!(event.file_paths, vec![PathBuf::from("/project/removed.rs")]);
+}
+
+#[test]
+fn test_codearts_shell_hooks_preserve_command_and_invocation_id() {
+    for tool in ["bash", "shell"] {
+        for command_key in ["command", "cmd"] {
+            let input = json!({command_key: "  echo generated > output.txt  "});
+            let pre = parse_codearts(&hook_input("PreToolUse", tool, input.clone())).unwrap();
+            let ParsedHookEvent::PreBashCall(pre) = &pre[0] else {
+                panic!("expected a pre-shell event for {tool}");
+            };
+            assert_eq!(pre.tool_use_id, "tool-call-1");
+            assert_eq!(pre.command.as_deref(), Some("echo generated > output.txt"));
+            assert_eq!(pre.context.agent_id.tool, "codearts");
+
+            let post = parse_codearts(&hook_input("PostToolUse", tool, input)).unwrap();
+            let ParsedHookEvent::PostBashCall(post) = &post[0] else {
+                panic!("expected a post-shell event for {tool}");
+            };
+            assert_eq!(post.tool_use_id, pre.tool_use_id);
+            assert_eq!(post.command, pre.command);
+            assert!(post.stream_source.is_none());
+        }
+    }
+}
+
+#[test]
+fn test_codearts_ignores_unknown_events_and_read_only_tools() {
+    for event in ["Stop", "PostToolUseFailure", "session.updated"] {
+        assert!(
+            parse_codearts(&hook_input(event, "edit", json!({"filePath": "main.rs"})))
+                .unwrap()
+                .is_empty()
+        );
+    }
+    for tool in ["read", "glob", "grep", "webfetch", "unknown_tool"] {
+        for event in ["PreToolUse", "PostToolUse"] {
+            assert!(
+                parse_codearts(&hook_input(event, tool, json!({"filePath": "main.rs"})))
+                    .unwrap()
+                    .is_empty()
+            );
+        }
+    }
+}
+
+#[test]
+fn test_codearts_requires_nonempty_session_cwd_and_invocation_id() {
+    for field in ["session_id", "cwd", "tool_use_id"] {
+        for value in [None, Some(json!("")), Some(json!("   "))] {
+            let mut input = hook_input("PreToolUse", "edit", json!({"filePath": "main.rs"}));
+            if let Some(value) = value {
+                input[field] = value;
+            } else {
+                input.as_object_mut().unwrap().remove(field);
+            }
+            let error = parse_codearts(&input).unwrap_err();
+            assert!(error.to_string().contains(field), "{field}: {error}");
+        }
+    }
+}
+
+#[test]
+fn test_codearts_rejects_file_edits_without_resolvable_paths() {
+    for event in ["PreToolUse", "PostToolUse"] {
+        for input in [Value::Null, json!({}), json!({"filePath": " "})] {
+            assert!(parse_codearts(&hook_input(event, "edit", input)).is_err());
+        }
+    }
+}
+
+fn checkpoint(repo: &TestRepo, event: &str, tool: &str, tool_id: &str, input: Value) {
+    let mut hook = hook_input(event, tool, input);
+    hook["cwd"] = json!(repo.canonical_path());
+    hook["tool_use_id"] = json!(tool_id);
+    hook["model"] = json!("deepseek-v3.2");
+    repo.git_ai(&["checkpoint", "codearts", "--hook-input", &hook.to_string()])
+        .unwrap();
+}
+
+#[test]
+fn test_codearts_e2e_file_edit_preserves_human_and_untracked_lines() {
+    let repo = TestRepo::new();
+    let file_path = repo.path().join("example.txt");
+    let mut file = repo.filename("example.txt");
+
+    fs::write(&file_path, "Original untracked line\n").unwrap();
+    repo.stage_all_and_commit("Initial untracked content")
+        .unwrap();
+    file.assert_committed_lines(lines!["Original untracked line".unattributed_human()]);
+
+    fs::write(&file_path, "Original untracked line\nKnown human line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "example.txt"])
+        .unwrap();
+    repo.stage_all_and_commit("Known human edit").unwrap();
+    file.assert_committed_lines(lines![
+        "Original untracked line".unattributed_human(),
+        "Known human line".human(),
+    ]);
+
+    // Keep the pre-existing untracked edit apart from the AI edit: the shared
+    // commit recovery intentionally extends AI attribution to adjacent lines.
+    fs::write(
+        &file_path,
+        "Untracked before CodeArts\nOriginal untracked line\nKnown human line\n",
+    )
+    .unwrap();
+    let input = json!({"filePath": "example.txt"});
+    checkpoint(&repo, "PreToolUse", "edit", "edit-1", input.clone());
+    fs::write(
+        &file_path,
+        "Untracked before CodeArts\nOriginal untracked line\nKnown human line\nCodeArts generated line\n",
+    )
+    .unwrap();
+    checkpoint(&repo, "PostToolUse", "edit", "edit-1", input);
+    let commit = repo.stage_all_and_commit("CodeArts file edit").unwrap();
+    file.assert_committed_lines(lines![
+        "Untracked before CodeArts".unattributed_human(),
+        "Original untracked line".unattributed_human(),
+        "Known human line".human(),
+        "CodeArts generated line".ai(),
+    ]);
+    let sessions = &commit.authorship_log.metadata.sessions;
+    assert_eq!(sessions.len(), 1);
+    let session = sessions.values().next().unwrap();
+    assert_eq!(session.agent_id.tool, "codearts");
+    assert_eq!(session.agent_id.id, "codearts-session");
+    assert_eq!(session.agent_id.model, "deepseek-v3.2");
+}
+
+#[test]
+fn test_codearts_e2e_shell_edit_attributes_only_new_changes() {
+    let bash_db = tempfile::tempdir().unwrap();
+    let bash_db_path = bash_db.path().join("bash-checkpoints.db");
+    let repo = TestRepo::new_with_daemon_env(&[(
+        "GIT_AI_TEST_BASH_CHECKPOINT_DB_PATH",
+        bash_db_path.to_str().unwrap(),
+    )]);
+    let file_path = repo.path().join("example.txt");
+    let mut file = repo.filename("example.txt");
+
+    fs::write(&file_path, "Original untracked line\n").unwrap();
+    repo.stage_all_and_commit("Initial untracked content")
+        .unwrap();
+    file.assert_committed_lines(lines!["Original untracked line".unattributed_human()]);
+
+    fs::write(&file_path, "Original untracked line\nKnown human line\n").unwrap();
+    repo.git_ai(&["checkpoint", "mock_known_human", "example.txt"])
+        .unwrap();
+    repo.stage_all_and_commit("Known human edit").unwrap();
+    file.assert_committed_lines(lines![
+        "Original untracked line".unattributed_human(),
+        "Known human line".human(),
+    ]);
+
+    let input = json!({"command": "echo CodeArts shell line >> example.txt"});
+    checkpoint(&repo, "PreToolUse", "bash", "bash-1", input.clone());
+    fs::write(
+        &file_path,
+        "Original untracked line\nKnown human line\nCodeArts shell line\n",
+    )
+    .unwrap();
+    checkpoint(&repo, "PostToolUse", "bash", "bash-1", input);
+    let commit = repo.stage_all_and_commit("CodeArts shell edit").unwrap();
+    file.assert_committed_lines(lines![
+        "Original untracked line".unattributed_human(),
+        "Known human line".human(),
+        "CodeArts shell line".ai(),
+    ]);
+    let sessions = &commit.authorship_log.metadata.sessions;
+    assert_eq!(sessions.len(), 1);
+    let session = sessions.values().next().unwrap();
+    assert_eq!(session.agent_id.tool, "codearts");
+    assert_eq!(session.agent_id.id, "codearts-session");
+    assert_eq!(session.agent_id.model, "deepseek-v3.2");
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -41,6 +41,7 @@ mod ci_partial_clone;
 mod ci_squash_rebase;
 mod claude_code;
 mod cli_parser_rebase_args;
+mod codearts;
 mod codex;
 mod cold_trace2_repo;
 mod commit_metric_metadata;

--- a/tests/integration/repos/test_file.rs
+++ b/tests/integration/repos/test_file.rs
@@ -8,6 +8,7 @@ use insta::assert_debug_snapshot;
 const AI_AUTHOR_NAMES: &[&str] = &[
     "mock_ai",
     "claude",
+    "codearts",
     "continue-cli",
     "gpt",
     "copilot",

--- a/tests/integration/repos/test_repo.rs
+++ b/tests/integration/repos/test_repo.rs
@@ -1017,6 +1017,7 @@ fn is_known_checkpoint_preset(arg: &str) -> bool {
     matches!(
         arg,
         "claude"
+            | "codearts"
             | "codex"
             | "continue-cli"
             | "cursor"


### PR DESCRIPTION
CodeArts Agent tool edits are not currently attributed by Git AI. Add a `codearts` checkpoint preset and automatic installation of `~/.codeartsdoer/plugins/git-ai.ts`, reusing the OpenCode plugin template, file-path parser, and shell checkpoint flow. Authorship records retain the CodeArts session and coding model, and its native SQLite conversations are read by the existing asynchronous transcript worker. This adds no work to trace2 ingestion.

The shared plugin now preserves tool working directories, pairs calls by session and invocation ID, and excludes source-content fields from path discovery. Its model cache is bounded to 256 recently used sessions and cleared on session deletion; in-flight calls retain their captured model. CodeArts captures its coding model from chat hooks, ignores title-generation model changes, and additionally recognizes `deleteFile`. Installer generation safely escapes executable paths and substitutes them after template branding so directory names cannot be rewritten.

File hooks reuse the exact pre-edit scope for their post checkpoint and skip empty scopes, so files first reported in post-tool metadata cannot absorb pre-existing untracked edits. Failed/cancelled calls are removed through the tool-error event, including cancellation during a pending checkpoint, with a 1,024-call retention cap when terminal events are missing. The plugin decodes standard file URIs and matches CodeArts' Windows `/d/...` conversion specifically for `edit` and `deleteFile`.

The shared TypeScript template is used by OpenCode and CodeArts. The Rust path-extraction helper also has existing Codex and Cline callers, so its content-field filtering was checked against both integrations.

## CodeArts setup and manual verification

This setup follows [Multica PR #6985](https://github.com/multica-ai/multica/pull/6985). The recorded live validation used **Windows, CodeArts CLI 26.8.1, and `mimo/mimo-v2.5`**. Linux installation commands are included for reviewers; the live results below are from Windows.

### 1. Install CodeArts CLI

Use the [official installation instructions](https://support.huaweicloud.com/usermanual-cli/codeartsagent_cli_0005.html).

Windows PowerShell:

```powershell
irm https://cnnorth4-cloudide-marketplace.obs.cn-north-4.myhuaweicloud.com/codearts/cli_tui/install_script/install.ps1 | iex
```

Linux:

```bash
sh -c "$(curl -L https://cnnorth4-cloudide-marketplace.obs.cn-north-4.myhuaweicloud.com/codearts/cli_tui/install_script/install.sh)" \
  && export PATH="$HOME/.codeartsdoer/installers:$PATH"
```

Open a new terminal after installation and run `codearts --version`. If the command is unavailable, add `~/.codeartsdoer/installers` to that terminal's PATH (`%USERPROFILE%\.codeartsdoer\installers` on Windows).

### 2. Configure a model and authentication

Create or merge the provider entry into the user-level configuration:

- Windows: `%USERPROFILE%\.codeartsdoer\codearts_cli.json`
- Linux: `~/.codeartsdoer/codearts_cli.json`

The `.jsonc` variant is also supported. See the [CodeArts configuration example](https://support.huaweicloud.com/usermanual-cli/codeartsagent_cli_00022.html).

For example, using [MiMo's standard API endpoint](https://platform.xiaomimimo.com/docs/en-US/usage-guide/passing-back-reasoning_content):

```json
{
  "$schema": "https://opencode.ai/config.json",
  "provider": {
    "mimo": {
      "name": "MiMo",
      "options": {
        "apiKey": "<YOUR_MIMO_API_KEY>",
        "baseURL": "https://api.xiaomimimo.com/v1"
      },
      "models": {
        "mimo-v2.5": {
          "name": "MiMo V2.5"
        }
      }
    }
  }
}
```

Use the endpoint and key matching your provider/API plan; a Token Plan may require its own endpoint and key. Keep the API key in local configuration. For another provider, replace the provider/model IDs and credentials, then substitute its `provider/model` identifier in the commands below.

CodeArts CLI 26.8.1 also requires `CODEARTS_CLI_AK` and `CODEARTS_CLI_SK` to be present for `models`, `run`, and `serve`. In the third-party-provider test documented in Multica #6985, non-secret placeholders passed this presence check while the actual model request used `provider.options.apiKey`:

```powershell
$env:CODEARTS_CLI_AK = "placeholder-ak"
$env:CODEARTS_CLI_SK = "placeholder-sk"
```

```bash
export CODEARTS_CLI_AK="placeholder-ak"
export CODEARTS_CLI_SK="placeholder-sk"
```

Placeholder acceptance is observed behavior in **26.8.1**, not an official compatibility guarantee. For Huawei-hosted models, use valid Huawei Cloud credentials as described in the [AK/SK documentation](https://support.huaweicloud.com/usermanual-cli/codeartsagent_cli_0026.html). Launch CodeArts from the terminal with these variables set; set them again if opening a new terminal.

Run `codearts models` and confirm `mimo/mimo-v2.5` is listed. Always pass `--model mimo/mimo-v2.5` for the non-interactive tests, so the CLI does not select a different default provider.

### 3. Install this PR's Git AI build and hook

With Git, Rust, and [Task](https://taskfile.dev/) installed, check out this PR and follow the repository's [development setup](https://github.com/git-ai-project/git-ai/blob/main/CONTRIBUTING.md#using-a-development-build-locally). From the Git AI checkout:

```sh
git fetch origin pull/2323/head
git switch --detach FETCH_HEAD
task dev
git-ai install-hooks
```

Here `origin` is `https://github.com/git-ai-project/git-ai.git`; use that URL in the fetch command if your remote points elsewhere. `task dev` installs the current branch build to `~/.git-ai/bin`, updates the Git integration, and restarts the daemon. Ensure that directory is on the test terminal's PATH. This replaces the installed Git AI binary with the development build.

The CodeArts hook should now exist at `~/.codeartsdoer/plugins/git-ai.ts` (`%USERPROFILE%\.codeartsdoer\plugins\git-ai.ts` on Windows). Start a new CodeArts process to load it. Leave `--pure` off because it disables external plugins. Node.js is also needed for the functional assertions below.

### 4. Prepare a small test repository

The following reproduction commands use Windows PowerShell. Use a configured Git author identity and create a separate repository:

```powershell
$testRepo = Join-Path $env:TEMP ("git-ai-codearts-" + [guid]::NewGuid().ToString("N"))
New-Item -ItemType Directory -Path $testRepo | Out-Null
Set-Location $testRepo
git init
@'
function multiply(a, b) {
  return a * b;
}

module.exports = { multiply };
'@ | Set-Content -Encoding ascii math.js
git add math.js
git commit -m "Add human baseline"
git-ai await --timeout 30
```

### 5. Verify native `edit` and `write` attribution

Start the interactive client in the test repository:

```powershell
codearts --model mimo/mimo-v2.5
```

Send this prompt and approve the two requested file changes using **Allow once**:

```text
Use the native edit tool to add an add(a, b) function to math.js and export it
alongside multiply. Preserve multiply's behavior. Use the native write tool to
create native-generated.js containing exactly:
module.exports = 'CODEARTS_NATIVE_OK';
Do not use bash, shell, or another tool to change files. Do not commit.
```

Confirm both `edit` and `write` completed successfully in the tool activity, then exit the client. If a native call is rejected or the model substitutes a shell command, that run does not validate the native path.

```powershell
node -e "const a=require('node:assert/strict'); const m=require('./math.js'); a.equal(m.multiply(3,4),12); a.equal(m.add(2,3),5); a.equal(m.add(-2,2),0); a.equal(require('./native-generated.js'),'CODEARTS_NATIVE_OK');"
if ($LASTEXITCODE -ne 0) { throw "Native file assertions failed" }
git diff -- math.js
git add math.js native-generated.js
git commit -m "Verify CodeArts native tools"
git-ai await --timeout 30
git-ai stats HEAD --json
git-ai blame math.js --json
git-ai blame native-generated.js --json
git notes --ref=ai show HEAD
codearts session list --format json
```

Proceed to the commit only after the Node assertions and tool results pass. Verify that the generated lines are attributed to `codearts`, with model `mimo-v2.5` and the actual CodeArts session ID, while unchanged baseline lines retain their original attribution. Stats should contain a `codearts::mimo-v2.5` entry under `tool_model_breakdown`, with the generated additions attributed to that model rather than `unknown`.

CodeArts 26.8.1 non-interactive `run` rejects permissions configured as `ask`; `--auto` only controls shell execution and does not approve native file edits. The interactive steps above use normal one-time approval. Our recorded automated native test exercised the same approval flow through CodeArts' permission API, with no shell fallback. See the [CodeArts permission documentation](https://support.huaweicloud.com/usermanual-cli/codeartsagent_cli_0006.html).

### 6. Verify shell attribution in a separate session and commit

In the same repository and terminal, send the prompt through stdin with an explicit model:

```powershell
@'
Use the bash tool to create shell-generated.txt containing exactly one line:
CODEARTS_SHELL_OK
Do not modify other files. Do not use edit or write tools. Do not commit.
'@ | codearts run --format json --auto --model mimo/mimo-v2.5
```

Inspect the JSON stream for a successfully completed `bash` tool call and retain its session ID. A zero exit code alone is insufficient.

```powershell
node -e "const a=require('node:assert/strict'); a.equal(require('node:fs').readFileSync('shell-generated.txt','utf8').trim(),'CODEARTS_SHELL_OK');"
if ($LASTEXITCODE -ne 0) { throw "Shell file assertion failed" }
git add shell-generated.txt
git commit -m "Verify CodeArts shell tool"
git-ai await --timeout 30
git-ai stats HEAD --json
git-ai blame shell-generated.txt --json
git-ai blame native-generated.js --json
git notes --ref=ai show HEAD
```

After the content assertion passes, verify that the marker's added line belongs to `codearts::mimo-v2.5` and this shell session. `native-generated.js` should retain the previous native session's attribution. Separating the sessions and commits makes it possible to verify both paths independently.

If attribution is missing, check `git-ai bg status`, confirm the plugin exists, and set `$env:GIT_AI_CODEARTS_DEBUG = "1"` before starting a fresh CodeArts process to inspect checkpoint errors. Further coverage details are in [`docs/codearts.md`](https://github.com/mikyan/git-ai/blob/feat/codearts-support/docs/codearts.md).

### Transcript collection and verification

No separate transcript setup is required after `task dev` and restarting CodeArts. The plugin resolves the database from the CodeArts kernel's own environment (`KERNEL_DATA_DIR`, or `XDG_DATA_HOME`/`SCENARIO` defaults, with an optional `OPENCODE_DB` override) and sends an absolute path. Git AI queries only the reported session, reuses the OpenCode SQLite reader, and preserves the distinct `codearts` identity and parent session IDs. In-memory databases are skipped; unavailable database files do not block code attribution.

CodeArts invokes `tool.execute.after` before it persists the tool result and final reply. The plugin therefore also sends a transcript-only `SessionUpdate` after an assistant message is completed. The daemon only queues this request for its existing worker; it does not create an attribution checkpoint or inspect working-tree files. The new path honors repository filters and retains the worker's existing prompt policy and secret redaction.

The regression test first captures a running tool without output, then updates that same message and inserts a final reply after the last tool checkpoint. It verifies the completed result, final text, CodeArts/parent identity, and unchanged attribution of unrelated edits. A separate TestRepo case verifies excluded/allowlisted repositories and a completed conversation with no editing tool. Run `task test TEST_FILTER=codearts TEST_THREADS=4` to reproduce these checks.

Live Windows / CodeArts 26.8.1 / MiMo verification (2026-09-12):

- Before the completion notification, the native test reproduced a missing final assistant message and a last `write` snapshot stuck at `running` with no output.
- After the fix, native `edit`/`write` through the normal one-time permission API captured all **5 messages and 18 parts**, including final tool output and assistant text. Every latest captured raw message/part matched the source SQLite data. Functional checks, commit, await, stats, notes, and line-level blame passed: **6 CodeArts AI additions and 1 unrelated known-human addition**.
- A separate actual non-interactive `codearts run --format json --auto --model mimo/mimo-v2.5` invocation received its prompt on stdin. After the process exited, all **3 messages and 10 parts** matched the source, including the completed bash output and final reply. Functional checks and committed attribution passed: **1 CodeArts AI addition and 1 unrelated known-human addition**. This checks CLI exit behavior separately from the long-running native test server.

The live transcript checks read only the newly generated synthetic session from CodeArts and Git AI's local databases; they compare final raw objects as well as IDs. No credentials or real user conversations are included in the PR.

## Validation

- `task test TEST_FILTER=codearts TEST_THREADS=4`: 4 unit and 19 integration tests passed, including `TestRepo` multi-file edits with unrelated dirty files and patch add/move/delete commits.
- `task test TEST_FILTER=opencode TEST_THREADS=4`: 36 unit and 15 integration tests passed for existing OpenCode behavior.
- `npm test` and `npm run type-check` in `agent-support/opencode`; all 53 plugin tests passed locally and are configured in an Ubuntu/Windows CI matrix.
- `task fmt`, `task format:check`, and `task lint` with the repository's Rust 1.93.0 toolchain.
- Real Windows CodeArts CLI 26.8.1 with `mimo/mimo-v2.5`: separate shell and native `edit`/`write` sessions, functional assertions, commits, explicit daemon waits, stats, notes, and line-level blame. Each test commit had six added lines, all attributed to `codearts::mimo-v2.5`; session IDs matched the actual calls and existing attribution survived subsequent edits. Native tool calls were approved once through CodeArts' normal permission API.
- Pre-submit review identified a path-branding regression; the added regression case failed before the fix and passed afterward.

- Follow-up real Windows/MiMo regression: native `edit` received an unnormalized `/D/...` path, while `write` used a normal Windows path. Both completed without shell fallback. The commit's six AI additions retained the actual CodeArts session/model, and one unrelated pre-existing dirty line remained untracked; functional assertions, stats, notes, and line-level blame passed.
- Scope, failure-event cleanup, bounded pending calls, cancellation timing, and URI/Windows-path regressions were reproduced by failing tests before their fixes.

- Additional shared-parser audit: Codex passed 143 unit and 61 integration tests; three metrics-history assertions failed. Cline passed 19 unit tests, including its parser tests; one Windows installer test failed. All four failures were reproduced at the original base `1f16720db8553f19622fa83e728a8247ff825727`, with no CodeArts changes applied.

## Scope

The accepted tool names cover the current OpenCode plugin's edit/shell set plus `deleteFile`. `docs/codearts.md` distinguishes implemented handling, parser/hook tests, and real-client validation. IDE/extension behavior, subagent edits, and the remaining tool variants have not been live-tested. CodeArts SQLite transcript collection, including parent/child session identifiers, is covered by integration tests. The SQLite schema and path rules were checked against CLI 26.8.1 and VS Code AgentKernel 26.8.101. Legacy Snap inline completions are outside this hook integration. The shared reader retains its existing limits around part-only changes to old messages and timestamp-watermark boundaries.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/2323" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
