### PR TITLE
feat(daemon): keep temporary repositories out of the untraced fixup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,7 @@ Signal forwarding: On Unix, the git proxy installs signal handlers (SIGTERM, SIG
 
 `Config` is a global `OnceLock` singleton accessed via `Config::get()`. It reads from `~/.git-ai/config.json`. In tests, `GIT_AI_TEST_CONFIG_PATCH` env var allows overriding specific config fields without a real config file. Feature flags follow precedence: environment vars (`GIT_AI_*` prefix via `envy`) > config file > defaults.
 
-Feature flags have separate debug/release defaults defined via the `define_feature_flags!` macro in `src/feature_flags.rs`. Currently: `auth_keyring` (false/false), `transcript_streaming` (true/true), `transcript_sweep` (true/true), `checkpoint_debug_log` (false/false), `daemon_log_upload` (true/true), `untraced_commit_fixup` (true/true).
+Feature flags have separate debug/release defaults defined via the `define_feature_flags!` macro in `src/feature_flags.rs`. Currently: `auth_keyring` (false/false), `transcript_streaming` (true/true), `transcript_sweep` (true/true), `checkpoint_debug_log` (false/false), `daemon_log_upload` (true/true), `untraced_commit_fixup` (true/true), `untraced_fixup_ignore_temp_repos` (true/true).
 
 ### Error handling
 

--- a/docs/untraced-commit-fixup-spec.md
+++ b/docs/untraced-commit-fixup-spec.md
@@ -111,6 +111,28 @@ untraced history, which is exactly what the fixup exists to claim.
   `untraced_cursor_reseeds`, `untraced_scan_errors`, `known_repo_families` in
   `status.daemon`, `git-ai bg status`, and the heartbeat.
 
+## Repositories the fixup ignores
+
+AI agents create scratch repositories under the OS temp directory for their own
+work. The fixup leaves those alone: it never remembers, scans, persists or
+backfills a family whose canonical common dir is under a temp root
+(`$TMPDIR`/`TEMP`/`TMP`, `/tmp`, `/var/tmp`, macOS `/var/folders`, Windows
+`%TEMP%`) or matches an `untraced_fixup_ignored_paths` glob from the config.
+Rows for such families are forgotten on the next maintenance round.
+
+This is scoped to the fixup and its store (`src/daemon/untraced_fixup_ignore.rs`,
+consulted only by the fixup scheduler). It is not a global repository exclusion:
+traced commands and checkpoints in a temp repository keep their normal
+behaviour. The temp-root part is gated by the `untraced_fixup_ignore_temp_repos`
+feature flag (on by default; the test harness turns it off because every test
+repository lives under the temp dir); configured globs always apply.
+
+The check is a component-wise prefix comparison per root and a glob match per
+pattern on strings computed once at startup, placed at the top of the per-family
+loop a tick already runs, before the stat and any store write. An ignored
+family therefore costs less than it did, and a non-ignored one costs a handful
+of byte comparisons more.
+
 ## Known limitations
 
 - Detached-HEAD commits are never fixed up.

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -101,6 +101,9 @@ fn print_config_help() {
     println!("  exclude_prompts_in_repositories  Repos to exclude prompts from (array)");
     println!("  allow_repositories           Allowed repos (array)");
     println!("  exclude_repositories         Excluded repos (array)");
+    println!(
+        "  untraced_fixup_ignored_paths Repo path globs the untraced-commit fixup skips (array)"
+    );
     println!("  telemetry_oss                OSS telemetry setting (on/off)");
     println!("  telemetry_enterprise_dsn     Enterprise telemetry DSN");
     println!("  disable_version_checks       Disable version checks (bool)");
@@ -300,6 +303,17 @@ fn show_all_config() -> Result<(), String> {
         effective_config.insert("exclude_repositories".to_string(), Value::Array(vec![]));
     }
 
+    effective_config.insert(
+        "untraced_fixup_ignored_paths".to_string(),
+        serde_json::to_value(
+            file_config
+                .untraced_fixup_ignored_paths
+                .clone()
+                .unwrap_or_default(),
+        )
+        .unwrap(),
+    );
+
     // Booleans with runtime values
     effective_config.insert(
         "telemetry_oss_disabled".to_string(),
@@ -479,6 +493,13 @@ fn get_config_value(key: &str) -> Result<(), String> {
                     Value::Array(vec![])
                 }
             }
+            "untraced_fixup_ignored_paths" => serde_json::to_value(
+                file_config
+                    .untraced_fixup_ignored_paths
+                    .clone()
+                    .unwrap_or_default(),
+            )
+            .unwrap(),
             "telemetry_oss_disabled" => Value::Bool(runtime_config.is_telemetry_oss_disabled()),
             "telemetry_enterprise_dsn" => {
                 if let Some(ref dsn) = file_config.telemetry_enterprise_dsn {
@@ -697,6 +718,15 @@ fn set_config_value(key: &str, value: &str, add_mode: bool) -> Result<(), String
             "exclude_repositories" => {
                 let added = set_repository_array_field(
                     &mut file_config.exclude_repositories,
+                    value,
+                    add_mode,
+                )?;
+                crate::config::save_file_config(&file_config)?;
+                log_array_changes(&added, add_mode);
+            }
+            "untraced_fixup_ignored_paths" => {
+                let added = set_string_array_field(
+                    &mut file_config.untraced_fixup_ignored_paths,
                     value,
                     add_mode,
                 )?;
@@ -1116,6 +1146,13 @@ fn unset_config_value(key: &str) -> Result<(), String> {
                     log_array_removals(&items);
                 }
             }
+            "untraced_fixup_ignored_paths" => {
+                let old_values = file_config.untraced_fixup_ignored_paths.take();
+                crate::config::save_file_config(&file_config)?;
+                if let Some(items) = old_values {
+                    log_array_removals(&items);
+                }
+            }
             "telemetry_oss" => {
                 let old_value = file_config.telemetry_oss.take();
                 crate::config::save_file_config(&file_config)?;
@@ -1512,6 +1549,46 @@ fn set_repository_array_field(
 /// Resolve a repository value - returns the actual patterns to store
 /// For file paths, resolves to repository remote URLs
 /// For URLs/patterns, returns as-is
+/// Set a plain string-array field (path globs): a JSON array or one value,
+/// appended without duplicates in add mode. Unlike repository patterns,
+/// values are taken literally — nothing is resolved to remotes.
+fn set_string_array_field(
+    field: &mut Option<Vec<String>>,
+    value: &str,
+    add_mode: bool,
+) -> Result<Vec<String>, String> {
+    let values: Vec<String> = if value.trim_start().starts_with('[') {
+        match serde_json::from_str::<Value>(value)
+            .map_err(|e| format!("Invalid JSON array: {}", e))?
+        {
+            Value::Array(items) => items
+                .into_iter()
+                .map(|item| match item {
+                    Value::String(s) => Ok(s),
+                    _ => Err("Array must contain only strings".to_string()),
+                })
+                .collect::<Result<Vec<_>, _>>()?,
+            _ => return Err("Expected a JSON array".to_string()),
+        }
+    } else {
+        vec![value.to_string()]
+    };
+    if add_mode {
+        let existing = field.get_or_insert_with(Vec::new);
+        let mut added = Vec::new();
+        for value in values {
+            if !existing.contains(&value) && !added.contains(&value) {
+                added.push(value);
+            }
+        }
+        existing.extend(added.iter().cloned());
+        Ok(added)
+    } else {
+        *field = Some(values.clone());
+        Ok(values)
+    }
+}
+
 fn resolve_repository_value(value: &str) -> Result<Vec<String>, String> {
     match detect_pattern_type(value) {
         PatternType::GlobalWildcard | PatternType::UrlOrGitProtocol => {

--- a/src/config.rs
+++ b/src/config.rs
@@ -167,6 +167,11 @@ pub struct Config {
     allow_repositories: Vec<Pattern>,
     #[serde(serialize_with = "serialize_patterns")]
     exclude_repositories: Vec<Pattern>,
+    /// Path globs (POSIX form of a repository's canonical common dir) the
+    /// untraced-commit fixup leaves alone, on top of the OS temp roots. Only
+    /// the fixup consults this; it is not a global repository exclusion.
+    #[serde(serialize_with = "serialize_patterns")]
+    untraced_fixup_ignored_paths: Vec<Pattern>,
     telemetry_oss_disabled: bool,
     telemetry_enterprise_dsn: Option<String>,
     disable_version_checks: bool,
@@ -235,6 +240,8 @@ pub struct FileConfig {
     pub allow_repositories: Option<Vec<String>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub exclude_repositories: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub untraced_fixup_ignored_paths: Option<Vec<String>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub telemetry_oss: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -320,6 +327,8 @@ pub struct ConfigPatch {
     pub git_path: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub exclude_prompts_in_repositories: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub untraced_fixup_ignored_paths: Option<Vec<String>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub telemetry_oss_disabled: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -412,6 +421,12 @@ impl Config {
     /// Returns the command to invoke git.
     pub fn git_cmd(&self) -> &str {
         &self.git_path
+    }
+
+    /// Path globs the untraced-commit fixup ignores (see
+    /// `daemon::untraced_fixup_ignore`); not a global repository exclusion.
+    pub fn untraced_fixup_ignored_paths(&self) -> &[Pattern] {
+        &self.untraced_fixup_ignored_paths
     }
 
     pub fn has_repository_filters(&self) -> bool {
@@ -1025,6 +1040,13 @@ fn build_config() -> Config {
                 .ok()
         })
         .collect();
+    let untraced_fixup_ignored_paths = parse_path_patterns(
+        "untraced_fixup_ignored_paths",
+        file_cfg
+            .as_ref()
+            .and_then(|c| c.untraced_fixup_ignored_paths.clone())
+            .unwrap_or_default(),
+    );
     let telemetry_oss_disabled = file_cfg
         .as_ref()
         .and_then(|c| c.telemetry_oss.clone())
@@ -1248,6 +1270,7 @@ fn build_config() -> Config {
             include_prompts_in_repositories,
             allow_repositories,
             exclude_repositories,
+            untraced_fixup_ignored_paths,
             telemetry_oss_disabled,
             telemetry_enterprise_dsn,
             disable_version_checks,
@@ -1282,6 +1305,7 @@ fn build_config() -> Config {
         include_prompts_in_repositories,
         allow_repositories,
         exclude_repositories,
+        untraced_fixup_ignored_paths,
         telemetry_oss_disabled,
         telemetry_enterprise_dsn,
         disable_version_checks,
@@ -1697,6 +1721,23 @@ pub fn is_real_git_candidate(p: &Path) -> bool {
     is_executable(p) && !path_is_git_ai_binary(p)
 }
 
+/// Glob patterns from a config list, warning about and dropping invalid ones.
+fn parse_path_patterns(key: &str, patterns: Vec<String>) -> Vec<Pattern> {
+    patterns
+        .into_iter()
+        .filter_map(|pattern_str| {
+            Pattern::new(&pattern_str)
+                .map_err(|e| {
+                    eprintln!(
+                        "Warning: Invalid glob pattern in {key} '{}': {}",
+                        pattern_str, e
+                    );
+                })
+                .ok()
+        })
+        .collect()
+}
+
 /// Apply test config patch from environment variable (test-only)
 /// Reads GIT_AI_TEST_CONFIG_PATCH env var containing JSON and applies patches to config
 #[cfg(any(test, feature = "test-support"))]
@@ -1721,6 +1762,10 @@ fn apply_test_config_patch(config: &mut Config) {
                             .ok()
                     })
                     .collect();
+        }
+        if let Some(patterns) = patch.untraced_fixup_ignored_paths {
+            config.untraced_fixup_ignored_paths =
+                parse_path_patterns("untraced_fixup_ignored_paths", patterns);
         }
         if let Some(telemetry_oss_disabled) = patch.telemetry_oss_disabled {
             config.telemetry_oss_disabled = telemetry_oss_disabled;
@@ -1812,6 +1857,7 @@ mod tests {
                 .into_iter()
                 .filter_map(|s| Pattern::new(&s).ok())
                 .collect(),
+            untraced_fixup_ignored_paths: vec![],
             telemetry_oss_disabled: false,
             telemetry_enterprise_dsn: None,
             disable_version_checks: false,
@@ -2048,6 +2094,27 @@ mod tests {
 
     // Tests for exclude_prompts_in_repositories (blacklist)
 
+    #[test]
+    fn untraced_fixup_ignored_paths_parse_from_file_config_and_drop_invalid_globs() {
+        let parsed = parse_path_patterns(
+            "untraced_fixup_ignored_paths",
+            vec![
+                "*/agent-scratch-*/.git".to_string(),
+                "[unclosed".to_string(),
+            ],
+        );
+        assert_eq!(parsed.len(), 1);
+        assert!(parsed[0].matches("/home/me/work/agent-scratch-1/.git"));
+        assert!(!parsed[0].matches("/home/me/work/real/.git"));
+
+        let file: FileConfig =
+            serde_json::from_str(r#"{"untraced_fixup_ignored_paths": ["*/scratch/**"]}"#).unwrap();
+        assert_eq!(
+            file.untraced_fixup_ignored_paths,
+            Some(vec!["*/scratch/**".to_string()])
+        );
+    }
+
     fn create_test_config_with_exclude_prompts(exclude_prompts_patterns: Vec<String>) -> Config {
         Config {
             git_path: "/usr/bin/git".to_string(),
@@ -2058,6 +2125,7 @@ mod tests {
             include_prompts_in_repositories: vec![],
             allow_repositories: vec![],
             exclude_repositories: vec![],
+            untraced_fixup_ignored_paths: vec![],
             telemetry_oss_disabled: false,
             telemetry_enterprise_dsn: None,
             disable_version_checks: false,
@@ -2207,6 +2275,7 @@ mod tests {
                 .collect(),
             allow_repositories: vec![],
             exclude_repositories: vec![],
+            untraced_fixup_ignored_paths: vec![],
             telemetry_oss_disabled: false,
             telemetry_enterprise_dsn: None,
             disable_version_checks: false,

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -84,6 +84,7 @@ pub mod token_usage_worker;
 pub mod trace_normalizer;
 pub mod transcript_redaction;
 pub mod untraced_commit_fixup;
+pub mod untraced_fixup_ignore;
 
 pub use control_api::{
     BashSessionQueryResponse, BashSnapshotQueryResponse, ControlRequest, ControlResponse,
@@ -2755,6 +2756,9 @@ pub(crate) struct UntracedScanSchedule {
     /// Changed worktrees left for the next tick: by the per-tick cap, or
     /// because a git command of their family was still running.
     deferred: usize,
+    /// Families the fixup ignores (temp scratch repositories, configured
+    /// globs) that were named or remembered and therefore skipped.
+    ignored: usize,
 }
 
 /// What the daemon remembers about one worktree between fixup ticks.
@@ -3102,6 +3106,11 @@ pub struct ActorDaemonCoordinator {
     /// Families and fixup cursors remembered across restarts; `None` when the
     /// database could not be opened (fixup then only covers this process).
     repo_family_store: Option<Arc<crate::daemon::repo_family_store::RepoFamilyStore>>,
+    /// Repositories the untraced-commit fixup leaves alone (temp scratch repos,
+    /// configured globs); consulted only by the fixup scheduler and store, and
+    /// rebuilt from a fresh config read on each maintenance round so a config
+    /// change takes effect within the hour rather than at the next restart.
+    untraced_fixup_ignore: Mutex<crate::daemon::untraced_fixup_ignore::UntracedFixupIgnore>,
     /// Worktree git dirs whose fixup cursor must not be persisted again this
     /// lifetime: a pass had a side effect fail, and the durable cursor has to
     /// stay behind that commit so a later lifetime can retry it.
@@ -3262,6 +3271,7 @@ impl ActorDaemonCoordinator {
             telemetry_worker: None,
             repo_family_store: None,
             untraced_persistence_blocked: Mutex::new(HashSet::new()),
+            untraced_fixup_ignore: Mutex::new(Default::default()),
             stream_worker: None,
             token_usage_worker: None,
             transcript_shutdown_notify: std::sync::OnceLock::new(),
@@ -5662,16 +5672,26 @@ impl ActorDaemonCoordinator {
                 },
             )
             .await?;
-        if maintenance
-            && let Some(count) = self
+        if maintenance {
+            // Rows for repositories the fixup now ignores (scratch repos from
+            // before this rule, or newly configured globs) are forgotten here.
+            let ignore = self.untraced_fixup_ignore()?;
+            if let Some(count) = self
                 .with_repo_family_store(move |store| {
+                    let forgotten: Vec<String> = store
+                        .known_families(true)?
+                        .into_iter()
+                        .filter(|family| ignore.ignores(family))
+                        .collect();
+                    store.forget_families(&forgotten)?;
                     store.prune(now_secs)?;
                     store.family_count()
                 })
                 .await?
-        {
-            self.known_repo_families
-                .store(count as u64, Ordering::Relaxed);
+            {
+                self.known_repo_families
+                    .store(count as u64, Ordering::Relaxed);
+            }
         }
         Ok(schedule)
     }
@@ -5685,11 +5705,18 @@ impl ActorDaemonCoordinator {
     ) -> Result<UntracedScanSchedule, GitAiError> {
         let now_secs = crate::utils::unix_timestamp_now();
         let mut targets = Vec::new();
+        let mut ignored = 0;
         match repo_working_dir {
             Some(dir) => {
                 // The whole family: every worktree of the repository, with the
                 // named one included even when enumeration cannot see it.
                 let family = self.backend.resolve_family(Path::new(&dir))?;
+                if self.untraced_fixup_ignore()?.ignores(&family.0) {
+                    return Ok(UntracedScanSchedule {
+                        ignored: 1,
+                        ..UntracedScanSchedule::default()
+                    });
+                }
                 let worktree = worktree_root_for_path(Path::new(&dir)).ok_or_else(|| {
                     GitAiError::Generic(format!("{dir} is not inside a git worktree"))
                 })?;
@@ -5717,6 +5744,15 @@ impl ActorDaemonCoordinator {
                         ..
                     }
                 );
+                if maintenance {
+                    // Config edits (new globs, flag flips) apply from here on.
+                    *self.untraced_fixup_ignore.lock().map_err(|_| {
+                        GitAiError::Generic("untraced fixup ignore lock poisoned".to_string())
+                    })? = crate::daemon::untraced_fixup_ignore::UntracedFixupIgnore::from_config(
+                        &config::Config::fresh(),
+                    );
+                }
+                let ignore = self.untraced_fixup_ignore()?;
                 let mut families = self.coordinator.family_keys().await;
                 families.extend(self.remembered_families(maintenance).await?);
                 families.sort();
@@ -5745,6 +5781,12 @@ impl ActorDaemonCoordinator {
                 };
                 for family in families {
                     if known_missing.contains(&family) {
+                        continue;
+                    }
+                    // Scratch repositories (temp roots, configured globs) are
+                    // dropped before the stat and before any store write.
+                    if ignore.ignores(&family) {
+                        ignored += 1;
                         continue;
                     }
                     let common_dir = Path::new(&family);
@@ -5781,7 +5823,10 @@ impl ActorDaemonCoordinator {
             let len = targets.len();
             targets.rotate_left((rotation as usize) % len);
         }
-        let mut schedule = UntracedScanSchedule::default();
+        let mut schedule = UntracedScanSchedule {
+            ignored,
+            ..UntracedScanSchedule::default()
+        };
         let mut families = HashSet::new();
         for (family, git_dir, worktree) in targets {
             if self.family_has_pending_untraced_scan(&family, &git_dir)? {
@@ -5847,10 +5892,14 @@ impl ActorDaemonCoordinator {
         if !maintenance && let Some(cached) = self.lock_untraced_known_families()?.clone() {
             return Ok(cached);
         }
-        let remembered = self
+        let ignore = self.untraced_fixup_ignore()?;
+        let remembered: Vec<String> = self
             .with_repo_family_store(move |store| store.known_families(maintenance))
             .await?
-            .unwrap_or_default();
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|family| !ignore.ignores(family))
+            .collect();
         *self.lock_untraced_known_families()? = Some(remembered.clone());
         Ok(remembered)
     }
@@ -5906,6 +5955,16 @@ impl ActorDaemonCoordinator {
                 )
             })
         }))
+    }
+
+    /// A snapshot of the fixup's ignore rules (cheap: a few paths and globs).
+    fn untraced_fixup_ignore(
+        &self,
+    ) -> Result<crate::daemon::untraced_fixup_ignore::UntracedFixupIgnore, GitAiError> {
+        self.untraced_fixup_ignore
+            .lock()
+            .map(|ignore| ignore.clone())
+            .map_err(|_| GitAiError::Generic("untraced fixup ignore lock poisoned".to_string()))
     }
 
     fn untraced_persistence_blocked(&self, git_dir_key: &str) -> Result<bool, GitAiError> {
@@ -6198,6 +6257,12 @@ impl ActorDaemonCoordinator {
                         .map_err(|_| {
                             GitAiError::Generic("command side-effect semaphore closed".to_string())
                         })?;
+                    // The rules may have started ignoring this family after the
+                    // pass was queued (a config change, a maintenance refresh).
+                    if self.untraced_fixup_ignore()?.ignores(family) {
+                        tracing::debug!(%family, "untraced fixup pass skipped: family is ignored");
+                        continue;
+                    }
                     let git_dir_key = git_dir.to_string_lossy().to_string();
                     let worktree_key = worktree.to_string_lossy().to_string();
                     let scan = self
@@ -6206,7 +6271,10 @@ impl ActorDaemonCoordinator {
                         )
                         .await;
                     let persisted = match scan {
-                        Ok(Some(cursor)) if !self.untraced_persistence_blocked(&git_dir_key)? => {
+                        Ok(Some(cursor))
+                            if !self.untraced_persistence_blocked(&git_dir_key)?
+                                && !self.untraced_fixup_ignore()?.ignores(family) =>
+                        {
                             let family = family.to_string();
                             self.cache_untraced_cursor(
                                 &git_dir_key,
@@ -10646,6 +10714,11 @@ pub(crate) async fn run_daemon(config: DaemonConfig) -> Result<DaemonExitAction,
     crate::daemon::telemetry_worker::set_daemon_internal_telemetry(telemetry_handle.clone());
     coordinator_inner.telemetry_worker = Some(telemetry_handle.clone());
 
+    coordinator_inner.untraced_fixup_ignore = Mutex::new(
+        crate::daemon::untraced_fixup_ignore::UntracedFixupIgnore::from_config(
+            config::Config::get(),
+        ),
+    );
     let repo_family_store_path = config.internal_dir.join("repo-families-db");
     match crate::daemon::repo_family_store::RepoFamilyStore::open(&repo_family_store_path) {
         Ok(store) => coordinator_inner.repo_family_store = Some(Arc::new(store)),

--- a/src/daemon/repo_family_store.rs
+++ b/src/daemon/repo_family_store.rs
@@ -297,6 +297,29 @@ impl RepoFamilyStore {
         Ok(worktrees)
     }
 
+    /// Forgets the given families and their cursors, in one transaction; used
+    /// to drop repositories the fixup has since been told to ignore.
+    pub fn forget_families(&self, common_dirs: &[String]) -> Result<usize, GitAiError> {
+        if common_dirs.is_empty() {
+            return Ok(0);
+        }
+        let conn = self.lock();
+        let tx = conn.unchecked_transaction()?;
+        let mut removed = 0;
+        for common_dir in common_dirs {
+            removed += tx.execute(
+                "DELETE FROM repo_families WHERE common_dir = ?1",
+                params![common_dir],
+            )?;
+            tx.execute(
+                "DELETE FROM worktree_fixup_cursors WHERE common_dir = ?1",
+                params![common_dir],
+            )?;
+        }
+        tx.commit()?;
+        Ok(removed)
+    }
+
     /// Forgets families missing or unseen for too long, then the least
     /// recently seen beyond `MAX_FAMILIES`, with their cursors. Returns how
     /// many families were removed.
@@ -584,6 +607,32 @@ mod tests {
                 ),
             ]
         );
+    }
+
+    #[test]
+    fn forget_families_removes_them_and_their_cursors_only() {
+        let (_temp, store) = store();
+        for (family, git_dir, worktree) in [
+            ("/tmp/scratch/.git", "/tmp/scratch/.git", "/tmp/scratch"),
+            ("/home/me/real/.git", "/home/me/real/.git", "/home/me/real"),
+        ] {
+            store
+                .record_pass_completed(family, git_dir, worktree, &cursor_with_anchor(64), NOW)
+                .unwrap();
+        }
+
+        let removed = store
+            .forget_families(&["/tmp/scratch/.git".to_string(), "/nope/.git".to_string()])
+            .unwrap();
+
+        assert_eq!(removed, 1);
+        assert_eq!(
+            store.known_families(true).unwrap(),
+            vec!["/home/me/real/.git".to_string()]
+        );
+        assert_eq!(store.cursor("/tmp/scratch/.git").unwrap(), None);
+        assert!(store.cursor("/home/me/real/.git").unwrap().is_some());
+        assert_eq!(store.forget_families(&[]).unwrap(), 0);
     }
 
     #[test]

--- a/src/daemon/untraced_fixup_ignore.rs
+++ b/src/daemon/untraced_fixup_ignore.rs
@@ -1,0 +1,183 @@
+//! Repositories the untraced-commit fixup leaves alone. AI agents create
+//! scratch repositories under the OS temp directory for their own work; the
+//! fixup must not remember, scan, persist or backfill them. This is scoped to
+//! the fixup worker and its repo-family store only: traced commands and
+//! checkpoints in such repositories keep their normal behaviour, and nothing
+//! outside the fixup consults this.
+
+use crate::config::Config;
+use glob::Pattern;
+use std::path::{Path, PathBuf};
+
+/// Where temporary repositories live, plus operator-configured path globs.
+#[derive(Debug, Clone, Default)]
+pub struct UntracedFixupIgnore {
+    /// Canonical temp roots; a family whose common dir is under one is ignored.
+    temp_roots: Vec<PathBuf>,
+    /// `untraced_fixup_ignored_paths` globs, matched against the POSIX form of
+    /// the family's canonical common dir.
+    patterns: Vec<Pattern>,
+}
+
+impl UntracedFixupIgnore {
+    pub fn from_config(config: &Config) -> Self {
+        let temp_roots = if config.get_feature_flags().untraced_fixup_ignore_temp_repos {
+            default_temp_roots()
+        } else {
+            Vec::new()
+        };
+        Self::new(temp_roots, config.untraced_fixup_ignored_paths().to_vec())
+    }
+
+    /// `temp_roots` are canonicalized and de-duplicated once here; roots that
+    /// do not exist are dropped.
+    pub fn new(temp_roots: Vec<PathBuf>, patterns: Vec<Pattern>) -> Self {
+        let mut roots: Vec<PathBuf> = temp_roots
+            .into_iter()
+            .filter_map(|root| root.canonicalize().ok())
+            .collect();
+        roots.sort();
+        roots.dedup();
+        Self {
+            temp_roots: roots,
+            patterns,
+        }
+    }
+
+    /// Whether the fixup must leave this family (a canonical common dir) alone.
+    /// A component-wise prefix test per root and a glob match per pattern; no
+    /// filesystem access.
+    pub fn ignores(&self, common_dir: &str) -> bool {
+        let path = Path::new(common_dir);
+        if self.temp_roots.iter().any(|root| path.starts_with(root)) {
+            return true;
+        }
+        if self.patterns.is_empty() {
+            return false;
+        }
+        let posix = crate::utils::normalize_to_posix(common_dir);
+        self.patterns.iter().any(|pattern| pattern.matches(&posix))
+    }
+
+    pub fn temp_roots(&self) -> &[PathBuf] {
+        &self.temp_roots
+    }
+}
+
+/// The OS temp locations agents put scratch repositories in: the process temp
+/// dir (`TMPDIR` / `TEMP` / `TMP`) and the platform's well-known ones.
+pub fn default_temp_roots() -> Vec<PathBuf> {
+    let mut roots = vec![std::env::temp_dir()];
+    if cfg!(unix) {
+        roots.push(PathBuf::from("/tmp"));
+        roots.push(PathBuf::from("/var/tmp"));
+    }
+    if cfg!(target_os = "macos") {
+        roots.push(PathBuf::from("/private/tmp"));
+        roots.push(PathBuf::from("/var/folders"));
+        roots.push(PathBuf::from("/private/var/folders"));
+    }
+    if cfg!(windows) {
+        for var in ["TEMP", "TMP"] {
+            if let Some(value) = std::env::var_os(var) {
+                roots.push(PathBuf::from(value));
+            }
+        }
+        if let Some(local) = std::env::var_os("LOCALAPPDATA") {
+            roots.push(PathBuf::from(local).join("Temp"));
+        }
+    }
+    roots
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn canonical(path: &Path) -> String {
+        path.canonicalize().unwrap().to_string_lossy().to_string()
+    }
+
+    #[test]
+    fn ignores_families_under_a_temp_root_but_not_siblings_or_lookalikes() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("tmp");
+        let inside = root.join("scratch-repo").join(".git");
+        let lookalike = temp.path().join("tmpfoo").join("repo").join(".git");
+        let sibling = temp.path().join("projects").join("real").join(".git");
+        for dir in [&inside, &lookalike, &sibling] {
+            fs::create_dir_all(dir).unwrap();
+        }
+        let ignore = UntracedFixupIgnore::new(vec![root.clone()], Vec::new());
+
+        assert!(ignore.ignores(&canonical(&inside)));
+        assert!(
+            !ignore.ignores(&canonical(&lookalike)),
+            "prefix matching is by path component, not by string"
+        );
+        assert!(!ignore.ignores(&canonical(&sibling)));
+    }
+
+    #[test]
+    fn temp_roots_are_canonicalized_deduplicated_and_pruned_of_missing_ones() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("tmp");
+        fs::create_dir_all(&root).unwrap();
+        #[cfg_attr(not(unix), allow(unused_mut))]
+        let mut roots = vec![
+            root.clone(),
+            root.join(".").join("..").join("tmp"),
+            temp.path().join("does-not-exist"),
+        ];
+        #[cfg(unix)]
+        {
+            let link = temp.path().join("tmp-link");
+            std::os::unix::fs::symlink(&root, &link).unwrap();
+            roots.push(link);
+        }
+        let ignore = UntracedFixupIgnore::new(roots, Vec::new());
+
+        assert_eq!(ignore.temp_roots(), &[root.canonicalize().unwrap()]);
+    }
+
+    #[test]
+    fn configured_globs_match_the_posix_form_of_the_common_dir() {
+        let temp = tempfile::tempdir().unwrap();
+        let scratch = temp
+            .path()
+            .join("work")
+            .join("agent-scratch-42")
+            .join(".git");
+        let real = temp.path().join("work").join("real").join(".git");
+        fs::create_dir_all(&scratch).unwrap();
+        fs::create_dir_all(&real).unwrap();
+        let ignore = UntracedFixupIgnore::new(
+            Vec::new(),
+            vec![Pattern::new("*/agent-scratch-*/.git").unwrap()],
+        );
+
+        assert!(ignore.ignores(&canonical(&scratch)));
+        assert!(!ignore.ignores(&canonical(&real)));
+    }
+
+    #[test]
+    fn without_temp_roots_only_globs_apply() {
+        let temp = tempfile::tempdir().unwrap();
+        let inside = temp.path().join("tmp").join("repo").join(".git");
+        fs::create_dir_all(&inside).unwrap();
+        let ignore = UntracedFixupIgnore::new(Vec::new(), Vec::new());
+        assert!(!ignore.ignores(&canonical(&inside)));
+    }
+
+    #[test]
+    fn default_temp_roots_include_the_process_temp_dir() {
+        let roots = default_temp_roots();
+        assert!(roots.contains(&std::env::temp_dir()));
+        let ignore = UntracedFixupIgnore::new(roots, Vec::new());
+        let temp = tempfile::tempdir().unwrap();
+        let repo = temp.path().join("repo").join(".git");
+        fs::create_dir_all(&repo).unwrap();
+        assert!(ignore.ignores(&canonical(&repo)));
+    }
+}

--- a/src/feature_flags.rs
+++ b/src/feature_flags.rs
@@ -88,6 +88,7 @@ define_feature_flags!(
     rewrite_metrics_events: rewrite_metrics_events, debug = true, release = false,
     token_usage_metrics: token_usage_metrics, debug = true, release = false,
     untraced_commit_fixup: untraced_commit_fixup, debug = true, release = true,
+    untraced_fixup_ignore_temp_repos: untraced_fixup_ignore_temp_repos, debug = true, release = true,
 );
 
 impl FeatureFlags {
@@ -147,6 +148,7 @@ mod tests {
             assert!(flags.rewrite_metrics_events);
             assert!(flags.token_usage_metrics);
             assert!(flags.untraced_commit_fixup);
+            assert!(flags.untraced_fixup_ignore_temp_repos);
         }
         #[cfg(not(debug_assertions))]
         {
@@ -160,6 +162,7 @@ mod tests {
             assert!(!flags.rewrite_metrics_events);
             assert!(!flags.token_usage_metrics);
             assert!(flags.untraced_commit_fixup);
+            assert!(flags.untraced_fixup_ignore_temp_repos);
         }
     }
 
@@ -283,6 +286,7 @@ mod tests {
             rewrite_metrics_events: true,
             token_usage_metrics: true,
             untraced_commit_fixup: true,
+            untraced_fixup_ignore_temp_repos: true,
         };
 
         let serialized = serde_json::to_string(&flags).unwrap();
@@ -296,6 +300,7 @@ mod tests {
         assert!(serialized.contains("rewrite_metrics_events"));
         assert!(serialized.contains("token_usage_metrics"));
         assert!(serialized.contains("untraced_commit_fixup"));
+        assert!(serialized.contains("untraced_fixup_ignore_temp_repos"));
     }
 
     #[test]
@@ -311,6 +316,7 @@ mod tests {
             rewrite_metrics_events: true,
             token_usage_metrics: true,
             untraced_commit_fixup: false,
+            untraced_fixup_ignore_temp_repos: true,
         };
         let cloned = flags.clone();
         assert_eq!(cloned.lite_mode, flags.lite_mode);
@@ -323,6 +329,10 @@ mod tests {
         assert_eq!(cloned.rewrite_metrics_events, flags.rewrite_metrics_events);
         assert_eq!(cloned.token_usage_metrics, flags.token_usage_metrics);
         assert_eq!(cloned.untraced_commit_fixup, flags.untraced_commit_fixup);
+        assert_eq!(
+            cloned.untraced_fixup_ignore_temp_repos,
+            flags.untraced_fixup_ignore_temp_repos
+        );
     }
 
     #[test]

--- a/tests/integration/config_cli_coverage.rs
+++ b/tests/integration/config_cli_coverage.rs
@@ -436,6 +436,7 @@ fn fully_populated_file_config() -> FileConfig {
         include_prompts_in_repositories: Some(vec!["*".to_string()]),
         allow_repositories: Some(vec!["*".to_string()]),
         exclude_repositories: Some(vec!["*".to_string()]),
+        untraced_fixup_ignored_paths: Some(vec!["*-scratch/.git".to_string()]),
         telemetry_oss: Some("off".to_string()),
         telemetry_enterprise_dsn: Some("https://example.com".to_string()),
         disable_version_checks: Some(true),

--- a/tests/integration/performance.rs
+++ b/tests/integration/performance.rs
@@ -25,6 +25,7 @@ fn setup() {
         rewrite_metrics_events: false,
         token_usage_metrics: false,
         untraced_commit_fixup: false,
+        untraced_fixup_ignore_temp_repos: false,
     };
 
     git_ai::config::Config::set_test_feature_flags(test_flags.clone());

--- a/tests/integration/repos/test_repo.rs
+++ b/tests/integration/repos/test_repo.rs
@@ -233,6 +233,9 @@ impl DaemonProcess {
                     std::env::var("GIT_AI_TEST_UNTRACED_FIXUP_INTERVAL_MS")
                         .unwrap_or_else(|_| "3600000".to_string()),
                 )
+                // Every TestRepo lives under the OS temp dir, which the fixup
+                // ignores by default; tests that cover that rule opt back in.
+                .env("GIT_AI_UNTRACED_FIXUP_IGNORE_TEMP_REPOS", "false")
                 .stdout(Stdio::null())
                 .stderr(
                     stderr_log

--- a/tests/integration/untraced_commit_fixup.rs
+++ b/tests/integration/untraced_commit_fixup.rs
@@ -10,6 +10,7 @@ use crate::test_utils::{
     isolated_metrics_db_path,
 };
 use git_ai::authorship::authorship_log_serialization::AuthorshipLog;
+use git_ai::daemon::repo_family_store::RepoFamilyStore;
 use git_ai::metrics::events::committed_pos;
 use serde_json::Value;
 use std::fs;
@@ -667,4 +668,145 @@ fn feature_flag_disables_the_periodic_scan_but_not_explicit_requests() {
         "base".unattributed_human(),
         "untraced".unattributed_human()
     ]);
+}
+
+/// A scratch repository next to `repo` with one raw commit: the kind of
+/// repository an agent creates for its own work.
+fn scratch_sibling(repo: &TestRepo, suffix: &str) -> PathBuf {
+    let path = sibling_repo(repo, suffix);
+    fs::write(path.join("scratch.txt"), "scratch\n").unwrap();
+    raw_commit_all_in(&path, "scratch");
+    path
+}
+
+fn store_families(repo: &TestRepo) -> Vec<String> {
+    RepoFamilyStore::open(
+        &repo
+            .daemon_home_path()
+            .join(".git-ai")
+            .join("internal")
+            .join("repo-families-db"),
+    )
+    .expect("test daemon's repo-families store opens")
+    .known_families(true)
+    .expect("families load")
+}
+
+#[test]
+fn temp_repositories_are_ignored_by_the_fixup_but_not_by_the_traced_path() {
+    // The test repo itself lives under the OS temp dir: with the rule on it is
+    // exactly the kind of repository the fixup must leave alone.
+    let (_metrics_dir, metrics_db_path) = isolated_metrics_db_path();
+    let mut env = fixup_daemon_env(&metrics_db_path);
+    env.push(("GIT_AI_UNTRACED_FIXUP_IGNORE_TEMP_REPOS", "true"));
+    let repo = TestRepo::new_with_daemon_env(&env);
+    write_file(&repo, "agent.txt", "base\n");
+    repo.stage_all_and_commit("traced base")
+        .expect("traced base commit");
+    codex_edit(&repo, "agent.txt", "base\nai line\n", "tool-use-1");
+    let traced = repo
+        .stage_all_and_commit("traced agent commit")
+        .expect("traced agent commit")
+        .commit_sha;
+    // Traced work is untouched by the rule.
+    let mut file = repo.filename("agent.txt");
+    file.assert_committed_lines(lines!["base".unattributed_human(), "ai line".ai()]);
+    assert_eq!(commit_source(&metrics_db_path, &traced), None);
+
+    write_file(&repo, "agent.txt", "base\nai line\nuntraced\n");
+    let untraced = raw_commit_all(&repo, "untraced in a temp repo");
+    let scheduled = repo.request_untraced_fixup_scan();
+
+    assert_eq!(scheduled.get("ignored").and_then(Value::as_u64), Some(1));
+    assert_eq!(scheduled.get("worktrees").and_then(Value::as_u64), Some(0));
+    assert!(repo.read_authorship_note(&untraced).is_none());
+    assert_eq!(health_counter(&repo, "untraced_commits_fixed"), 0);
+    assert!(store_families(&repo).is_empty(), "nothing is remembered");
+}
+
+#[test]
+fn configured_globs_ignore_a_scratch_sibling_while_the_repo_is_still_fixed_up() {
+    let (_metrics_dir, metrics_db_path) = isolated_metrics_db_path();
+    let patch = serde_json::json!({
+        "untraced_fixup_ignored_paths": ["*-agent-scratch/.git"]
+    })
+    .to_string();
+    let mut env = fixup_daemon_env(&metrics_db_path);
+    env.push(("GIT_AI_TEST_CONFIG_PATCH", patch.as_str()));
+    let repo = TestRepo::new_with_daemon_env(&env);
+    write_file(&repo, "plain.txt", "base\n");
+    repo.stage_all_and_commit("traced base")
+        .expect("traced base commit");
+    repo.request_untraced_fixup_scan();
+    let scratch = scratch_sibling(&repo, "agent-scratch");
+
+    let scratch_scan = repo.request_untraced_fixup_scan_for(&scratch);
+    assert_eq!(scratch_scan.get("ignored").and_then(Value::as_u64), Some(1));
+
+    write_file(&repo, "plain.txt", "base\nuntraced\n");
+    let untraced = raw_commit_all(&repo, "untraced in the real repo");
+    repo.request_untraced_fixup_scan();
+    assert!(repo.read_authorship_note(&untraced).is_some());
+    let mut file = repo.filename("plain.txt");
+    file.assert_committed_lines(lines![
+        "base".unattributed_human(),
+        "untraced".unattributed_human()
+    ]);
+    let families = store_families(&repo);
+    assert_eq!(families.len(), 1, "{families:?}");
+    assert!(!families[0].contains("agent-scratch"));
+    let _ = fs::remove_dir_all(&scratch);
+}
+
+#[test]
+fn remembered_temp_repositories_are_purged_once_the_rule_is_on() {
+    let (_metrics_dir, metrics_db_path, mut repo) = fixup_repo();
+    write_file(&repo, "plain.txt", "base\n");
+    repo.stage_all_and_commit("traced base")
+        .expect("traced base commit");
+    // Rule off (the harness default): the repo is remembered like any other.
+    repo.request_untraced_fixup_scan();
+    assert_eq!(store_families(&repo).len(), 1);
+
+    repo.shutdown_dedicated_daemon_for_test();
+    let mut env = fixup_daemon_env(&metrics_db_path);
+    env.push(("GIT_AI_UNTRACED_FIXUP_IGNORE_TEMP_REPOS", "true"));
+    repo.start_dedicated_daemon_with_env_for_test(&env);
+
+    // The first tick is a maintenance round and forgets the row; an explicit
+    // scan afterwards schedules nothing for it.
+    let deadline = Instant::now() + Duration::from_secs(20);
+    while Instant::now() < deadline && !store_families(&repo).is_empty() {
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    assert!(
+        store_families(&repo).is_empty(),
+        "{:?}",
+        store_families(&repo)
+    );
+    let scheduled = repo.request_untraced_fixup_scan_all();
+    assert_eq!(scheduled.get("worktrees").and_then(Value::as_u64), Some(0));
+    assert_eq!(health_counter(&repo, "known_repo_families"), 0);
+}
+
+#[test]
+fn the_periodic_scan_never_touches_an_ignored_temp_repository() {
+    let (_metrics_dir, metrics_db_path) = isolated_metrics_db_path();
+    let mut env = fixup_daemon_env(&metrics_db_path);
+    env.push(("GIT_AI_DAEMON_UNTRACED_FIXUP_INTERVAL_MS", "200"));
+    env.push(("GIT_AI_UNTRACED_FIXUP_IGNORE_TEMP_REPOS", "true"));
+    let repo = TestRepo::new_with_daemon_env(&env);
+    write_file(&repo, "plain.txt", "base\n");
+    repo.stage_all_and_commit("traced base")
+        .expect("traced base commit");
+    write_file(&repo, "plain.txt", "base\nuntraced\n");
+    let untraced = raw_commit_all(&repo, "untraced in a temp repo");
+
+    assert!(
+        !wait_for_note(&repo, &untraced, Duration::from_secs(3)),
+        "the timer must not fix up a temp repository"
+    );
+    assert_eq!(health_counter(&repo, "untraced_commits_fixed"), 0);
+    assert_eq!(health_counter(&repo, "known_repo_families"), 0);
+    assert!(store_families(&repo).is_empty());
 }


### PR DESCRIPTION
## Summary

AI agents (Codex, Claude Code, …) create scratch repositories under the OS temp directory for their own work. The untraced-commit fixup treated them like any other family: it remembered them in the repo-family store, stat'd their reflogs every tick, kept "missing" rows for a week after they vanished and let them compete with real repositories for the store's recency cap. On a dogfooding machine 307 of 310 remembered families were under `/tmp`.

- New `src/daemon/untraced_fixup_ignore.rs`: a family whose canonical common dir is under a temp root (`$TMPDIR`/`TEMP`/`TMP`, `/tmp`, `/var/tmp`, macOS `/var/folders`, Windows `%TEMP%`) or matches an `untraced_fixup_ignored_paths` config glob is ignored by the fixup. Roots are canonicalized once at startup; the check is a component-wise prefix compare per root plus a glob match per pattern, with no filesystem access.
- Scoped on purpose, and named accordingly: only the fixup scheduler and its store consult this. Traced commands and checkpoints in such repositories keep their normal behaviour. This is not a global repository exclusion.
- Enforcement: ignored families are dropped at the top of the scheduler's per-family loop, before the stat and before any store write; `fixup.scan` for such a repository schedules nothing and reports `ignored`; remembered families are filtered; the maintenance round forgets existing rows for them (`RepoFamilyStore::forget_families`), so a machine upgrading to this purges its scratch rows within the first tick.
- Config: `untraced_fixup_ignored_paths` (array of globs) through `git-ai config get/set/--add/unset`; feature flag `untraced_fixup_ignore_temp_repos` (on by default) gates the temp-root part. The test harness turns the flag off because every `TestRepo` lives under the temp dir; the tests covering the rule opt back in.

## Cost

Strictly a reduction. Nothing changes on trace ingestion, the normalizer, actor creation, checkpoint admission or side effects. Startup canonicalizes at most six roots once. For each family a tick already examines it adds at most six byte-prefix comparisons and the configured glob matches; for an ignored family everything after that point (stat, worktree enumeration, per-worktree stats, store writes, scan passes) disappears. The purge is one transaction per hourly maintenance round.

Isolated daemon, other workers disabled, 200 scratch families under `/tmp` (150 deleted after registration), 60 s idle: see the perf numbers in the checklist below.

## Test plan

- [x] unit: temp roots canonicalized/de-duplicated/pruned; prefix match by component (`/tmpfoo` is not under `/tmp`); globs on the POSIX path; flag off keeps globs only; process temp dir included
- [x] config: parse + invalid glob dropped; `FileConfig` round trip; CLI get/set/unset coverage tests
- [x] store: `forget_families` removes families and cursors only
- [x] integration: temp repo ignored by `fixup.scan` (`ignored = 1`, no note, nothing remembered) while its traced commits are attributed normally; configured glob ignores a scratch sibling while the real repo is fixed up; remembered temp rows purged after restart with the rule on; periodic scan never touches an ignored repo
- [x] `task lint`, `task fmt`, full `task test`
