### PR TITLE
feat(daemon): bg start --retry-secs for login-time lock races

### DIFF
--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -69,11 +69,39 @@ pub fn handle_daemon(args: &[String]) {
     }
 }
 
+/// Pause between `bg start --retry-secs` attempts.
+const START_RETRY_INTERVAL: Duration = Duration::from_secs(2);
+
 fn handle_start(args: &[String]) -> Result<(), String> {
     if has_flag(args, "--mode") {
         return Err("--mode is no longer supported; daemon always runs in write mode".to_string());
     }
-    ensure_daemon_running_attached(daemon_startup_timeout()).map(|_| ())
+    let retry_window = start_retry_window(args)?;
+    let deadline = Instant::now() + retry_window;
+    loop {
+        match ensure_daemon_running_attached(daemon_startup_timeout()) {
+            Ok(_) => return Ok(()),
+            // A daemon that is still releasing its lock (logout/login,
+            // self-update) blocks the first attempt; login launchers pass a
+            // retry window so that race does not leave the daemon down.
+            Err(err) if Instant::now() + START_RETRY_INTERVAL < deadline => {
+                eprintln!("Daemon not started yet ({}); retrying", err);
+                thread::sleep(START_RETRY_INTERVAL);
+            }
+            Err(err) => return Err(err),
+        }
+    }
+}
+
+/// `--retry-secs <n>`: keep retrying failed starts for up to `n` seconds.
+/// Absent flag means a single attempt.
+fn start_retry_window(args: &[String]) -> Result<Duration, String> {
+    if !has_flag(args, "--retry-secs") {
+        return Ok(Duration::ZERO);
+    }
+    parse_number_arg(args, "--retry-secs")
+        .map(|secs| Duration::from_secs(secs as u64))
+        .ok_or_else(|| "--retry-secs requires a whole number of seconds".to_string())
 }
 
 fn daemon_startup_timeout() -> Duration {
@@ -819,7 +847,7 @@ fn print_help() {
     eprintln!("git-ai bg - run and control git-ai background service");
     eprintln!();
     eprintln!("Usage:");
-    eprintln!("  git-ai bg start");
+    eprintln!("  git-ai bg start [--retry-secs <n>]");
     eprintln!("  git-ai bg run");
     eprintln!("  git-ai bg status [--repo <path>]");
     eprintln!("  git-ai bg shutdown [--hard]");

--- a/src/commands/daemon.rs
+++ b/src/commands/daemon.rs
@@ -77,7 +77,9 @@ fn handle_start(args: &[String]) -> Result<(), String> {
         return Err("--mode is no longer supported; daemon always runs in write mode".to_string());
     }
     let retry_window = start_retry_window(args)?;
-    let deadline = Instant::now() + retry_window;
+    let deadline = Instant::now()
+        .checked_add(retry_window)
+        .ok_or_else(|| "--retry-secs is too large".to_string())?;
     loop {
         match ensure_daemon_running_attached(daemon_startup_timeout()) {
             Ok(_) => return Ok(()),

--- a/tests/async_mode.rs
+++ b/tests/async_mode.rs
@@ -8,6 +8,7 @@ use git_ai::daemon::{
     local_socket_connects_with_timeout, open_local_socket_stream_with_timeout,
     send_control_request,
 };
+use git_ai::utils::LockFile;
 #[cfg(not(windows))]
 use interprocess::local_socket::traits::Stream;
 use repos::test_repo::{DaemonTestScope, TestRepo, get_binary_path, real_git_executable};
@@ -18,7 +19,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::process::{Child, Command, Output, Stdio};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 const DAEMON_TEST_PROBE_TIMEOUT: Duration = Duration::from_millis(100);
 
@@ -673,4 +674,73 @@ fn daemon_reaps_idle_control_connection_after_valid_request() {
     wait_for_control_connection_close(&mut reader, Duration::from_secs(15));
 
     shutdown_daemon(&repo);
+}
+
+/// `bg shutdown` returns before the old daemon releases its lock, so a login
+/// start racing that window sees "lock held". `--retry-secs` keeps trying
+/// within a bounded window instead of giving up on the first attempt.
+#[test]
+fn daemon_start_retries_while_lock_is_held() {
+    let repo = TestRepo::new_with_daemon_scope(DaemonTestScope::NoDaemon);
+    write_daemon_config(&repo);
+    let lock_path = DaemonConfig::from_home(&repo.daemon_home_path()).lock_path;
+    fs::create_dir_all(lock_path.parent().unwrap()).unwrap();
+    let held_lock = LockFile::try_acquire(&lock_path).expect("test should hold the daemon lock");
+
+    let output = daemon_command_output(&repo, &["bg", "start"], repo.test_home_path());
+    assert!(
+        !output.status.success(),
+        "bg start without --retry-secs should fail while the lock is held"
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("lock held"),
+        "stderr should explain the held lock: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let releaser = thread::spawn(move || {
+        thread::sleep(Duration::from_secs(1));
+        drop(held_lock);
+    });
+    let started = Instant::now();
+    let output = daemon_command_output(
+        &repo,
+        &["bg", "start", "--retry-secs", "20"],
+        repo.test_home_path(),
+    );
+    releaser.join().unwrap();
+    assert!(
+        output.status.success(),
+        "bg start --retry-secs should succeed once the lock is released: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        started.elapsed() < Duration::from_secs(20),
+        "bg start should return as soon as the daemon is up, not after the whole retry window"
+    );
+
+    wait_for_daemon_sockets(&repo);
+    shutdown_daemon(&repo);
+}
+
+#[test]
+fn daemon_start_rejects_invalid_retry_window() {
+    let repo = TestRepo::new_with_daemon_scope(DaemonTestScope::NoDaemon);
+    write_daemon_config(&repo);
+
+    let output = daemon_command_output(
+        &repo,
+        &["bg", "start", "--retry-secs", "soon"],
+        repo.test_home_path(),
+    );
+    assert!(
+        !output.status.success(),
+        "a non-numeric --retry-secs must be rejected"
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("--retry-secs"),
+        "stderr should name the bad flag: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
 }

--- a/tests/async_mode.rs
+++ b/tests/async_mode.rs
@@ -743,4 +743,19 @@ fn daemon_start_rejects_invalid_retry_window() {
         "stderr should name the bad flag: {}",
         String::from_utf8_lossy(&output.stderr)
     );
+
+    let output = daemon_command_output(
+        &repo,
+        &["bg", "start", "--retry-secs", &u64::MAX.to_string()],
+        repo.test_home_path(),
+    );
+    assert!(
+        !output.status.success(),
+        "an overflowing --retry-secs must be rejected, not panic"
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("--retry-secs is too large"),
+        "stderr should explain the rejected window: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
 }


### PR DESCRIPTION
bg shutdown returns before the old daemon process releases daemon.lock, so a
login start that fires in that window (fast logout/login, self-update) fails
with 'lock held' and nothing retries until the next checkpoint. The MDM login
launchers currently wrap bg start in a shell retry loop, which makes macOS
report the login item as "sh". Give bg start a bounded retry window instead
so the launchers can run the binary directly.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>