### PR TITLE
fix(mdm): run git-ai directly from the launchers using bg start --retry-secs

### DIFF
--- a/.github/workflows/mdm-login-start-nightly.yml
+++ b/.github/workflows/mdm-login-start-nightly.yml
@@ -53,11 +53,23 @@ jobs:
           if len(versions) < 2:
               raise SystemExit("Need at least two semver releases")
 
-          ordered = sorted(versions)
-          latest = versions[ordered[-1]]
+          # The daemon updates to whatever the `latest` channel serves, which can
+          # lag the newest GitHub release while a release is being promoted.
+          channel_url = "https://usegitai.com/worker/releases"
+          with urllib.request.urlopen(urllib.request.Request(channel_url, headers=headers)) as response:
+              channel_version = json.load(response)["channels"]["latest"]["version"]
+          channel = pattern.match(channel_version)
+          if not channel:
+              raise SystemExit(f"unexpected channel version {channel_version!r}")
+          latest_tuple = tuple(int(p) for p in channel.groups())
+          latest = "v" + ".".join(channel.groups())
+
           # Recent releases only: the daemon-driven self-update path must exist
           # in the starting version.
-          older = versions[random.choice(ordered[-6:-1])]
+          candidates = [v for v in sorted(versions) if v < latest_tuple][-5:]
+          if not candidates:
+              raise SystemExit(f"no release older than {latest}")
+          older = versions[random.choice(candidates)]
           with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
               output.write(f"latest={latest}\nolder={older}\n")
           print(f"latest={latest} older={older}")

--- a/mdm/README.md
+++ b/mdm/README.md
@@ -18,9 +18,10 @@ user (that step writes the per-user trace2 config the daemon depends on).
 
 ## Why the scripts only start the daemon
 
-Every script registers the idempotent `git-ai bg start` and nothing else (the
-launchers retry it a few times, two seconds apart, in case a previous daemon is
-still releasing its lock at login). The daemon supervises itself:
+Every script registers the idempotent `git-ai bg start --retry-secs 10` and
+nothing else. The retry window covers a previous daemon that is still
+releasing its lock at login (fast logout/login, self-update in progress); the
+daemon itself supervises everything after that:
 
 - It exits 0 immediately if a daemon is already up, and refuses to start a
   second instance while the daemon **lock** is held.
@@ -35,8 +36,15 @@ invariants:
 
 - **macOS**: `AbandonProcessGroup` is `true` (launchd otherwise kills the
   daemon when `bg start` exits), `KeepAlive` is `false`, `RunAtLoad` is `true`.
+  The agent runs the `git-ai` binary directly, so Login Items & Extensions and
+  the "can run in the background" notice name `git-ai`, not `sh`. The one
+  exception is `--system` without `--bin`, which needs `/bin/sh` to resolve
+  each user's home; pass `--bin` with a shared path to avoid it.
 - **Linux**: `Type=oneshot` with `RemainAfterExit=yes` keeps the unit and its
-  cgroup (where the daemon lives) active until logout; no `Restart=`.
+  cgroup (where the daemon lives) active until logout; no `Restart=`. The unit
+  goes through a one-line `sh -c exec` because systemd rejects executable
+  paths containing quotes or parentheses; `systemctl status` shows the unit's
+  description, so this has no user-visible cost.
 - **Windows**: `-MultipleInstances IgnoreNew` so a second logon trigger cannot
   race the daemon, and the execution time limit is disabled so Task Scheduler
   never ends the instance.
@@ -53,9 +61,9 @@ install-login-start --uninstall
 - `--env KEY=VALUE` (repeatable) is written into the launch definition and
   reaches the daemon, e.g. `HTTPS_PROXY`, `GIT_AI_API_BASE_URL`.
 - `--bin PATH` points at a non-default `git-ai` binary. Any path without a
-  newline or carriage return works: on macOS and Linux it reaches the launcher
-  through the `GIT_AI_LOGIN_START_BIN` environment variable, on Windows it is
-  quoted into the launcher file.
+  newline or carriage return works: macOS and Windows quote it into the plist
+  or launcher file, Linux passes it through the `GIT_AI_LOGIN_START_BIN`
+  environment variable.
 - `--no-start` registers without starting now; the daemon starts at next login.
 - `--uninstall` removes the registration. On macOS and Windows the running
   daemon is left alone; on Linux stopping the unit stops its cgroup and thus

--- a/mdm/linux/install-login-start.sh
+++ b/mdm/linux/install-login-start.sh
@@ -8,13 +8,14 @@
 set -eu
 
 UNIT="git-ai-bg.service"
-# The launcher resolves the binary at run time from GIT_AI_LOGIN_START_BIN (set
-# by --bin) or the default install location, and retries briefly so a daemon
-# that is still releasing its lock (logout/login, self-update) does not make
-# the login start give up. Paths never touch the shell command line.
+# systemd refuses executable paths with quotes or parentheses in ExecStart, so
+# a one-line sh wrapper resolves the binary from GIT_AI_LOGIN_START_BIN (set by
+# --bin) or the default install location. `bg start` keeps retrying for
+# RETRY_SECS if a previous daemon is still releasing its lock at login.
+RETRY_SECS=10
 LAUNCH_BIN='"${GIT_AI_LOGIN_START_BIN:-$HOME/.git-ai/bin/git-ai}"'
-LAUNCH_START="n=0; until $LAUNCH_BIN bg start; do [ \$((n+=1)) -lt 5 ] || exit 1; sleep 2; done"
-LAUNCH_STOP="$LAUNCH_BIN bg shutdown"
+LAUNCH_START="exec $LAUNCH_BIN bg start --retry-secs $RETRY_SECS"
+LAUNCH_STOP="exec $LAUNCH_BIN bg shutdown"
 
 MODE="install"
 SYSTEM=0

--- a/mdm/macos/install-login-start.sh
+++ b/mdm/macos/install-login-start.sh
@@ -13,12 +13,9 @@ set -eu
 
 LABEL="com.usegitai.bg"
 DEFAULT_PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
-# The launcher resolves the binary at run time from GIT_AI_LOGIN_START_BIN (set
-# by --bin) or the default install location, and retries briefly so a daemon
-# that is still releasing its lock (logout/login, self-update) does not make
-# the login start give up. Paths never touch the shell command line.
-LOG_DIR='$HOME/.git-ai/internal/daemon/logs'
-COMMAND="mkdir -p \"$LOG_DIR\" && { n=0; until \"\${GIT_AI_LOGIN_START_BIN:-\$HOME/.git-ai/bin/git-ai}\" bg start; do [ \$((n+=1)) -lt 5 ] || exit 1; sleep 2; done; } >>\"$LOG_DIR/login-start.log\" 2>&1"
+# `bg start` keeps retrying for this long if a previous daemon is still
+# releasing its lock at login (fast logout/login, self-update in progress).
+RETRY_SECS=10
 
 MODE="install"
 SYSTEM=0
@@ -56,6 +53,11 @@ add_env() {
 
 xml_escape() {
   printf '%s' "$1" | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' -e 's/"/\&quot;/g'
+}
+
+# One indented plist <string> element.
+xml_string() {
+  printf '        <string>%s</string>\n' "$(xml_escape "$1")"
 }
 
 while [ $# -gt 0 ]; do
@@ -113,9 +115,35 @@ if [ -n "$BIN" ]; then
     *"
 "*|*"$(printf '\r')"*) fail "--bin path must not contain a newline or carriage return" ;;
   esac
-  add_env "GIT_AI_LOGIN_START_BIN=$BIN"
-elif [ "$SYSTEM" -eq 0 ] && [ ! -x "$HOME/.git-ai/bin/git-ai" ]; then
-  fail "$HOME/.git-ai/bin/git-ai not found; install git-ai first or pass --bin"
+elif [ "$SYSTEM" -eq 0 ]; then
+  BIN="$HOME/.git-ai/bin/git-ai"
+  [ -x "$BIN" ] || fail "$BIN not found; install git-ai first or pass --bin"
+fi
+
+# Run the binary directly so macOS names the login item "git-ai". Only an
+# all-users agent without --bin needs a shell to resolve each user's home.
+if [ -n "$BIN" ]; then
+  PROGRAM_XML="$(xml_string "$BIN")
+$(xml_string bg)
+$(xml_string start)
+$(xml_string --retry-secs)
+$(xml_string "$RETRY_SECS")"
+else
+  PROGRAM_XML="$(xml_string /bin/sh)
+$(xml_string -c)
+$(xml_string "exec \"\$HOME/.git-ai/bin/git-ai\" bg start --retry-secs $RETRY_SECS")"
+fi
+
+# Per-user agents log `bg start` output; all-users agents have no fixed path.
+LOG_XML=""
+if [ "$SYSTEM" -eq 0 ]; then
+  LOG_DIR="$HOME/.git-ai/internal/daemon/logs"
+  mkdir -p "$LOG_DIR"
+  LOG_FILE_XML="$(xml_string "$LOG_DIR/login-start.log" | sed 's/^    //')"
+  LOG_XML="    <key>StandardOutPath</key>
+$LOG_FILE_XML
+    <key>StandardErrorPath</key>
+$LOG_FILE_XML"
 fi
 
 if [ "$HAS_PATH" -eq 0 ]; then
@@ -131,7 +159,7 @@ for pair in $ENV_VARS; do
   key="${pair%%=*}"
   value="${pair#*=}"
   ENV_XML="${ENV_XML}        <key>$(xml_escape "$key")</key>
-        <string>$(xml_escape "$value")</string>
+$(xml_string "$value")
 "
 done
 IFS="$OLD_IFS"
@@ -146,9 +174,7 @@ cat >"$PLIST" <<EOF
     <string>$LABEL</string>
     <key>ProgramArguments</key>
     <array>
-        <string>/bin/sh</string>
-        <string>-c</string>
-        <string>$(xml_escape "$COMMAND")</string>
+$PROGRAM_XML
     </array>
     <key>RunAtLoad</key>
     <true/>
@@ -158,6 +184,7 @@ cat >"$PLIST" <<EOF
     <true/>
     <key>ProcessType</key>
     <string>Background</string>
+$LOG_XML
     <key>EnvironmentVariables</key>
     <dict>
 ${ENV_XML}    </dict>

--- a/mdm/windows/install-login-start.ps1
+++ b/mdm/windows/install-login-start.ps1
@@ -102,13 +102,9 @@ foreach ($pair in $EnvPairs) {
     $key, $value = $pair.Split('=', 2)
     $launcherLines += "`$env:$key = $(ConvertTo-Literal $value)"
 }
-# Retry briefly so a daemon still releasing its lock (logoff/logon, self-update)
-# does not make the logon start give up.
-$launcherLines += 'for ($attempt = 1; $attempt -le 5; $attempt++) {'
-$launcherLines += "    & $(ConvertTo-Literal $Bin) bg start"
-$launcherLines += '    if ($LASTEXITCODE -eq 0) { break }'
-$launcherLines += '    Start-Sleep -Seconds 2'
-$launcherLines += '}'
+# --retry-secs rides out a daemon that is still releasing its lock at logon
+# (fast logoff/logon, self-update in progress).
+$launcherLines += "& $(ConvertTo-Literal $Bin) bg start --retry-secs 10"
 $launcherLines += 'exit $LASTEXITCODE'
 
 New-Item -ItemType Directory -Path $LauncherDir -Force | Out-Null

--- a/scripts/mdm/test-login-start.ps1
+++ b/scripts/mdm/test-login-start.ps1
@@ -214,9 +214,9 @@ function Invoke-UnusualBinaryPathScenario {
     Stop-Daemon
 }
 
-# Writes a fake git-ai.cmd that fails until its Nth invocation, then hands off
-# to the real binary. Attempts are counted in a file next to it.
-function Write-FakeBinary([string]$Path, [int]$SucceedAt) {
+# Writes a fake git-ai.cmd that always fails and counts its invocations in a
+# file next to it.
+function Write-FailingBinary([string]$Path) {
     $lines = @(
         '@echo off',
         'setlocal',
@@ -224,9 +224,7 @@ function Write-FakeBinary([string]$Path, [int]$SucceedAt) {
         'if exist "%~dp0attempts" set /p n=<"%~dp0attempts"',
         'set /a n+=1',
         '>"%~dp0attempts" echo %n%',
-        "if %n% lss $SucceedAt exit /b 1",
-        "`"$Bin`" %*",
-        'exit /b %errorlevel%'
+        'exit /b 1'
     )
     Set-Content -LiteralPath $Path -Value ($lines -join "`r`n") -Encoding ASCII
 }
@@ -237,31 +235,44 @@ function Get-Attempts([string]$Dir) {
     return 0
 }
 
-# The launcher retries bg start a few times: transient failures must end in a
-# healthy daemon, and persistent failure must surface as a failed logon task.
-function Invoke-LauncherRetryScenario {
-    $fakeDir = Join-Path $HOME 'mdm-fake'
-    New-Item -ItemType Directory -Path $fakeDir -Force | Out-Null
-    $fake = Join-Path $fakeDir 'git-ai.cmd'
+# Holds the daemon lock (exclusive open, like the daemon) for a few seconds in
+# the background, the state a logon start sees while a previous daemon is still
+# shutting down.
+function Hold-DaemonLock([int]$Seconds) {
+    New-Item -ItemType Directory -Path $DaemonDir -Force | Out-Null
+    $lockPath = Join-Path $DaemonDir 'daemon.lock'
+    return Start-Job -ScriptBlock {
+        param($Path, $Secs)
+        $stream = [IO.File]::Open($Path, 'OpenOrCreate', 'ReadWrite', 'None')
+        Start-Sleep -Seconds $Secs
+        $stream.Dispose()
+    } -ArgumentList $lockPath, $Seconds
+}
 
-    Write-FakeBinary $fake 3
-    Invoke-MdmScript --bin $fake
-    Wait-For 60 'daemon up after transient launcher failures' { Test-DaemonUp }
-    $attempts = Get-Attempts $fakeDir
-    if ($attempts -ne 3) { Fail "expected 3 attempts, got $attempts" }
+# `bg start --retry-secs` must ride out a lock held at logon, and a binary that
+# keeps failing must surface as a failed logon task.
+function Invoke-LauncherRetryScenario {
+    $holder = Hold-DaemonLock 4
+    Start-Sleep -Seconds 1
+    Invoke-MdmScript
+    Wait-For 60 'daemon up despite a lock held at logon' { Test-DaemonUp }
+    Receive-Job $holder -Wait | Out-Null
     Test-MechanismSane
     Invoke-MdmScript --uninstall
     Stop-Daemon
 
+    $fakeDir = Join-Path $HOME 'mdm-fake'
+    New-Item -ItemType Directory -Path $fakeDir -Force | Out-Null
     Remove-Item (Join-Path $fakeDir 'attempts') -Force -ErrorAction SilentlyContinue
-    Write-FakeBinary $fake 99
+    $fake = Join-Path $fakeDir 'git-ai.cmd'
+    Write-FailingBinary $fake
     Invoke-MdmScript --bin $fake --no-start
     Start-ScheduledTask -TaskPath $TaskPath -TaskName $TaskName
     Wait-TaskIdle
     $info = Get-ScheduledTaskInfo -TaskPath $TaskPath -TaskName $TaskName
     if ($info.LastTaskResult -eq 0) { Fail 'persistent launcher failure was reported as success' }
     $attempts = Get-Attempts $fakeDir
-    if ($attempts -ne 5) { Fail "expected 5 attempts, got $attempts" }
+    if ($attempts -ne 1) { Fail "launcher should invoke the binary once, got $attempts" }
     if (Test-DaemonUp) { Fail 'no daemon should be running after persistent failure' }
     Invoke-MdmScript --uninstall
     Write-Log 'launcher retry semantics verified'

--- a/scripts/mdm/test-login-start.ps1
+++ b/scripts/mdm/test-login-start.ps1
@@ -251,15 +251,24 @@ function Hold-DaemonLock([int]$Seconds) {
 
 # `bg start --retry-secs` must ride out a lock held at logon, and a binary that
 # keeps failing must surface as a failed logon task.
+function Test-SupportsRetry {
+    return [bool]((& $Bin bg --help 2>&1 | Out-String) -match '--retry-secs')
+}
+
 function Invoke-LauncherRetryScenario {
-    $holder = Hold-DaemonLock 4
-    Start-Sleep -Seconds 1
-    Invoke-MdmScript
-    Wait-For 60 'daemon up despite a lock held at logon' { Test-DaemonUp }
-    Receive-Job $holder -Wait | Out-Null
-    Test-MechanismSane
-    Invoke-MdmScript --uninstall
-    Stop-Daemon
+    if (Test-SupportsRetry) {
+        $holder = Hold-DaemonLock 4
+        Start-Sleep -Seconds 1
+        Invoke-MdmScript
+        Wait-For 60 'daemon up despite a lock held at logon' { Test-DaemonUp }
+        Receive-Job $holder -Wait | Out-Null
+        Test-MechanismSane
+        Invoke-MdmScript --uninstall
+        Stop-Daemon
+    } else {
+        # Published releases without --retry-secs cannot ride out the lock race.
+        Write-Log "SKIP held-lock phase: $(Get-InstalledVersion) predates bg start --retry-secs"
+    }
 
     $fakeDir = Join-Path $HOME 'mdm-fake'
     New-Item -ItemType Directory -Path $fakeDir -Force | Out-Null

--- a/scripts/mdm/test-login-start.sh
+++ b/scripts/mdm/test-login-start.sh
@@ -258,17 +258,27 @@ scenario_unusual_binary_path() {
   stop_daemon
 }
 
-# Writes a fake git-ai that fails until its Nth invocation, then hands off to
-# the real binary. Attempts are counted in $2.
-write_fake_binary() {
-  local path="$1" attempts="$2" succeed_at="$3"
+# Writes a fake git-ai that always fails and counts its invocations in $2.
+write_failing_binary() {
+  local path="$1" attempts="$2"
   cat >"$path" <<EOF
 #!/bin/sh
-n=\$(cat "$attempts" 2>/dev/null || echo 0); n=\$((n + 1)); echo "\$n" >"$attempts"
-[ "\$n" -ge $succeed_at ] || exit 1
-exec "$BIN" "\$@"
+n=\$(cat "$attempts" 2>/dev/null || echo 0); echo "\$((n + 1))" >"$attempts"
+exit 1
 EOF
   chmod +x "$path"
+}
+
+# Holds the daemon lock for $1 seconds in the background, the state a login
+# start sees while a previous daemon is still shutting down.
+hold_daemon_lock() {
+  mkdir -p "$DAEMON_DIR"
+  python3 - "$DAEMON_DIR/daemon.lock" "$1" <<'PY' &
+import fcntl, sys, time
+handle = open(sys.argv[1], "w")
+fcntl.flock(handle, fcntl.LOCK_EX)
+time.sleep(float(sys.argv[2]))
+PY
 }
 
 mechanism_failed() {
@@ -286,26 +296,27 @@ trigger_login_expect_failure() {
   esac
 }
 
-# The launcher retries bg start a few times: transient failures must end in a
-# healthy daemon, and persistent failure must surface as a failed login start.
+# `bg start --retry-secs` must ride out a lock held at login, and a binary that
+# keeps failing must surface as a failed login start.
 scenario_launcher_retry() {
-  local fake_dir="$HOME/mdm-fake" attempts="$HOME/mdm-fake/attempts"
-  mkdir -p "$fake_dir"
-
-  write_fake_binary "$fake_dir/git-ai" "$attempts" 3
-  run_mdm_script --bin "$fake_dir/git-ai"
-  wait_for 45 "daemon up after transient launcher failures" daemon_up
-  [ "$(cat "$attempts")" = 3 ] || fail "expected 3 attempts, got $(cat "$attempts")"
+  hold_daemon_lock 4
+  local holder=$!
+  sleep 1
+  run_mdm_script
+  wait_for 45 "daemon up despite a lock held at login" daemon_up
+  wait "$holder" || true
   mechanism_sane
   run_mdm_script --uninstall
   stop_daemon
 
+  local fake_dir="$HOME/mdm-fake" attempts="$HOME/mdm-fake/attempts"
+  mkdir -p "$fake_dir"
   rm -f "$attempts"
-  write_fake_binary "$fake_dir/git-ai" "$attempts" 99
+  write_failing_binary "$fake_dir/git-ai" "$attempts"
   run_mdm_script --bin "$fake_dir/git-ai" --no-start
   trigger_login_expect_failure
   wait_for 45 "persistent launcher failure reported by the login mechanism" mechanism_failed
-  [ "$(cat "$attempts")" = 5 ] || fail "expected 5 attempts, got $(cat "$attempts")"
+  [ "$(cat "$attempts")" = 1 ] || fail "launcher should invoke the binary once, got $(cat "$attempts")"
   daemon_up && fail "no daemon should be running after persistent failure"
   run_mdm_script --uninstall
   [ "$OS" != linux ] || systemctl --user reset-failed "$UNIT" 2>/dev/null || true

--- a/scripts/mdm/test-login-start.sh
+++ b/scripts/mdm/test-login-start.sh
@@ -298,16 +298,23 @@ trigger_login_expect_failure() {
 
 # `bg start --retry-secs` must ride out a lock held at login, and a binary that
 # keeps failing must surface as a failed login start.
+supports_retry() { "$BIN" bg --help 2>&1 | grep -q -- --retry-secs; }
+
 scenario_launcher_retry() {
-  hold_daemon_lock 4
-  local holder=$!
-  sleep 1
-  run_mdm_script
-  wait_for 45 "daemon up despite a lock held at login" daemon_up
-  wait "$holder" || true
-  mechanism_sane
-  run_mdm_script --uninstall
-  stop_daemon
+  if supports_retry; then
+    hold_daemon_lock 4
+    local holder=$!
+    sleep 1
+    run_mdm_script
+    wait_for 45 "daemon up despite a lock held at login" daemon_up
+    wait "$holder" || true
+    mechanism_sane
+    run_mdm_script --uninstall
+    stop_daemon
+  else
+    # Published releases without --retry-secs cannot ride out the lock race.
+    log "SKIP held-lock phase: $(installed_version) predates bg start --retry-secs"
+  fi
 
   local fake_dir="$HOME/mdm-fake" attempts="$HOME/mdm-fake/attempts"
   mkdir -p "$fake_dir"

--- a/tests/mdm_scripts.rs
+++ b/tests/mdm_scripts.rs
@@ -66,6 +66,10 @@ fn macos_launch_agent_abandons_process_group_and_never_keeps_alive() {
         script.contains("bg start") && !script.contains("bg run"),
         "the agent must invoke the idempotent `bg start`, never the foreground `bg run`"
     );
+    assert!(
+        script.contains(r#"$(xml_string "$BIN")"#),
+        "per-user agents must run the git-ai binary directly so macOS shows \"git-ai\", not \"sh\", as the login item"
+    );
 }
 
 #[test]
@@ -91,6 +95,10 @@ fn linux_unit_is_oneshot_that_remains_after_exit_without_restart() {
     assert!(
         script.contains("bg start") && !script.contains("bg run"),
         "the unit must invoke the idempotent `bg start`, never the foreground `bg run`"
+    );
+    assert!(
+        !script.contains("; do "),
+        "the unit must not loop itself; retries live in `bg start --retry-secs`"
     );
 }
 
@@ -118,6 +126,10 @@ fn windows_task_runs_once_per_logon_as_the_current_user_without_time_limit() {
         script.contains("bg start") && !script.contains("bg run"),
         "the task must invoke the idempotent `bg start`, never the foreground `bg run`"
     );
+    assert!(
+        !script.contains("$attempt"),
+        "the launcher must not loop itself; retries live in `bg start --retry-secs`"
+    );
 }
 
 #[test]
@@ -133,6 +145,10 @@ fn all_scripts_share_the_same_cli_contract() {
                 "{name} script must support {flag} like the other platforms"
             );
         }
+        assert!(
+            script.contains("bg start --retry-secs"),
+            "{name} launcher must let bg start retry through a login-time lock race"
+        );
     }
     for (name, script) in [("macos", macos_script()), ("linux", linux_script())] {
         assert!(
@@ -151,6 +167,7 @@ fn readme_documents_the_launch_invariants() {
         "RemainAfterExit",
         "IgnoreNew",
         "lock",
+        "--retry-secs",
         "--uninstall",
         "--env",
     ] {


### PR DESCRIPTION
macOS names a LaunchAgent after its executable, so the sh -c retry wrapper
made the login item and the 'can run in the background' notice say "sh",
and a Managed Login Items profile could not match it by the git-ai signing
team. Per-user agents now run the git-ai binary directly with
--retry-secs 10 and log through StandardOut/ErrorPath; only --system without
--bin keeps a shell to resolve each user's home. The Windows launcher drops
its loop for the same flag. Linux keeps a one-line sh exec wrapper because
systemd rejects executable paths containing quotes or parentheses, but its
retry loop is gone too.

The e2e drivers now hold the daemon lock while triggering the login start to
prove --retry-secs rides out the race, and keep the always-failing binary
check for the failure path.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>