### PR TITLE
feat(token-usage): enable token_usage_metrics by default in release builds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,7 @@ Signal forwarding: On Unix, the git proxy installs signal handlers (SIGTERM, SIG
 
 `Config` is a global `OnceLock` singleton accessed via `Config::get()`. It reads from `~/.git-ai/config.json`. In tests, `GIT_AI_TEST_CONFIG_PATCH` env var allows overriding specific config fields without a real config file. Feature flags follow precedence: environment vars (`GIT_AI_*` prefix via `envy`) > config file > defaults.
 
-Feature flags have separate debug/release defaults defined via the `define_feature_flags!` macro in `src/feature_flags.rs`. Currently: `auth_keyring` (false/false), `transcript_streaming` (true/true), `transcript_sweep` (true/true), `checkpoint_debug_log` (false/false), `daemon_log_upload` (true/true), `untraced_commit_fixup` (true/true), `untraced_fixup_ignore_temp_repos` (true/true).
+Feature flags have separate debug/release defaults defined via the `define_feature_flags!` macro in `src/feature_flags.rs`. Currently: `auth_keyring` (false/false), `transcript_streaming` (true/true), `transcript_sweep` (true/true), `checkpoint_debug_log` (false/false), `daemon_log_upload` (true/true), `token_usage_metrics` (true/true), `untraced_commit_fixup` (true/true), `untraced_fixup_ignore_temp_repos` (true/true).
 
 ### Error handling
 

--- a/docs/token-usage-events-spec.md
+++ b/docs/token-usage-events-spec.md
@@ -42,7 +42,7 @@ Driven by `TokenUsageWorker` (`src/daemon/token_usage_worker.rs`):
   file already queued for backfill promotes it. Shutdown is observed while a
   pass is in flight (the worker selects on its own shutdown `Notify` around
   the blocking pass).
-- **Feature flag:** `token_usage_metrics` (debug: on, release: off) gates the
+- **Feature flag:** `token_usage_metrics` (on by default) gates the
   worker at daemon startup, like `transcript_streaming`. When the flag is
   off, no worker or ticker runs, the token-usage database is not created, and
   a previously created one is deleted at daemon startup (independent of the

--- a/src/feature_flags.rs
+++ b/src/feature_flags.rs
@@ -86,7 +86,7 @@ define_feature_flags!(
     bash_checkpoints_v2: bash_checkpoints_v2, debug = false, release = false,
     daemon_log_upload: daemon_log_upload, debug = true, release = true,
     rewrite_metrics_events: rewrite_metrics_events, debug = true, release = false,
-    token_usage_metrics: token_usage_metrics, debug = true, release = false,
+    token_usage_metrics: token_usage_metrics, debug = true, release = true,
     untraced_commit_fixup: untraced_commit_fixup, debug = true, release = true,
     untraced_fixup_ignore_temp_repos: untraced_fixup_ignore_temp_repos, debug = true, release = true,
 );
@@ -160,7 +160,7 @@ mod tests {
             assert!(!flags.bash_checkpoints_v2);
             assert!(flags.daemon_log_upload);
             assert!(!flags.rewrite_metrics_events);
-            assert!(!flags.token_usage_metrics);
+            assert!(flags.token_usage_metrics);
             assert!(flags.untraced_commit_fixup);
             assert!(flags.untraced_fixup_ignore_temp_repos);
         }


### PR DESCRIPTION
The v2 token-usage pipeline (transcript extraction, 5-minute bucket
events, authoritative pricing) has been validated behind the
token_usage_metrics feature flag with debug-only default. Flip the
release default to on so all environments collect token usage. The
flag remains overridable via GIT_AI_TOKEN_USAGE_METRICS / config, and
turning it off still deletes the token-usage database at daemon
startup.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/2335" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
