### PR TITLE
chore: update toml to version 4.3.0 and add MessagePack package

### DIFF
--- a/agent-support/opencode/package-lock.json
+++ b/agent-support/opencode/package-lock.json
@@ -196,9 +196,18 @@
         "kubernetes-types": "^1.30.0",
         "msgpackr": "^2.0.1",
         "multipasta": "^0.2.7",
-        "toml": "^4.1.1",
+        "toml": "^4.3.0",
         "uuid": "^14.0.0",
         "yaml": "^2.9.0"
+      }
+    },
+    "node_modules/effect/node_modules/toml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-4.3.0.tgz",
+      "integrity": "sha512-lVb8X9BsPVuH0M4BKeS91tXAmJvCjQ5UIyAbQFaxkKGyUFK2RPkhwaFSQH8vbpl1d23eu/IBH+dwVMHWaq9A5A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/fast-check": {
@@ -352,15 +361,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/toml": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/toml/-/toml-4.1.2.tgz",
-      "integrity": "sha512-m0vXfHODcw3gk+KONAOlVQ5yNHc3yS3B1ybM3HS1vqDoS0RWTDDVBVVTYi8hH0k+2OM1vmo9fb1WX9EVqjqfHA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
       }
     },
     "node_modules/typescript": {

--- a/agent-support/opencode/package.json
+++ b/agent-support/opencode/package.json
@@ -13,5 +13,8 @@
   "devDependencies": {
     "@types/node": "^26.x",
     "typescript": "^5.8.3"
+  },
+  "overrides": {
+    "toml": "4.3.0"
   }
 }

--- a/agent-support/visualstudio/src/GitAiVS/GitAiVS.csproj
+++ b/agent-support/visualstudio/src/GitAiVS/GitAiVS.csproj
@@ -30,6 +30,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.32112.339" ExcludeAssets="runtime" />
+    <PackageReference Include="MessagePack" Version="2.5.301" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.14.2142">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
update toml and MessagePack to solve CVE  security issue

CVE Details
Published: Jun 23, 2026
A vulnerability exists in the optional LZ4 decompression path used by MessagePack compression modes Lz4Block and Lz4BlockArray. This affects MessagePack versions prior to 2.5.301, and 3.x prior to 3.1.7.


CVE Details
Published: Sep 4, 2026
toml-node is a TOML parser for Node.js and the browser. Prior to 4.2.0, toml.parse() uses a Peggy 5.1.0 generated recursive-descent parser in lib/parser.js whose peg$parsevalue, peg$parsearray, and peg$parseinlinetableentry functions recurse through nested arrays and inline tables without a depth limit. A remote unauthenticated application parsing an attacker-controlled TOML document containing a few thousand nested arrays or inline tables can exhaust the Node.js call stack, raise an unexpected RangeError rather than the parser's SyntaxError, and terminate an unprotected request worker or process. The corresponding grammar source is src/toml.pegjs, where the generated parser must be bounded. This issue is fixed in version 4.2.0.


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/2342" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->