### PR TITLE
fix(stats): deduplicate overlapping added-line attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ git ai stats <start_sha>..<end_sha> --json
 
 Calculates % AI-code, AI-lines generated vs committed, accepted rates, human overrides broken down by tool and model. Learn more: [Stats command reference docs](https://usegitai.com/docs/cli/reference#stats). 
 
+For commit-level overlap handling and non-additive model counts, see
+[Attribution counts in commit stats](docs/commit-stats-attribution.md).
+
 
 <details>
 <summary>Example JSON output</summary>

--- a/docs/commit-stats-attribution.md
+++ b/docs/commit-stats-attribution.md
@@ -1,0 +1,52 @@
+# Attribution counts in commit stats
+
+`git-ai stats <commit> --json` counts lines added by the commit's diff, rather
+than the number of attribution records covering those lines. Repeated ranges,
+sessions, or file records do not count an added line again. The same line number
+in two different files represents two additions.
+
+The headline buckets are exclusive:
+
+- `human_additions`: added lines with explicit known-human (`h_`) attribution,
+  including lines that also have AI attribution.
+- `ai_additions` and `ai_accepted`: added lines with AI attribution and no explicit
+  known-human attribution. These two fields retain the same value.
+- `unknown_additions`: the remaining added lines.
+
+Consequently, `human_additions + ai_additions + unknown_additions` equals
+`git_diff_added_lines`. Known-human precedence is a reporting convention: it
+does not assert that the human edited last, that no AI contributed to that line,
+or that the human was its only author. An AI session's `human_author` metadata
+alone is not a known-human line attestation.
+
+## Tool/model coverage is not additive
+
+Each `tool_model_breakdown` entry counts distinct qualifying AI-added lines for
+that tool/model. Multiple sessions or legacy prompts resolving to the same key
+are combined. Different keys can cover the same line, so their counts must not
+be summed to obtain the headline AI total or displayed as exclusive shares.
+
+For example, if model A covers lines 1–4 and model B covers lines 3–6, with no
+known-human attribution, the headline AI count is 6 and each model's count is 4.
+The original overlapping provenance is retained in the authorship note.
+
+Known-human lines are excluded from each model's count as well as the headline
+AI count. A model with no qualifying added lines is omitted. Existing metadata
+resolution is unchanged: non-`h_` attestations still contribute to the AI
+headline when their session or legacy prompt metadata is unavailable, but they
+do not create an invented tool/model entry.
+
+## Scope and compatibility
+
+This counting rule does not change stored notes, blame attribution, file-ignore
+selection, the diff used to find additions, or existing merge-commit handling.
+Overlapping historical notes can therefore produce lower counts when inspected
+again. Non-overlapping records retain their counts. The JSON field names and
+types are unchanged; consumers must treat model counts as overlapping coverage.
+
+The commit-level rule does not redefine the separate range-statistics metrics.
+
+Telemetry continues to omit mock-model entries. Its aggregate excludes only
+added lines attributed exclusively to mock models, so overlap with a real or
+unresolved model does not remove that model's coverage. Mock-exclusive counts
+are carried internally and do not add fields to the public JSON output.

--- a/src/authorship/post_commit.rs
+++ b/src/authorship/post_commit.rs
@@ -7,7 +7,9 @@ use crate::authorship::ignore::{
     build_ignore_matcher, effective_ignore_patterns, should_ignore_file_with_matcher,
 };
 use crate::authorship::rewrite::DiffTreeResult;
-use crate::authorship::stats::{stats_for_commit_stats_from_hunks, write_stats_to_terminal};
+use crate::authorship::stats::{
+    stats_for_commit_stats_and_mock_counts_from_hunks, write_stats_to_terminal,
+};
 use crate::authorship::virtual_attribution::{AuthorshipLogDiffContext, VirtualAttributions};
 use crate::authorship::working_log::{Checkpoint, CheckpointKind, WorkingLogEntry};
 use crate::config::Config;
@@ -482,13 +484,12 @@ where
                 &commit_sha,
             )?;
 
-            let computed = stats_for_commit_stats_from_hunks(
-                repo,
-                &commit_sha,
+            let (computed, mock_only) = stats_for_commit_stats_and_mock_counts_from_hunks(
                 &ignore_patterns,
                 &diff_hunks,
                 Some(&authorship_log),
-            )?;
+                is_merge_commit,
+            );
 
             let hunks_json = crate::commands::diff::build_diff_artifacts_from_hunks(
                 repo,
@@ -509,6 +510,7 @@ where
                 &human_author,
                 &authorship_note_str,
                 &computed,
+                &mock_only,
                 &parent_working_log,
                 hunks_json.as_deref(),
                 options.commit_source,
@@ -1001,27 +1003,24 @@ pub(crate) struct MetricToolModelBreakdown {
 }
 
 /// Build the metrics tool/model arrays and remove mock_ai test data.
-/// Returns None when the entire event would only represent mock_ai data.
+/// Returns None when all named models and all qualifying AI coverage are mock.
 pub(crate) fn metric_tool_model_breakdown(
     stats: &crate::authorship::stats::CommitStats,
+    mock_only: &crate::authorship::stats::ToolModelHeadlineStats,
 ) -> Option<MetricToolModelBreakdown> {
     let only_mock_ai = !stats.tool_model_breakdown.is_empty()
         && stats
             .tool_model_breakdown
             .keys()
-            .all(|k| k.starts_with("mock_ai::"));
+            .all(|k| k.starts_with("mock_ai::"))
+        && mock_only.ai_additions == stats.ai_additions
+        && mock_only.ai_accepted == stats.ai_accepted;
     if only_mock_ai {
         return None;
     }
 
-    let mut agg_ai = stats.ai_additions;
-    let mut agg_accepted = stats.ai_accepted;
-    for (key, ts) in &stats.tool_model_breakdown {
-        if key.starts_with("mock_ai::") {
-            agg_ai = agg_ai.saturating_sub(ts.ai_additions);
-            agg_accepted = agg_accepted.saturating_sub(ts.ai_accepted);
-        }
-    }
+    let agg_ai = stats.ai_additions.saturating_sub(mock_only.ai_additions);
+    let agg_accepted = stats.ai_accepted.saturating_sub(mock_only.ai_accepted);
 
     let mut tool_model_pairs: Vec<String> = vec!["all".to_string()];
     let mut ai_additions: Vec<u32> = vec![agg_ai];
@@ -1132,8 +1131,24 @@ pub(crate) fn commit_metric_attrs(
     attrs.custom_attributes_map(Config::fresh().custom_attributes())
 }
 
-/// Record metrics for a committed change.
-/// This is a best-effort operation - failures are silently ignored.
+/// Build the ordinary-commit count payload, excluding mock-only coverage.
+pub(crate) fn committed_metric_values(
+    stats: &crate::authorship::stats::CommitStats,
+    mock_only: &crate::authorship::stats::ToolModelHeadlineStats,
+) -> Option<crate::metrics::CommittedValues> {
+    let breakdown = metric_tool_model_breakdown(stats, mock_only)?;
+    Some(
+        crate::metrics::CommittedValues::new()
+            .human_additions(stats.human_additions)
+            .git_diff_deleted_lines(stats.git_diff_deleted_lines)
+            .git_diff_added_lines(stats.git_diff_added_lines)
+            .tool_model_pairs(breakdown.tool_model_pairs)
+            .ai_additions(breakdown.ai_additions)
+            .ai_accepted(breakdown.ai_accepted),
+    )
+}
+
+/// Record metrics for a committed change on a best-effort basis.
 #[allow(clippy::too_many_arguments)]
 fn record_commit_metrics(
     repo: &Repository,
@@ -1142,24 +1157,16 @@ fn record_commit_metrics(
     human_author: &str,
     authorship_note: &str,
     stats: &crate::authorship::stats::CommitStats,
+    mock_only: &crate::authorship::stats::ToolModelHeadlineStats,
     checkpoints: &[Checkpoint],
     hunks_json: Option<&str>,
     commit_source: Option<&str>,
 ) {
-    use crate::metrics::{CommittedValues, record};
+    use crate::metrics::record;
 
-    let Some(breakdown) = metric_tool_model_breakdown(stats) else {
+    let Some(values) = committed_metric_values(stats, mock_only) else {
         return;
     };
-
-    // Build values with all stats
-    let values = CommittedValues::new()
-        .human_additions(stats.human_additions)
-        .git_diff_deleted_lines(stats.git_diff_deleted_lines)
-        .git_diff_added_lines(stats.git_diff_added_lines)
-        .tool_model_pairs(breakdown.tool_model_pairs)
-        .ai_additions(breakdown.ai_additions)
-        .ai_accepted(breakdown.ai_accepted);
 
     // Add first checkpoint timestamp (null if no checkpoints)
     let values = if let Some(first) = checkpoints.first() {
@@ -1355,11 +1362,44 @@ mod tests {
             ..Default::default()
         };
 
-        let result = metric_tool_model_breakdown(&stats).unwrap();
+        let result = metric_tool_model_breakdown(
+            &stats,
+            &ToolModelHeadlineStats {
+                ai_additions: 4,
+                ai_accepted: 3,
+            },
+        )
+        .unwrap();
 
         assert_eq!(result.tool_model_pairs, vec!["all", "codex::gpt-5"]);
         assert_eq!(result.ai_additions, vec![6, 6]);
         assert_eq!(result.ai_accepted, vec![5, 5]);
+    }
+
+    #[test]
+    fn test_metric_tool_model_breakdown_preserves_real_coverage_overlapping_mock() {
+        use crate::authorship::stats::{CommitStats, ToolModelHeadlineStats};
+
+        // Both models cover every one of the same six added lines.
+        let model = ToolModelHeadlineStats {
+            ai_additions: 6,
+            ai_accepted: 6,
+        };
+        let stats = CommitStats {
+            ai_additions: 6,
+            ai_accepted: 6,
+            tool_model_breakdown: std::collections::BTreeMap::from([
+                ("mock_ai::unknown".to_string(), model.clone()),
+                ("codex::test-model".to_string(), model),
+            ]),
+            ..Default::default()
+        };
+
+        let result =
+            metric_tool_model_breakdown(&stats, &ToolModelHeadlineStats::default()).unwrap();
+        assert_eq!(result.tool_model_pairs, vec!["all", "codex::test-model"]);
+        assert_eq!(result.ai_additions, vec![6, 6]);
+        assert_eq!(result.ai_accepted, vec![6, 6]);
     }
 
     #[test]
@@ -1381,7 +1421,16 @@ mod tests {
             ..Default::default()
         };
 
-        assert_eq!(metric_tool_model_breakdown(&stats), None);
+        assert_eq!(
+            metric_tool_model_breakdown(
+                &stats,
+                &ToolModelHeadlineStats {
+                    ai_additions: 4,
+                    ai_accepted: 3,
+                },
+            ),
+            None
+        );
     }
 
     #[test]

--- a/src/authorship/stats.rs
+++ b/src/authorship/stats.rs
@@ -17,25 +17,27 @@ const WAIT_MESSAGE: &str = "Waiting for git-ai to process this commit";
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ToolModelHeadlineStats {
     #[serde(default)]
-    pub ai_additions: u32, // Number of lines committed with AI attribution
+    pub ai_additions: u32, // Distinct model-attributed additions without known-human attribution
     #[serde(default)]
-    pub ai_accepted: u32, // Number of AI-generated lines that were accepted by the user without any human edits
+    pub ai_accepted: u32, // Same qualifying added-line count as ai_additions
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct CommitStats {
     #[serde(default)]
-    pub human_additions: u32, // Number of lines committed with human attribution
+    pub human_additions: u32, // Distinct additions with explicit known-human attribution
     #[serde(default)]
     pub unknown_additions: u32, // Number of lines with no attestation at all
     #[serde(default)]
-    pub ai_additions: u32, // Number of lines committed with AI attribution
+    pub ai_additions: u32, // Distinct AI-attributed additions without known-human attribution
     #[serde(default)]
-    pub ai_accepted: u32, // Number of AI-generated lines that were accepted by the user without any human edits
+    pub ai_accepted: u32, // Same qualifying added-line count as ai_additions
     #[serde(default)]
     pub git_diff_deleted_lines: u32,
     #[serde(default)]
     pub git_diff_added_lines: u32,
+    /// Distinct AI-attributed additions per tool/model, excluding known-human
+    /// additions. Models may cover the same line, so these counts are not additive.
     #[serde(default)]
     pub tool_model_breakdown: BTreeMap<String, ToolModelHeadlineStats>,
 }
@@ -516,77 +518,163 @@ pub fn stats_for_commit_stats_with_parent_and_authorship(
     stats_for_commit_stats_from_hunks(repo, commit_sha, ignore_patterns, &hunks, authorship_log)
 }
 
+fn merge_added_line_spans(mut spans: Vec<(usize, usize)>) -> Vec<(usize, usize)> {
+    spans.sort_unstable();
+    let mut merged: Vec<(usize, usize)> = Vec::new();
+    for (start, end) in spans {
+        if let Some(last) = merged.last_mut()
+            && start <= last.1
+        {
+            last.1 = last.1.max(end);
+        } else {
+            merged.push((start, end));
+        }
+    }
+    merged
+}
+
+fn count_added_line_spans_without_human(
+    spans: Vec<(usize, usize)>,
+    human_spans: &[(usize, usize)],
+) -> u32 {
+    merge_added_line_spans(spans)
+        .into_iter()
+        .map(|(start, end)| {
+            let first = human_spans.partition_point(|&(_, human_end)| human_end <= start);
+            let excluded: usize = human_spans[first..]
+                .iter()
+                .take_while(|&&(human_start, _)| human_start < end)
+                .map(|&(human_start, human_end)| end.min(human_end) - start.max(human_start))
+                .sum();
+            (end - start - excluded) as u32
+        })
+        .sum()
+}
+
+/// Count distinct added lines, with explicit known-human attribution taking
+/// precedence over AI attribution. Tool/model counts are independent unions,
+/// not an exclusive allocation of multi-model provenance.
 #[doc(hidden)]
 pub fn accepted_lines_from_attestations(
     authorship_log: Option<&crate::authorship::authorship_log_serialization::AuthorshipLog>,
     added_lines_by_file: &HashMap<String, Vec<u32>>,
     is_merge_commit: bool,
 ) -> (u32, u32, BTreeMap<String, u32>) {
-    // returns (ai_accepted, known_human_accepted, per_tool_model)
+    let (ai, human, per_tool, _) =
+        accepted_line_counts(authorship_log, added_lines_by_file, is_merge_commit);
+    (ai, human, per_tool)
+}
+
+fn accepted_line_counts(
+    authorship_log: Option<&crate::authorship::authorship_log_serialization::AuthorshipLog>,
+    added_lines_by_file: &HashMap<String, Vec<u32>>,
+    is_merge_commit: bool,
+) -> (u32, u32, BTreeMap<String, u32>, u32) {
+    // Headline AI, known human, per-model coverage, and mock-exclusive AI.
     if is_merge_commit {
-        return (0, 0, BTreeMap::new());
+        return (0, 0, BTreeMap::new(), 0);
     }
 
     let mut total_ai_accepted = 0u32;
     let mut known_human_accepted = 0u32;
     let mut per_tool_model = BTreeMap::new();
+    let mut mock_only_ai = 0;
 
     let Some(log) = authorship_log else {
-        return (0, 0, per_tool_model);
+        return (0, 0, per_tool_model, 0);
     };
 
-    for file_attestation in &log.attestations {
-        let Some(added_lines) = added_lines_by_file.get(&file_attestation.file_path) else {
-            continue;
-        };
+    // Group repeated file records before counting: notes can retain overlapping
+    // provenance after a rewrite. Spans index actual additions, never every line
+    // in an attested numeric range.
+    let mut entries_by_file: HashMap<&str, Vec<_>> = HashMap::new();
+    for file in &log.attestations {
+        if added_lines_by_file.contains_key(&file.file_path) {
+            entries_by_file
+                .entry(&file.file_path)
+                .or_default()
+                .extend(&file.entries);
+        }
+    }
 
-        for entry in &file_attestation.entries {
-            // KnownHuman entries (h_ prefix): count as known-human-attested lines.
-            if entry.hash.starts_with("h_") {
-                let accepted = entry
-                    .line_ranges
-                    .iter()
-                    .map(|line_range| line_range_overlap_len(line_range, added_lines))
-                    .sum::<u32>();
-                if accepted > 0 {
-                    known_human_accepted += accepted;
-                }
-                continue;
-            }
+    for (file_path, entries) in entries_by_file {
+        let added_lines = &added_lines_by_file[file_path];
+        let mut ai_spans = Vec::new();
+        let mut non_mock_ai_spans = Vec::new();
+        let mut human_spans = Vec::new();
+        let mut spans_by_tool_model: BTreeMap<String, Vec<(usize, usize)>> = BTreeMap::new();
 
-            let accepted = entry
+        for entry in entries {
+            let spans: Vec<_> = entry
                 .line_ranges
                 .iter()
-                .map(|line_range| line_range_overlap_len(line_range, added_lines))
-                .sum::<u32>();
+                .filter_map(|range| {
+                    let (start, end) = match range {
+                        LineRange::Single(line) => (*line, *line),
+                        LineRange::Range(start, end) => (*start, *end),
+                    };
+                    let start_idx = added_lines.partition_point(|line| *line < start);
+                    let end_idx = added_lines.partition_point(|line| *line <= end);
+                    (start_idx < end_idx).then_some((start_idx, end_idx))
+                })
+                .collect();
 
-            if accepted == 0 {
+            if entry.hash.starts_with("h_") {
+                human_spans.extend(spans);
                 continue;
             }
 
-            total_ai_accepted += accepted;
+            if spans.is_empty() {
+                continue;
+            }
+            ai_spans.extend_from_slice(&spans);
 
-            // Session entries (s_ prefix): look up in sessions map
-            if entry.hash.starts_with("s_") {
+            let agent_id = if entry.hash.starts_with("s_") {
                 let session_key = entry.hash.split("::").next().unwrap_or(&entry.hash);
-                if let Some(session_record) = log.metadata.sessions.get(session_key) {
-                    let tool_model = format!(
-                        "{}::{}",
-                        session_record.agent_id.tool, session_record.agent_id.model
-                    );
-                    *per_tool_model.entry(tool_model).or_insert(0) += accepted;
-                }
-            } else if let Some(prompt_record) = log.metadata.prompts.get(&entry.hash) {
-                let tool_model = format!(
-                    "{}::{}",
-                    prompt_record.agent_id.tool, prompt_record.agent_id.model
-                );
+                log.metadata.sessions.get(session_key).map(|s| &s.agent_id)
+            } else {
+                log.metadata.prompts.get(&entry.hash).map(|p| &p.agent_id)
+            };
+            let tool_model = agent_id.map(|agent| format!("{}::{}", agent.tool, agent.model));
+            // Missing metadata is not evidence that an AI attestation is mock.
+            // Use the same key classification as the telemetry mapper.
+            if tool_model
+                .as_ref()
+                .is_none_or(|key| !key.starts_with("mock_ai::"))
+            {
+                non_mock_ai_spans.extend_from_slice(&spans);
+            }
+            if let Some(tool_model) = tool_model {
+                spans_by_tool_model
+                    .entry(tool_model)
+                    .or_default()
+                    .extend(spans);
+            }
+        }
+
+        let human_spans = merge_added_line_spans(human_spans);
+        known_human_accepted += human_spans
+            .iter()
+            .map(|(start, end)| (end - start) as u32)
+            .sum::<u32>();
+        let file_ai = count_added_line_spans_without_human(ai_spans, &human_spans);
+        let non_mock_ai = count_added_line_spans_without_human(non_mock_ai_spans, &human_spans);
+        total_ai_accepted += file_ai;
+        mock_only_ai += file_ai - non_mock_ai;
+        for (tool_model, spans) in spans_by_tool_model {
+            let accepted = count_added_line_spans_without_human(spans, &human_spans);
+            if accepted > 0 {
                 *per_tool_model.entry(tool_model).or_insert(0) += accepted;
             }
         }
     }
 
-    (total_ai_accepted, known_human_accepted, per_tool_model)
+    (
+        total_ai_accepted,
+        known_human_accepted,
+        per_tool_model,
+        mock_only_ai,
+    )
 }
 
 #[doc(hidden)]
@@ -628,6 +716,23 @@ pub(crate) fn stats_for_commit_stats_from_hunks_with_merge_flag(
     authorship_log: Option<&crate::authorship::authorship_log_serialization::AuthorshipLog>,
     is_merge_commit: bool,
 ) -> CommitStats {
+    stats_for_commit_stats_and_mock_counts_from_hunks(
+        ignore_patterns,
+        hunks,
+        authorship_log,
+        is_merge_commit,
+    )
+    .0
+}
+
+/// Return mock-exclusive coverage separately for telemetry. Per-model marginal
+/// counts cannot be subtracted from headline unions when models overlap.
+pub(crate) fn stats_for_commit_stats_and_mock_counts_from_hunks(
+    ignore_patterns: &[String],
+    hunks: &[crate::commands::diff::DiffHunk],
+    authorship_log: Option<&crate::authorship::authorship_log_serialization::AuthorshipLog>,
+    is_merge_commit: bool,
+) -> (CommitStats, ToolModelHeadlineStats) {
     let ignore_matcher = build_ignore_matcher(ignore_patterns);
 
     let mut git_diff_added_lines = 0u32;
@@ -654,16 +759,23 @@ pub(crate) fn stats_for_commit_stats_from_hunks_with_merge_flag(
         lines.dedup();
     }
 
-    let (ai_accepted, known_human_accepted, ai_accepted_by_tool) =
-        accepted_lines_from_attestations(authorship_log, &added_lines_by_file, is_merge_commit);
+    let (ai_accepted, known_human_accepted, ai_accepted_by_tool, mock_only_ai) =
+        accepted_line_counts(authorship_log, &added_lines_by_file, is_merge_commit);
 
-    stats_from_authorship_log(
+    let stats = stats_from_authorship_log(
         authorship_log,
         git_diff_added_lines,
         git_diff_deleted_lines,
         ai_accepted,
         known_human_accepted,
         &ai_accepted_by_tool,
+    );
+    (
+        stats,
+        ToolModelHeadlineStats {
+            ai_additions: mock_only_ai,
+            ai_accepted: mock_only_ai,
+        },
     )
 }
 
@@ -713,6 +825,112 @@ pub fn get_git_diff_stats(
 mod tests {
     use super::*;
     use insta::assert_debug_snapshot;
+
+    #[test]
+    fn test_stats_mock_exclusive_counts_match_independent_mask_oracle() {
+        use crate::authorship::authorship_log::SessionRecord;
+        use crate::authorship::authorship_log_serialization::{AttestationEntry, AuthorshipLog};
+        use crate::authorship::post_commit::committed_metric_values;
+        use crate::authorship::working_log::AgentId;
+        use crate::metrics::{PosEncoded, events::committed_pos};
+
+        let positions = [10, 20, 30];
+        let hunks = vec![crate::commands::diff::DiffHunk {
+            file_path: "file.txt".to_string(),
+            old_file_path: None,
+            old_start: 0,
+            old_count: 0,
+            new_start: 10,
+            new_count: 21,
+            deleted_lines: vec![],
+            added_lines: positions.to_vec(),
+            deleted_contents: vec![],
+            added_contents: vec!["same text".to_string(); 3],
+        }];
+        let mut base = AuthorshipLog::new();
+        for (id, tool) in [
+            ("s_real", "codex"),
+            ("s_mock_a", "mock_ai"),
+            ("s_mock_b", "mock_ai"),
+        ] {
+            base.metadata.sessions.insert(
+                id.to_string(),
+                SessionRecord {
+                    agent_id: AgentId {
+                        tool: tool.to_string(),
+                        id: id.to_string(),
+                        model: id.to_string(),
+                    },
+                    human_author: Some("Test Author".to_string()),
+                    custom_attributes: None,
+                },
+            );
+        }
+        for human in 0..8u8 {
+            for real in 0..8u8 {
+                for mock in 0..8u8 {
+                    for unresolved in 0..8u8 {
+                        let mut log = base.clone();
+                        for (hash, mask) in [
+                            ("h_human", human),
+                            ("s_real::t", real),
+                            ("s_mock_a::t", mock),
+                            ("s_mock_b::t", mock),
+                            ("s_missing::t", unresolved),
+                        ] {
+                            let ranges = positions
+                                .iter()
+                                .enumerate()
+                                .filter(|(i, _)| mask & (1 << i) != 0)
+                                .map(|(_, line)| LineRange::Single(*line))
+                                .collect();
+                            log.get_or_create_file("file.txt")
+                                .add_entry(AttestationEntry::new(hash.to_string(), ranges));
+                        }
+                        let (stats, mock_only) = stats_for_commit_stats_and_mock_counts_from_hunks(
+                            &[],
+                            &hunks,
+                            Some(&log),
+                            false,
+                        );
+                        let qualifying = (real | mock | unresolved) & !human;
+                        let expected_mock_only = (mock & !(real | unresolved | human)).count_ones();
+                        let expected_non_mock = ((real | unresolved) & !human).count_ones();
+                        assert_eq!(stats.ai_accepted, qualifying.count_ones());
+                        assert_eq!(stats.human_additions, human.count_ones());
+                        assert_eq!(mock_only.ai_additions, expected_mock_only);
+                        assert_eq!(mock_only.ai_accepted, expected_mock_only);
+                        assert_eq!(stats.ai_accepted - mock_only.ai_accepted, expected_non_mock);
+
+                        let metric = committed_metric_values(&stats, &mock_only);
+                        let pure_mock = (mock & !human) != 0 && expected_non_mock == 0;
+                        if pure_mock {
+                            assert!(metric.is_none());
+                        } else {
+                            let values = metric.unwrap().to_sparse();
+                            let expected_real = (real & !human).count_ones();
+                            let mut expected_counts = vec![expected_non_mock];
+                            let mut expected_models = vec!["all"];
+                            if expected_real > 0 {
+                                expected_counts.push(expected_real);
+                                expected_models.push("codex::s_real");
+                            }
+                            for pos in [committed_pos::AI_ADDITIONS, committed_pos::AI_ACCEPTED] {
+                                assert_eq!(
+                                    values.get(&pos.to_string()),
+                                    Some(&serde_json::json!(expected_counts))
+                                );
+                            }
+                            assert_eq!(
+                                values.get(&committed_pos::TOOL_MODEL_PAIRS.to_string()),
+                                Some(&serde_json::json!(expected_models))
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
 
     #[test]
     fn test_terminal_stats_display() {

--- a/src/daemon/rewrite_metrics.rs
+++ b/src/daemon/rewrite_metrics.rs
@@ -265,13 +265,14 @@ fn build_rewrite_committed_metric_event(
     if should_skip_rewrite_metric_stats(&diff_hunks, &batch_context.ignore_patterns) {
         return Ok(None);
     }
-    let stats = crate::authorship::stats::stats_for_commit_stats_from_hunks_with_merge_flag(
-        &batch_context.ignore_patterns,
-        &diff_hunks,
-        Some(&authorship_log),
-        false,
-    );
-    let Some(breakdown) = metric_tool_model_breakdown(&stats) else {
+    let (stats, mock_only) =
+        crate::authorship::stats::stats_for_commit_stats_and_mock_counts_from_hunks(
+            &batch_context.ignore_patterns,
+            &diff_hunks,
+            Some(&authorship_log),
+            false,
+        );
+    let Some(breakdown) = metric_tool_model_breakdown(&stats, &mock_only) else {
         return Ok(None);
     };
 
@@ -603,6 +604,155 @@ mod tests {
                 .get(&crate::metrics::attrs::attr_pos::BASE_COMMIT_SHA.to_string()),
             Some(&serde_json::json!("parent"))
         );
+    }
+
+    #[test]
+    fn rewrite_metric_event_keeps_real_lines_overlapping_mock_attribution() {
+        let tmp = crate::git::test_utils::TmpRepo::new().expect("tmp repo");
+        let mut log = AuthorshipLog::deserialize_from_string(&note_for_ai_line("file.txt", 2))
+            .expect("parse fixture");
+        let mut mock = log.metadata.prompts["prompt1"].clone();
+        mock.agent_id.tool = "mock_ai".to_string();
+        for hash in ["mock1", "mock2"] {
+            log.metadata.prompts.insert(hash.to_string(), mock.clone());
+            log.get_or_create_file("file.txt")
+                .add_entry(AttestationEntry::new(
+                    hash.to_string(),
+                    vec![LineRange::Range(2, 3)],
+                ));
+        }
+        log.get_or_create_file("file.txt")
+            .add_entry(AttestationEntry::new(
+                "h_human".to_string(),
+                vec![LineRange::Single(1)],
+            ));
+        let note = log.serialize_to_string().expect("serialize note");
+        let parent_diff = DiffTreeResult {
+            hunks_by_file: HashMap::from([(
+                "file.txt".to_string(),
+                vec![crate::authorship::hunk_shift::DiffHunk {
+                    old_start: 0,
+                    old_count: 0,
+                    new_start: 1,
+                    new_count: 3,
+                }],
+            )]),
+            added_lines_by_file: HashMap::new(),
+            renames: Vec::new(),
+        };
+        let commit = metric_commit("new", &["old"], RewriteMetricOperation::Rebase)
+            .with_parent_sha("parent")
+            .with_authorship_note(note.clone())
+            .with_parent_diff(parent_diff);
+        let context = RewriteMetricBatchContext::new(tmp.gitai_repo());
+        let event = build_rewrite_committed_metric_event(&commit, &context)
+            .expect("metric build")
+            .expect("real coverage should emit an event");
+        for pos in [
+            rewrite_committed_pos::AI_ADDITIONS,
+            rewrite_committed_pos::AI_ACCEPTED,
+        ] {
+            assert_eq!(
+                event.values.get(&pos.to_string()),
+                Some(&serde_json::json!([1, 1]))
+            );
+        }
+        assert_eq!(
+            event
+                .values
+                .get(&rewrite_committed_pos::HUMAN_ADDITIONS.to_string()),
+            Some(&serde_json::json!(1))
+        );
+        assert_eq!(
+            event
+                .values
+                .get(&rewrite_committed_pos::TOOL_MODEL_PAIRS.to_string()),
+            Some(&serde_json::json!(["all", "codex::gpt-5"]))
+        );
+        assert_eq!(
+            event
+                .values
+                .get(&rewrite_committed_pos::AUTHORSHIP_NOTE.to_string()),
+            Some(&serde_json::json!(note))
+        );
+    }
+
+    #[test]
+    fn rewrite_metric_event_preserves_mock_suppression_and_unresolved_coverage() {
+        let tmp = crate::git::test_utils::TmpRepo::new().expect("tmp repo");
+        let context = RewriteMetricBatchContext::new(tmp.gitai_repo());
+        for (real, unresolved, expected) in [
+            (true, false, Some(3)),
+            (false, false, None),
+            (false, true, Some(1)),
+        ] {
+            let mut log = AuthorshipLog::deserialize_from_string(&note_for_ai_line("file.txt", 1))
+                .expect("parse fixture");
+            log.attestations.clear();
+            let mut mock = log.metadata.prompts["prompt1"].clone();
+            mock.agent_id.tool = "mock_ai".to_string();
+            log.metadata.prompts.insert("mock".to_string(), mock);
+            log.get_or_create_file("file.txt")
+                .add_entry(AttestationEntry::new(
+                    "mock".to_string(),
+                    vec![LineRange::Range(1, 3)],
+                ));
+            if real {
+                log.get_or_create_file("file.txt")
+                    .add_entry(AttestationEntry::new(
+                        "prompt1".to_string(),
+                        vec![LineRange::Range(1, 3)],
+                    ));
+            }
+            if unresolved {
+                log.get_or_create_file("file.txt")
+                    .add_entry(AttestationEntry::new(
+                        "s_missing::t".to_string(),
+                        vec![LineRange::Single(2)],
+                    ));
+            }
+            let parent_diff = DiffTreeResult {
+                hunks_by_file: HashMap::from([(
+                    "file.txt".to_string(),
+                    vec![crate::authorship::hunk_shift::DiffHunk {
+                        old_start: 0,
+                        old_count: 0,
+                        new_start: 1,
+                        new_count: 3,
+                    }],
+                )]),
+                added_lines_by_file: HashMap::new(),
+                renames: Vec::new(),
+            };
+            let commit = metric_commit("new", &["old"], RewriteMetricOperation::Rebase)
+                .with_parent_sha("parent")
+                .with_authorship_note(log.serialize_to_string().expect("serialize note"))
+                .with_parent_diff(parent_diff);
+            let event =
+                build_rewrite_committed_metric_event(&commit, &context).expect("metric build");
+            if let Some(count) = expected {
+                let event = event.expect("retained coverage should emit an event");
+                let counts = if real {
+                    vec![count, count]
+                } else {
+                    vec![count]
+                };
+                for pos in [
+                    rewrite_committed_pos::AI_ADDITIONS,
+                    rewrite_committed_pos::AI_ACCEPTED,
+                ] {
+                    assert_eq!(
+                        event.values.get(&pos.to_string()),
+                        Some(&serde_json::json!(counts))
+                    );
+                }
+            } else {
+                assert!(
+                    event.is_none(),
+                    "entirely mock-only event must remain suppressed"
+                );
+            }
+        }
     }
 
     #[test]

--- a/tests/integration/stats.rs
+++ b/tests/integration/stats.rs
@@ -1,7 +1,14 @@
 use crate::repos::test_file::ExpectedLineExt;
 use crate::repos::test_repo::TestRepo;
 use crate::test_utils::extract_json_object;
+use git_ai::authorship::authorship_log::{LineRange, SessionRecord};
+use git_ai::authorship::authorship_log_serialization::{
+    AttestationEntry, AuthorshipLog, FileAttestation,
+};
 use git_ai::authorship::stats::CommitStats;
+use git_ai::authorship::working_log::AgentId;
+use git_ai::git::notes_api::write_note;
+use git_ai::git::repository::find_repository_in_path;
 use insta::assert_debug_snapshot;
 use std::fs;
 use std::io::{BufRead, BufReader};
@@ -16,6 +23,16 @@ fn stats_from_args(repo: &TestRepo, args: &[&str]) -> CommitStats {
     let raw = repo.git_ai(args).expect("git-ai stats should succeed");
     let json = extract_json_object(&raw);
     serde_json::from_str(&json).expect("valid stats json")
+}
+
+fn attach_authorship_log(repo: &TestRepo, commit_sha: &str, log: &AuthorshipLog) -> String {
+    let note = log
+        .serialize_to_string()
+        .expect("serialize authorship note");
+    let git_ai_repo =
+        find_repository_in_path(repo.path().to_str().unwrap()).expect("find test repository");
+    write_note(&git_ai_repo, commit_sha, &note).expect("attach synthetic authorship note");
+    note
 }
 
 fn range_stats_from_args_with_env(
@@ -334,6 +351,176 @@ fn test_authorship_log_stats() {
             .unwrap()
             .ai_accepted,
         5
+    );
+}
+
+#[test]
+fn test_stats_deduplicates_overlapping_sessions_for_same_model() {
+    let repo = TestRepo::new();
+    let mut app = repo.filename("app.txt");
+    let ten_lines = (1..=10)
+        .map(|line| format!("line {line}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(repo.path().join("app.txt"), format!("{ten_lines}\n")).unwrap();
+    let commit = repo.stage_all_and_commit("Add ten lines").unwrap();
+    app.assert_committed_lines(crate::lines![
+        "line 1".unattributed_human(),
+        "line 2".unattributed_human(),
+        "line 3".unattributed_human(),
+        "line 4".unattributed_human(),
+        "line 5".unattributed_human(),
+        "line 6".unattributed_human(),
+        "line 7".unattributed_human(),
+        "line 8".unattributed_human(),
+        "line 9".unattributed_human(),
+        "line 10".unattributed_human(),
+    ]);
+
+    let mut log = AuthorshipLog::new();
+    log.metadata.base_commit_sha = commit.commit_sha.clone();
+    for session_id in ["s_first-session", "s_second-session"] {
+        log.metadata.sessions.insert(
+            session_id.to_string(),
+            SessionRecord {
+                agent_id: AgentId {
+                    tool: "mock_ai".to_string(),
+                    id: session_id.to_string(),
+                    model: "test-model".to_string(),
+                },
+                human_author: None,
+                custom_attributes: None,
+            },
+        );
+    }
+    let mut file_attestation = FileAttestation::new("app.txt".to_string());
+    for (session_id, trace_id) in [
+        ("s_first-session", "t_first"),
+        ("s_second-session", "t_second"),
+    ] {
+        file_attestation.add_entry(AttestationEntry::new(
+            format!("{session_id}::{trace_id}"),
+            vec![LineRange::Range(1, 10)],
+        ));
+    }
+    log.attestations.push(file_attestation);
+    let note = attach_authorship_log(&repo, &commit.commit_sha, &log);
+
+    let stats = stats_from_args(&repo, &["stats", "--json"]);
+    assert_eq!(stats.git_diff_added_lines, 10);
+    assert_eq!(stats.ai_additions, 10);
+    assert_eq!(stats.ai_accepted, 10);
+    assert_eq!(stats.human_additions, 0);
+    assert_eq!(stats.unknown_additions, 0);
+    assert_eq!(
+        stats.ai_additions + stats.human_additions + stats.unknown_additions,
+        stats.git_diff_added_lines,
+        "each added line must occupy exactly one headline bucket"
+    );
+    let same_model = stats
+        .tool_model_breakdown
+        .get("mock_ai::test-model")
+        .expect("same-model sessions should have one breakdown entry");
+    assert_eq!(same_model.ai_additions, 10);
+    assert_eq!(same_model.ai_accepted, 10);
+    assert_eq!(
+        repo.read_authorship_note(&commit.commit_sha)
+            .expect("stats should not remove the authorship note"),
+        note,
+        "stats must not mutate authorship-note bytes"
+    );
+}
+
+#[test]
+fn test_stats_counts_mixed_human_and_overlapping_models_without_mutating_note() {
+    let repo = TestRepo::new();
+    let mut app = repo.filename("app.txt");
+    let six_lines = (1..=6)
+        .map(|line| format!("line {line}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    fs::write(repo.path().join("app.txt"), format!("{six_lines}\n")).unwrap();
+    let commit = repo.stage_all_and_commit("Add six lines").unwrap();
+    app.assert_committed_lines(crate::lines![
+        "line 1".unattributed_human(),
+        "line 2".unattributed_human(),
+        "line 3".unattributed_human(),
+        "line 4".unattributed_human(),
+        "line 5".unattributed_human(),
+        "line 6".unattributed_human(),
+    ]);
+
+    let mut log = AuthorshipLog::new();
+    log.metadata.base_commit_sha = commit.commit_sha.clone();
+    for (session_id, model) in [("s_model-x", "model-x"), ("s_model-y", "model-y")] {
+        log.metadata.sessions.insert(
+            session_id.to_string(),
+            SessionRecord {
+                agent_id: AgentId {
+                    tool: "mock_ai".to_string(),
+                    id: session_id.to_string(),
+                    model: model.to_string(),
+                },
+                human_author: None,
+                custom_attributes: None,
+            },
+        );
+    }
+
+    let mut file_attestation = FileAttestation::new("app.txt".to_string());
+    file_attestation.add_entry(AttestationEntry::new(
+        "h_known-human".to_string(),
+        vec![
+            LineRange::Single(2),
+            LineRange::Single(3),
+            LineRange::Single(5),
+        ],
+    ));
+    file_attestation.add_entry(AttestationEntry::new(
+        "s_model-x::t_first".to_string(),
+        vec![
+            LineRange::Single(1),
+            LineRange::Single(2),
+            LineRange::Single(4),
+        ],
+    ));
+    file_attestation.add_entry(AttestationEntry::new(
+        "s_model-y::t_second".to_string(),
+        vec![LineRange::Single(3), LineRange::Single(4)],
+    ));
+    log.attestations.push(file_attestation);
+
+    let note = attach_authorship_log(&repo, &commit.commit_sha, &log);
+
+    let stats = stats_from_args(&repo, &["stats", "--json"]);
+    assert_eq!(stats.git_diff_added_lines, 6);
+    assert_eq!(stats.ai_additions, 2);
+    assert_eq!(stats.ai_accepted, 2);
+    assert_eq!(stats.human_additions, 3);
+    assert_eq!(stats.unknown_additions, 1);
+    assert_eq!(
+        stats.ai_additions + stats.human_additions + stats.unknown_additions,
+        stats.git_diff_added_lines,
+        "each added line must occupy exactly one headline bucket"
+    );
+
+    let model_x = stats
+        .tool_model_breakdown
+        .get("mock_ai::model-x")
+        .expect("model-x should have a breakdown entry");
+    assert_eq!(model_x.ai_additions, 2);
+    assert_eq!(model_x.ai_accepted, 2);
+    let model_y = stats
+        .tool_model_breakdown
+        .get("mock_ai::model-y")
+        .expect("model-y should have a breakdown entry");
+    assert_eq!(model_y.ai_additions, 1);
+    assert_eq!(model_y.ai_accepted, 1);
+    assert_eq!(
+        repo.read_authorship_note(&commit.commit_sha)
+            .expect("stats should not remove the authorship note"),
+        note,
+        "stats must not mutate authorship-note bytes"
     );
 }
 

--- a/tests/integration/stats_unit.rs
+++ b/tests/integration/stats_unit.rs
@@ -1,6 +1,6 @@
 use crate::repos::test_repo::TestRepo;
-use git_ai::authorship::authorship_log::LineRange;
 use git_ai::authorship::authorship_log::PromptRecord;
+use git_ai::authorship::authorship_log::{LineRange, SessionRecord};
 use git_ai::authorship::authorship_log_serialization::AttestationEntry;
 use git_ai::authorship::authorship_log_serialization::AuthorshipLog;
 use git_ai::authorship::authorship_log_serialization::FileAttestation;
@@ -512,6 +512,402 @@ fn test_accepted_lines_basic_match() {
     // Verify per-tool breakdown contains the right key
     let expected_key = "cursor::claude-3-sonnet".to_string();
     assert_eq!(per_tool.get(&expected_key), Some(&3));
+}
+
+fn session_record(session_id: &str, model: &str) -> SessionRecord {
+    SessionRecord {
+        agent_id: AgentId {
+            tool: "mock_ai".to_string(),
+            id: session_id.to_string(),
+            model: model.to_string(),
+        },
+        human_author: None,
+        custom_attributes: None,
+    }
+}
+
+fn session_log(sessions: &[(&str, &str)], entries: &[(&str, Vec<LineRange>)]) -> AuthorshipLog {
+    let mut log = AuthorshipLog::new();
+    for (session_id, model) in sessions {
+        log.metadata
+            .sessions
+            .insert((*session_id).to_string(), session_record(session_id, model));
+    }
+    let mut file_attestation = FileAttestation::new("foo.rs".to_string());
+    for (hash, ranges) in entries {
+        file_attestation.add_entry(AttestationEntry::new((*hash).to_string(), ranges.clone()));
+    }
+    log.attestations.push(file_attestation);
+    log
+}
+
+fn accepted_counts(log: &AuthorshipLog, lines: Vec<u32>) -> (u32, u32, BTreeMap<String, u32>) {
+    let added_lines = HashMap::from([("foo.rs".to_string(), lines)]);
+    accepted_lines_from_attestations(Some(log), &added_lines, false)
+}
+
+#[test]
+fn test_accepted_lines_deduplicates_overlapping_ranges_in_one_entry() {
+    let log = session_log(
+        &[("s_same-entry", "test-model")],
+        &[(
+            "s_same-entry::t_first",
+            vec![LineRange::Range(1, 4), LineRange::Range(3, 6)],
+        )],
+    );
+    let (accepted, known_human, per_tool) = accepted_counts(&log, (1..=6).collect());
+
+    assert_eq!(accepted, 6);
+    assert_eq!(known_human, 0);
+    assert_eq!(per_tool.get("mock_ai::test-model"), Some(&6));
+}
+
+#[test]
+fn test_accepted_lines_deduplicates_same_model_sessions() {
+    let log = session_log(
+        &[
+            ("s_first-session", "test-model"),
+            ("s_second-session", "test-model"),
+        ],
+        &[
+            ("s_first-session::t_first", vec![LineRange::Range(1, 6)]),
+            ("s_second-session::t_second", vec![LineRange::Range(1, 6)]),
+        ],
+    );
+    let (accepted, known_human, per_tool) = accepted_counts(&log, (1..=6).collect());
+
+    assert_eq!(accepted, 6);
+    assert_eq!(known_human, 0);
+    assert_eq!(per_tool.get("mock_ai::test-model"), Some(&6));
+}
+
+#[test]
+fn test_accepted_lines_preserves_distinct_model_overlap_in_breakdown() {
+    let log = session_log(
+        &[("s_model-a", "model-a"), ("s_model-b", "model-b")],
+        &[
+            ("s_model-a::t_first", vec![LineRange::Range(1, 4)]),
+            ("s_model-b::t_second", vec![LineRange::Range(3, 6)]),
+        ],
+    );
+    let (accepted, known_human, per_tool) = accepted_counts(&log, (1..=6).collect());
+
+    assert_eq!(
+        accepted, 6,
+        "headline AI count uses the union of covered lines"
+    );
+    assert_eq!(known_human, 0);
+    // Distinct models each retain their independently covered lines.
+    assert_eq!(per_tool.get("mock_ai::model-a"), Some(&4));
+    assert_eq!(per_tool.get("mock_ai::model-b"), Some(&4));
+}
+
+#[test]
+fn test_accepted_lines_deduplicates_duplicate_file_attestations() {
+    let mut log = session_log(
+        &[("s_duplicate-file", "test-model")],
+        &[("s_duplicate-file::t_first", vec![LineRange::Range(1, 6)])],
+    );
+    log.attestations.push(log.attestations[0].clone());
+
+    let (accepted, known_human, per_tool) = accepted_counts(&log, (1..=6).collect());
+
+    assert_eq!(accepted, 6);
+    assert_eq!(known_human, 0);
+    assert_eq!(per_tool.get("mock_ai::test-model"), Some(&6));
+}
+
+#[test]
+fn test_accepted_lines_deduplicates_duplicate_known_human_ranges() {
+    let mut log = AuthorshipLog::new();
+    for _ in 0..2 {
+        let mut file_attestation = FileAttestation::new("foo.rs".to_string());
+        file_attestation.add_entry(AttestationEntry::new(
+            "h_known-human".to_string(),
+            vec![LineRange::Range(1, 6)],
+        ));
+        log.attestations.push(file_attestation);
+    }
+
+    let (accepted, known_human, per_tool) = accepted_counts(&log, (1..=6).collect());
+
+    assert_eq!(accepted, 0);
+    assert_eq!(known_human, 6);
+    assert!(per_tool.is_empty());
+}
+
+#[test]
+fn test_accepted_lines_deduplicates_legacy_prompt_and_session_for_same_model() {
+    let mut log = session_log(
+        &[("s_current", "test-model")],
+        &[
+            ("s_current::t_current", vec![LineRange::Range(1, 6)]),
+            ("legacy-prompt", vec![LineRange::Range(1, 6)]),
+        ],
+    );
+    log.metadata.prompts.insert(
+        "legacy-prompt".to_string(),
+        PromptRecord {
+            agent_id: AgentId {
+                tool: "mock_ai".to_string(),
+                id: "legacy-prompt".to_string(),
+                model: "test-model".to_string(),
+            },
+            human_author: None,
+            total_additions: 0,
+            total_deletions: 0,
+            accepted_lines: 0,
+            overriden_lines: 0,
+            custom_attributes: None,
+            messages_url: None,
+        },
+    );
+
+    let (accepted, known_human, per_tool) = accepted_counts(&log, (1..=6).collect());
+
+    assert_eq!(accepted, 6);
+    assert_eq!(known_human, 0);
+    assert_eq!(per_tool.get("mock_ai::test-model"), Some(&6));
+}
+
+#[test]
+fn test_accepted_lines_without_session_metadata_still_counts_ai() {
+    let log = session_log(
+        &[],
+        &[("s_missing-session::t_missing", vec![LineRange::Range(1, 6)])],
+    );
+
+    let (accepted, known_human, per_tool) = accepted_counts(&log, (1..=6).collect());
+
+    assert_eq!(accepted, 6);
+    assert_eq!(known_human, 0);
+    assert!(per_tool.is_empty());
+}
+
+#[test]
+fn test_accepted_lines_counts_only_sparse_added_lines_in_large_range() {
+    let log = session_log(
+        &[("s_sparse", "test-model")],
+        &[(
+            "s_sparse::t_large-range",
+            vec![LineRange::Range(1, u32::MAX)],
+        )],
+    );
+    let sparse_lines = vec![2, 500, u32::MAX];
+
+    let (accepted, known_human, per_tool) = accepted_counts(&log, sparse_lines);
+
+    assert_eq!(accepted, 3);
+    assert_eq!(known_human, 0);
+    assert_eq!(per_tool.get("mock_ai::test-model"), Some(&3));
+}
+
+#[test]
+fn test_accepted_lines_is_invariant_to_attestation_order() {
+    let sessions = [("s_first", "test-model"), ("s_second", "test-model")];
+    let mut in_forward_order = session_log(
+        &sessions,
+        &[("s_first::t_first", vec![LineRange::Range(1, 4)])],
+    );
+    let mut in_reverse_order = session_log(
+        &sessions,
+        &[("s_second::t_second", vec![LineRange::Range(3, 6)])],
+    );
+    let mut first_file_record = FileAttestation::new("foo.rs".to_string());
+    first_file_record.add_entry(AttestationEntry::new(
+        "s_first::t_first".to_string(),
+        vec![LineRange::Range(1, 4)],
+    ));
+    let mut second_file_record = FileAttestation::new("foo.rs".to_string());
+    second_file_record.add_entry(AttestationEntry::new(
+        "s_second::t_second".to_string(),
+        vec![LineRange::Range(3, 6)],
+    ));
+    in_forward_order.attestations.push(second_file_record);
+    in_reverse_order.attestations.push(first_file_record);
+
+    let forward = accepted_counts(&in_forward_order, (1..=6).collect());
+    let reverse = accepted_counts(&in_reverse_order, (1..=6).collect());
+
+    assert_eq!(forward, reverse);
+    assert_eq!(forward.0, 6);
+    assert_eq!(forward.2.get("mock_ai::test-model"), Some(&6));
+}
+
+#[test]
+fn test_accepted_lines_human_first_model_unions_oracle() {
+    let log = session_log(
+        &[("s_model-x", "model-x"), ("s_model-y", "model-y")],
+        &[
+            (
+                "h_known-human",
+                vec![
+                    LineRange::Single(2),
+                    LineRange::Single(3),
+                    LineRange::Single(5),
+                ],
+            ),
+            (
+                "s_model-x::t_first",
+                vec![
+                    LineRange::Single(1),
+                    LineRange::Single(2),
+                    LineRange::Single(4),
+                ],
+            ),
+            (
+                "s_model-y::t_second",
+                vec![LineRange::Single(3), LineRange::Single(4)],
+            ),
+        ],
+    );
+
+    let (accepted, known_human, per_tool) = accepted_counts(&log, (1..=6).collect());
+    let unknown = 6 - accepted - known_human;
+
+    assert_eq!(accepted, 2);
+    assert_eq!(known_human, 3);
+    assert_eq!(unknown, 1);
+    assert_eq!(per_tool.get("mock_ai::model-x"), Some(&2));
+    assert_eq!(per_tool.get("mock_ai::model-y"), Some(&1));
+}
+
+#[test]
+fn test_accepted_lines_human_coverage_removes_all_overlapped_ai() {
+    let log = session_log(
+        &[("s_model-x", "model-x")],
+        &[
+            ("h_known-human", vec![LineRange::Range(1, 6)]),
+            ("s_model-x::t_first", vec![LineRange::Range(1, 6)]),
+        ],
+    );
+
+    let (accepted, known_human, per_tool) = accepted_counts(&log, (1..=6).collect());
+
+    assert_eq!(accepted, 0);
+    assert_eq!(known_human, 6);
+    assert!(per_tool.is_empty());
+}
+
+fn mask_ranges(mask: u8, added_positions: &[u32; 4]) -> Vec<LineRange> {
+    added_positions
+        .iter()
+        .enumerate()
+        .filter(|(index, _)| mask & (1u8 << index) != 0)
+        .map(|(_, line)| LineRange::Single(*line))
+        .collect()
+}
+
+fn three_mask_log(
+    human_mask: u8,
+    model_x_mask: u8,
+    model_y_mask: u8,
+    added_positions: &[u32; 4],
+    reverse_and_duplicate: bool,
+) -> AuthorshipLog {
+    let mut entries = vec![
+        ("h_known-human", mask_ranges(human_mask, added_positions)),
+        (
+            "s_model-x::t_first",
+            mask_ranges(model_x_mask, added_positions),
+        ),
+        (
+            "s_model-y::t_second",
+            mask_ranges(model_y_mask, added_positions),
+        ),
+    ];
+    if reverse_and_duplicate {
+        entries.reverse();
+    }
+    let mut log = session_log(
+        &[("s_model-x", "model-x"), ("s_model-y", "model-y")],
+        &entries,
+    );
+    if reverse_and_duplicate {
+        log.attestations.push(log.attestations[0].clone());
+    }
+    log
+}
+
+#[test]
+fn test_accepted_lines_matches_independent_small_mask_oracle() {
+    let added_positions = [10, 20, 30, 40];
+    for human_mask in 0..16u8 {
+        for model_x_mask in 0..16u8 {
+            for model_y_mask in 0..16u8 {
+                let expected_human = human_mask.count_ones();
+                let expected_ai = ((model_x_mask | model_y_mask) & !human_mask).count_ones();
+                let expected_model_x = (model_x_mask & !human_mask).count_ones();
+                let expected_model_y = (model_y_mask & !human_mask).count_ones();
+                let expected_unknown =
+                    (!(human_mask | model_x_mask | model_y_mask) & 0b1111).count_ones();
+
+                for reverse_and_duplicate in [false, true] {
+                    let log = three_mask_log(
+                        human_mask,
+                        model_x_mask,
+                        model_y_mask,
+                        &added_positions,
+                        reverse_and_duplicate,
+                    );
+                    let (accepted, known_human, per_tool) =
+                        accepted_counts(&log, added_positions.to_vec());
+
+                    assert_eq!(accepted, expected_ai);
+                    assert_eq!(known_human, expected_human);
+                    assert_eq!(
+                        accepted + known_human + expected_unknown,
+                        4,
+                        "all actual added positions remain in one headline bucket"
+                    );
+                    assert_eq!(
+                        per_tool.get("mock_ai::model-x").copied(),
+                        (expected_model_x > 0).then_some(expected_model_x)
+                    );
+                    assert_eq!(
+                        per_tool.get("mock_ai::model-y").copied(),
+                        (expected_model_y > 0).then_some(expected_model_y)
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn test_accepted_lines_isolates_file_paths_and_repeated_text_positions() {
+    let mut log = AuthorshipLog::new();
+    for (session_id, model) in [("s_model-x", "model-x"), ("s_model-y", "model-y")] {
+        log.metadata
+            .sessions
+            .insert(session_id.to_string(), session_record(session_id, model));
+    }
+    for (file_path, hash, line) in [
+        ("first.txt", "s_model-x::t_first", 1),
+        ("second.txt", "s_model-y::t_second", 1),
+        ("repeated.txt", "s_model-x::t_repeated-first", 1),
+        ("repeated.txt", "s_model-y::t_repeated-second", 2),
+    ] {
+        let mut file = FileAttestation::new(file_path.to_string());
+        file.add_entry(AttestationEntry::new(
+            hash.to_string(),
+            vec![LineRange::Single(line)],
+        ));
+        log.attestations.push(file);
+    }
+    let added_lines = HashMap::from([
+        ("first.txt".to_string(), vec![1]),
+        ("second.txt".to_string(), vec![1]),
+        ("repeated.txt".to_string(), vec![1, 2]),
+    ]);
+
+    let (accepted, known_human, per_tool) =
+        accepted_lines_from_attestations(Some(&log), &added_lines, false);
+
+    assert_eq!(accepted, 4);
+    assert_eq!(known_human, 0);
+    assert_eq!(per_tool.get("mock_ai::model-x"), Some(&2));
+    assert_eq!(per_tool.get("mock_ai::model-y"), Some(&2));
 }
 
 // --- line_range_overlap_len tests ---


### PR DESCRIPTION
Fixes #2294.

Overlapping authorship records can count one added line repeatedly: the ten-line reproduction reports twenty AI additions. This change counts distinct actual added lines across ranges, records and sessions, while preserving the original authorship notes.

### Counting policy proposed for review

- Explicit known-human attribution takes precedence in the exclusive headline buckets. This is a reporting convention, not a claim about edit chronology or sole authorship.
- Each tool/model reports its independently deduplicated qualifying coverage. Different models can cover the same line, so their counts are non-additive.

The policy and historical-count implications are documented in `docs/commit-stats-attribution.md`. Please confirm these semantics as part of the review.

The existing telemetry filter also assumed additive model counts. Both ordinary-commit and rewrite telemetry now receive mock-exclusive coverage from the same aggregation, so mock overlap cannot remove real or unresolved AI coverage. The public counting signature, JSON fields, note contents, ignore behavior and merge selection are preserved. Coverage counting introduces no additional Git retrieval.

### Validation

- TDD: original code fails the real CLI reproduction (20 vs 10) and seven additional focused overlap regressions.
- Compatibility TDD: the old telemetry mapper produces `[0, 6]` for six real-model lines also covered by mock; expected `[6, 6]`.
- Two real-repository CLI regressions verify exact counts and byte-for-byte note preservation. Independent oracles cover 4,096 H/X/Y combinations in two orderings and 4,096 human/real/mock/unresolved combinations. Ordinary-commit payload and rewrite-event tests exercise coverage retention and suppression.
- `RUST_LOG=info task test CARGO_TEST_ARGS=--no-fail-fast` with Rust 1.98.1: **6,138 passed, 2 failed, 94 ignored**. All 3,363 integration tests passed.
- The two failures are `daemon_test_mode_human_checkpoint_with_explicit_preset_queues_via_daemon` and `daemon_symlink_repo_path_trace_and_status_use_same_family`. Both reproduce on untouched upstream `0670e7ef` with `RUST_LOG=info` and one test thread (112 daemon tests passed; those two plus two await/flush tests failed). I have not changed unrelated daemon behavior to mask them.
- Rust 1.93.0, matching pinned checks: `task lint`, `task format:check`, and `task doc` all pass with warnings denied.

The issue timeline and targeted open/all-state PR searches showed no competing #2294 fix immediately before publication. The broad area search returned unrelated profile-root and pending-status changes.

AI assistance: OpenAI Codex assisted implementation, tests and source review; GPT-6 Pro supplied design critique for the counting policy and telemetry compatibility. Upstream semantic approval and merge are still pending.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/2346" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->