### PR TITLE
Fix checkpoint completion waits in daemon tests

### DIFF
--- a/tests/daemon_mode.rs
+++ b/tests/daemon_mode.rs
@@ -1084,7 +1084,7 @@ fn checkpoint_delegate_autostarts_daemon_when_unavailable() {
     // Manually restart the daemon (production auto-start is disabled in test builds)
     start_daemon_for_repo(&repo);
 
-    let completion_baseline = repo.daemon_total_completion_count();
+    let checkpoint_baseline = repo.daemon_checkpoint_completion_count();
     repo.git_ai_with_env(
         &["checkpoint", "mock_ai", "delegate-fallback.txt"],
         &[("GIT_AI_DAEMON_CHECKPOINT_DELEGATE", "true")],
@@ -1092,7 +1092,7 @@ fn checkpoint_delegate_autostarts_daemon_when_unavailable() {
     .expect("checkpoint should delegate to daemon and succeed");
 
     // Wait for the fire-and-forget checkpoint to complete
-    repo.wait_for_next_daemon_checkpoint_completion(completion_baseline);
+    repo.wait_for_next_daemon_checkpoint_completion(checkpoint_baseline);
 
     let status = send_control_request(
         &daemon_control_socket_path(&repo),
@@ -1290,12 +1290,12 @@ fn daemon_test_mode_git_ai_checkpoint_runs_via_daemon() {
         "base\nchanged through daemon mode\n",
     )
     .expect("failed to write updated file");
-    let completion_baseline = repo.daemon_total_completion_count();
+    let checkpoint_baseline = repo.daemon_checkpoint_completion_count();
 
     repo.git_ai(&["checkpoint", "mock_ai", "daemon-mode-checkpoint.txt"])
         .expect("daemon-mode checkpoint should succeed");
 
-    repo.wait_for_next_daemon_checkpoint_completion(completion_baseline);
+    repo.wait_for_next_daemon_checkpoint_completion(checkpoint_baseline);
 
     let checkpoints = repo
         .current_working_logs()
@@ -1322,28 +1322,15 @@ fn daemon_test_mode_human_checkpoint_with_explicit_preset_queues_via_daemon() {
 
     fs::write(repo.path().join("human-direct-path.txt"), "base\nhuman\n")
         .expect("failed to write human change");
-    let completion_baseline = repo.daemon_total_completion_count();
+    let checkpoint_baseline = repo.daemon_checkpoint_completion_count();
 
     repo.git_ai(&["checkpoint", "human", "human-direct-path.txt"])
         .expect("human checkpoint with preset should succeed");
 
-    repo.wait_for_next_daemon_checkpoint_completion(completion_baseline);
+    repo.wait_for_next_daemon_checkpoint_completion(checkpoint_baseline);
 
-    let git_ai_repo = git_ai::git::repository::find_repository_in_path(
-        repo.path()
-            .to_str()
-            .expect("repo path should be valid UTF-8"),
-    )
-    .expect("repository should still be discoverable");
-    let base_commit = git_ai_repo
-        .head()
-        .ok()
-        .and_then(|head| head.target().ok())
-        .unwrap_or_else(|| "initial".to_string());
-    let checkpoints = git_ai_repo
-        .storage
-        .working_log_for_base_commit(&base_commit)
-        .unwrap()
+    let checkpoints = repo
+        .current_working_logs()
         .read_all_checkpoints()
         .expect("checkpoints should be readable");
     assert!(
@@ -1396,7 +1383,7 @@ fn daemon_symlink_repo_path_trace_and_status_use_same_family() {
     .expect("daemon status request should succeed for aliased path");
     assert!(status.ok, "aliased path daemon status should be ok");
 
-    let checkpoint_baseline = repo.daemon_total_completion_count();
+    let checkpoint_baseline = repo.daemon_checkpoint_completion_count();
     fs::write(repo.path().join("alias.txt"), "alias\nhuman\n")
         .expect("failed writing human aliased file");
     repo.git_ai(&["checkpoint", "human"])

--- a/tests/integration/repos/test_repo.rs
+++ b/tests/integration/repos/test_repo.rs
@@ -1969,6 +1969,14 @@ impl TestRepo {
         self.daemon_completion_entries_for_family(&family_key).len() as u64
     }
 
+    pub(crate) fn daemon_checkpoint_completion_count(&self) -> u64 {
+        let family_key = self.daemon_family_key();
+        self.daemon_completion_entries_for_family(&family_key)
+            .iter()
+            .filter(|entry| entry.sync_tracked && entry.kind == "checkpoint")
+            .count() as u64
+    }
+
     pub(crate) fn daemon_completion_entries(&self) -> Vec<DaemonTestCompletionLogEntry> {
         let family_key = self.daemon_family_key();
         self.daemon_completion_entries_for_family(&family_key)
@@ -2240,11 +2248,12 @@ impl TestRepo {
         );
     }
 
-    pub(crate) fn wait_for_next_daemon_checkpoint_completion(&self, baseline_count: u64) -> u64 {
-        self.wait_for_daemon_total_completion_count(
-            baseline_count,
-            baseline_count.saturating_add(1),
-        )
+    pub(crate) fn wait_for_next_daemon_checkpoint_completion(
+        &self,
+        checkpoint_baseline: u64,
+    ) -> u64 {
+        let family_key = self.daemon_family_key();
+        self.wait_for_daemon_checkpoint_count(&family_key, checkpoint_baseline.saturating_add(1))
     }
 
     fn daemon_family_key_for_repo_path(&self, repo_path: &Path) -> String {


### PR DESCRIPTION
Daemon checkpoint tests can read state before the queued checkpoint finishes: `wait_for_next_daemon_checkpoint_completion` currently accepts any new daemon completion, including an unrelated command. This produced missing Human checkpoint and missing symlink watermark assertions on the unchanged base.

Count checkpoint completions for the baseline and reuse the existing checkpoint-specific waiter, which also reports checkpoint errors. Update all four callers and read the Human test's working log through the synchronized `current_working_logs()` helper. The existing attribution and watermark assertions remain intact.

Validation: after clearing package build artifacts, the complete daemon suite passed (116 tests, 0 failures) with `task test CARGO_TEST_ARGS='--test daemon_mode' TEST_THREADS=1` and `RUST_LOG=info`. `task fmt` and `task lint` pass with Rust 1.93.0. This changes test synchronization only.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/git-ai-project/git-ai/pull/2347" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->